### PR TITLE
fix(device): use synchronous Ping.Send to avoid native fault under Wine

### DIFF
--- a/src/Aetherphone/Core/Device/DeviceStatus.cs
+++ b/src/Aetherphone/Core/Device/DeviceStatus.cs
@@ -86,7 +86,7 @@ internal sealed class DeviceStatus : IDisposable
             try
             {
                 SampleBattery();
-                await SampleNetworkAsync(ping).ConfigureAwait(false);
+                SampleNetwork(ping);
                 await Task.Delay(SampleIntervalMilliseconds, token).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
@@ -124,14 +124,14 @@ internal sealed class DeviceStatus : IDisposable
         charging = false;
     }
 
-    private async Task SampleNetworkAsync(Ping ping)
+    private void SampleNetwork(Ping ping)
     {
         var endpoint = target;
         var succeeded = false;
         long roundtrip = 0;
         try
         {
-            var reply = await Task.Run(() => ping.Send(endpoint, PingTimeoutMilliseconds)).ConfigureAwait(false);
+            var reply = ping.Send(endpoint, PingTimeoutMilliseconds);
             if (reply.Status == IPStatus.Success)
             {
                 succeeded = true;

--- a/src/Aetherphone/Core/Device/DeviceStatus.cs
+++ b/src/Aetherphone/Core/Device/DeviceStatus.cs
@@ -131,7 +131,7 @@ internal sealed class DeviceStatus : IDisposable
         long roundtrip = 0;
         try
         {
-            var reply = await ping.SendPingAsync(endpoint, PingTimeoutMilliseconds).ConfigureAwait(false);
+            var reply = await Task.Run(() => ping.Send(endpoint, PingTimeoutMilliseconds)).ConfigureAwait(false);
             if (reply.Status == IPStatus.Success)
             {
                 succeeded = true;


### PR DESCRIPTION
## Problem

`DeviceStatus.RunAsync` polls the signal-bar readout via `Ping.SendPingAsync`. Under Wine the async ICMP path faults at the native level rather than throwing, so the `try/catch` in `SampleNetworkAsync` never sees it and the game process dies.

Two crash signatures on the same machine within five minutes:

- native access violation (`C0000005`) in `ffxiv_dx11.exe` on the FrameworkUpdate thread
- CLR `ExecutionEngineException` (`0x80131506`) on a `.NET TP Worker` inside a task continuation — the shape `SendPingAsync` produces

Neither left an entry in `dalamud.log`, consistent with a native fault rather than a swallowed managed exception.

## Ruled out

- **Kernel ICMP permissions** — `net.ipv4.ping_group_range = 0 2147483647`, fully permissive
- **ICMP under Wine generally** — `wine ping 8.8.8.8` against a fresh prefix on the *same* wine-xiv 10.8 build: 4/4 replies, ~48ms, clean exit

Synchronous ICMP is healthy. The fault is specific to the async completion path.

## Causation

An ablation branch removing the probe entirely ran clean, confirming `DeviceStatus` as the source. Verified Dalamud was loading the local build rather than the installed plugin.

## Change

One line. `Task.Run` keeps the loop async without blocking a framework thread, while routing through the synchronous entry point.

## Testing

CachyOS, XIVLauncher.Core 1.4.0, wine-xiv-staging-fsync-git 10.8, Dalamud 15.0.2.3, .NET 10, RX 9070 XT (RADV).

Ran 01:17:19  with no crash. Signal bars, latency and packet loss all reporting normally. Both original crashes occurred within three minutes of login.

## Notes

This is the minimal fix. The more robust approach is the IpHlpApi route PingPlugin uses — `GetExtendedTcpTable` filtered to the game PID plus `GetRTTAndHopCount` — which would also retire the hardcoded data-center host list in `SyncTarget`/`TryDataCenterHost`. Happy to do that as a follow-up.

Happy to keep testing on Linux since you can't reproduce locally.