### PR TITLE
Fix Linux/Wine music playback: managed Opus/webm decode, fix thumbnail decode

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -97,6 +97,7 @@ once at the end of this section:
 | AngleSharp | 1.4.0 | AngleSharp contributors (https://github.com/AngleSharp/AngleSharp) |
 | HtmlAgilityPack | 1.11.74 | ZZZ Projects and contributors (https://github.com/zzzprojects/html-agility-pack) |
 | System.Security.Cryptography.ProtectedData | 10.0.0 | Microsoft Corporation (https://github.com/dotnet/runtime) |
+| NEbml | 0.11.0 | Oleg Zee (https://github.com/Oleg-Zee/NEbml) |
 
 ```
 MIT License

--- a/src/Aetherphone.Tests/WebmOpusDemuxerTests.cs
+++ b/src/Aetherphone.Tests/WebmOpusDemuxerTests.cs
@@ -115,9 +115,9 @@ public sealed class WebmOpusDemuxerTests
             _ => 4,
         };
         var bytes = new byte[length];
-        for (var i = length - 1; i >= 0; i--)
+        for (var index = length - 1; index >= 0; index--)
         {
-            bytes[i] = (byte)(id & 0xFF);
+            bytes[index] = (byte)(id & 0xFF);
             id >>= 8;
         }
 

--- a/src/Aetherphone.Tests/WebmOpusDemuxerTests.cs
+++ b/src/Aetherphone.Tests/WebmOpusDemuxerTests.cs
@@ -1,0 +1,194 @@
+using Aetherphone.Core.Songs;
+using Xunit;
+
+namespace Aetherphone.Tests;
+
+public sealed class WebmOpusDemuxerTests
+{
+    [Fact]
+    public void ReadsDurationAndSinglePacketFromMinimalContainer()
+    {
+        var payload = new byte[] { 1, 2, 3, 4, 5 };
+        var bytes = BuildMinimalWebm(trackNumber: 1, durationSeconds: 12.5, payload);
+
+        using var stream = new MemoryStream(bytes);
+        var demuxer = new WebmOpusDemuxer(stream);
+        demuxer.ReadHeader();
+
+        Assert.NotNull(demuxer.DurationSeconds);
+        Assert.Equal(12.5, demuxer.DurationSeconds!.Value, 3);
+
+        var packet = demuxer.ReadNextPacket();
+        Assert.NotNull(packet);
+        Assert.Equal(payload, packet);
+
+        Assert.Null(demuxer.ReadNextPacket());
+    }
+
+    [Fact]
+    public void SkipsBlocksForOtherTracks()
+    {
+        var wantedPayload = new byte[] { 9, 9, 9 };
+        var bytes = BuildMinimalWebm(
+            trackNumber: 2,
+            durationSeconds: 1.0,
+            wantedPayload,
+            extraBlockTrackNumber: 1,
+            extraBlockPayload: new byte[] { 0, 0 });
+
+        using var stream = new MemoryStream(bytes);
+        var demuxer = new WebmOpusDemuxer(stream);
+        demuxer.ReadHeader();
+
+        var packet = demuxer.ReadNextPacket();
+        Assert.Equal(wantedPayload, packet);
+        Assert.Null(demuxer.ReadNextPacket());
+    }
+
+    /// <summary>
+    /// Hand-encodes just enough EBML to exercise WebmOpusDemuxer: a Segment containing Info
+    /// (TimestampScale + Duration), Tracks (one Opus TrackEntry), and a Cluster with one
+    /// SimpleBlock for the Opus track. Optionally injects a second SimpleBlock for a different
+    /// track number first, to verify it's skipped.
+    /// </summary>
+    private static byte[] BuildMinimalWebm(
+        ulong trackNumber, double durationSeconds, byte[] payload,
+        ulong? extraBlockTrackNumber = null, byte[]? extraBlockPayload = null)
+    {
+        const ulong timestampScale = 1_000_000; // 1ms per tick, matches Matroska default.
+        var durationTicks = durationSeconds * 1_000_000_000.0 / timestampScale;
+
+        var info = Element(0x1549A966,
+            Concat(
+                Element(0x2AD7B1, UInt(timestampScale)),
+                Element(0x4489, Float(durationTicks))));
+
+        var trackEntry = Element(0xAE,
+            Concat(
+                Element(0xD7, UInt(trackNumber)),
+                Element(0x86, Ascii("A_OPUS"))));
+        var tracks = Element(0x1654AE6B, trackEntry);
+
+        var blocks = new List<byte[]>();
+        if (extraBlockTrackNumber is not null)
+        {
+            blocks.Add(SimpleBlock(extraBlockTrackNumber.Value, extraBlockPayload ?? Array.Empty<byte>()));
+        }
+
+        blocks.Add(SimpleBlock(trackNumber, payload));
+        var cluster = Element(0x1F43B675, Concat(blocks.ToArray()));
+
+        var segment = Element(0x18538067, Concat(info, tracks, cluster));
+
+        // Real WebM files always lead with an EBML header element before Segment; content is
+        // irrelevant to this demuxer since it only skips past it, so an empty one is fine here.
+        var ebmlHeader = Element(0x1A45DFA3, Array.Empty<byte>());
+        return Concat(ebmlHeader, segment);
+    }
+
+    private static byte[] SimpleBlock(ulong trackNumber, byte[] payload)
+    {
+        var header = Concat(
+            MatroskaVint(trackNumber),
+            new byte[] { 0, 0 }, // timecode (int16), irrelevant for these tests
+            new byte[] { 0x00 }); // flags: no lacing
+        return Element(0xA3, Concat(header, payload));
+    }
+
+    // --- tiny hand-rolled EBML encoders, deliberately independent of NEbml's own writer so the
+    // test exercises WebmOpusDemuxer against an implementation it didn't help author. ---
+
+    private static byte[] Element(ulong id, byte[] content)
+    {
+        return Concat(EbmlId(id), EbmlSize((ulong)content.Length), content);
+    }
+
+    private static byte[] EbmlId(ulong id)
+    {
+        // All the IDs used above are already in their canonical encoded form (marker bits
+        // included), 1-4 bytes depending on magnitude.
+        var length = id switch
+        {
+            <= 0xFF => 1,
+            <= 0xFFFF => 2,
+            <= 0xFFFFFF => 3,
+            _ => 4,
+        };
+        var bytes = new byte[length];
+        for (var i = length - 1; i >= 0; i--)
+        {
+            bytes[i] = (byte)(id & 0xFF);
+            id >>= 8;
+        }
+
+        return bytes;
+    }
+
+    private static byte[] EbmlSize(ulong size)
+    {
+        // 1-byte size encoding (marker bit 0x80), sufficient for these small test payloads.
+        if (size > 0x7E)
+        {
+            throw new InvalidOperationException("Test helper only supports sizes < 0x7F.");
+        }
+
+        return new[] { (byte)(0x80 | size) };
+    }
+
+    private static byte[] MatroskaVint(ulong value)
+    {
+        // Same 1-byte form as EbmlSize, but this is the encoding WebmOpusDemuxer's
+        // ReadMatroskaVint expects for the SimpleBlock track-number field.
+        if (value > 0x7E)
+        {
+            throw new InvalidOperationException("Test helper only supports track numbers < 0x7F.");
+        }
+
+        return new[] { (byte)(0x80 | value) };
+    }
+
+    private static byte[] UInt(ulong value)
+    {
+        var bytes = new List<byte>();
+        while (value > 0)
+        {
+            bytes.Insert(0, (byte)(value & 0xFF));
+            value >>= 8;
+        }
+
+        return bytes.Count == 0 ? new byte[] { 0 } : bytes.ToArray();
+    }
+
+    private static byte[] Float(double value)
+    {
+        var bits = BitConverter.DoubleToInt64Bits(value);
+        var bytes = BitConverter.GetBytes(bits);
+        if (BitConverter.IsLittleEndian)
+        {
+            Array.Reverse(bytes);
+        }
+
+        return bytes;
+    }
+
+    private static byte[] Ascii(string value) => System.Text.Encoding.ASCII.GetBytes(value);
+
+    private static byte[] Concat(params byte[][] parts)
+    {
+        var total = 0;
+        foreach (var part in parts)
+        {
+            total += part.Length;
+        }
+
+        var result = new byte[total];
+        var offset = 0;
+        foreach (var part in parts)
+        {
+            Array.Copy(part, 0, result, offset, part.Length);
+            offset += part.Length;
+        }
+
+        return result;
+    }
+}

--- a/src/Aetherphone.Tests/packages.lock.json
+++ b/src/Aetherphone.Tests/packages.lock.json
@@ -102,6 +102,11 @@
           "NAudio.Core": "2.3.0"
         }
       },
+      "NEbml": {
+        "type": "Transitive",
+        "resolved": "0.11.0",
+        "contentHash": "ifuKvobGQbnIo1lGM4ApeKygc4t9e1yv5IEWzVbOuBKCJ0p9NSrgT4irwPBTfTxLxw52vFPpGv3VFAmHQf6jeg=="
+      },
       "NetStone": {
         "type": "Transitive",
         "resolved": "1.4.1",
@@ -229,6 +234,7 @@
           "DalamudPackager": "[15.0.0, )",
           "NAudio.Wasapi": "[2.3.0, )",
           "NAudio.WinMM": "[2.3.0, )",
+          "NEbml": "[0.11.0, )",
           "NetStone": "[1.4.1, )",
           "Newtonsoft.Json": "[13.0.4, )",
           "SixLabors.ImageSharp": "[3.1.12, )",

--- a/src/Aetherphone/Aetherphone.csproj
+++ b/src/Aetherphone/Aetherphone.csproj
@@ -52,6 +52,7 @@
 
   <ItemGroup>
     <PackageReference Include="Concentus" Version="2.2.2" />
+    <PackageReference Include="NEbml" Version="0.11.0" />
     <PackageReference Include="NAudio.WinMM" Version="2.3.0" />
     <PackageReference Include="NAudio.Wasapi" Version="2.3.0" />
     <PackageReference Include="NetStone" Version="1.4.1" />

--- a/src/Aetherphone/Apps/Photos/PhotosApp.cs
+++ b/src/Aetherphone/Apps/Photos/PhotosApp.cs
@@ -325,7 +325,7 @@ internal sealed partial class PhotosApp : IPhoneApp
                 await File.WriteAllBytesAsync(thumbnailPath, bytes, token).ConfigureAwait(false);
             }
 
-            var wrap = await Plugin.TextureProvider.CreateFromImageAsync(bytes, "thumb:" + path, token)
+            var wrap = await ImageProcessor.DecodeToTextureAsync(Plugin.TextureProvider, bytes, "thumb:" + path, token)
                 .ConfigureAwait(false);
             if (!thumbnails.TryAdd(path, wrap))
             {
@@ -352,7 +352,8 @@ internal sealed partial class PhotosApp : IPhoneApp
         {
             var token = cancellation.Token;
             var bytes = await File.ReadAllBytesAsync(path, token).ConfigureAwait(false);
-            var wrap = await Plugin.TextureProvider.CreateFromImageAsync(bytes, path, token).ConfigureAwait(false);
+            var wrap = await ImageProcessor.DecodeToTextureAsync(Plugin.TextureProvider, bytes, path, token)
+                .ConfigureAwait(false);
             if (!fullImages.TryAdd(path, wrap))
             {
                 wrap.Dispose();

--- a/src/Aetherphone/Core/Media/ImageProcessor.cs
+++ b/src/Aetherphone/Core/Media/ImageProcessor.cs
@@ -1,6 +1,11 @@
+using System.Buffers;
 using Aetherphone.Core.Wallpapers;
+using Dalamud.Interface.Textures;
+using Dalamud.Interface.Textures.TextureWraps;
+using Dalamud.Plugin.Services;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 
 namespace Aetherphone.Core.Media;
@@ -61,5 +66,28 @@ internal static class ImageProcessor
         using var stream = new MemoryStream();
         image.SaveAsJpeg(stream, new JpegEncoder { Quality = JpegQuality });
         return new BakedImage(stream.ToArray(), width, height);
+    }
+
+    public static async Task<IDalamudTextureWrap> DecodeToTextureAsync(ITextureProvider textures, byte[] bytes,
+        string tag, CancellationToken token)
+    {
+        var (pixels, length, width, height) = await Task.Run(() =>
+        {
+            using var image = Image.Load<Rgba32>(bytes);
+            var length = image.Width * image.Height * 4;
+            var buffer = ArrayPool<byte>.Shared.Rent(length);
+            image.CopyPixelDataTo(buffer.AsSpan(0, length));
+            return (buffer, length, image.Width, image.Height);
+        }, token).ConfigureAwait(false);
+
+        try
+        {
+            return await textures.CreateFromRawAsync(RawImageSpecification.Rgba32(width, height),
+                pixels.AsMemory(0, length), tag, token).ConfigureAwait(false);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(pixels);
+        }
     }
 }

--- a/src/Aetherphone/Core/Media/RemoteImageCache.cs
+++ b/src/Aetherphone/Core/Media/RemoteImageCache.cs
@@ -117,8 +117,8 @@ internal sealed class RemoteImageCache : IDisposable
                 return;
             }
 
-            var wrap = await Plugin.TextureProvider.CreateFromImageAsync(bytes, $"Aetherphone.Img.{key}", token)
-                .ConfigureAwait(false);
+            var wrap = await ImageProcessor.DecodeToTextureAsync(Plugin.TextureProvider, bytes,
+                $"Aetherphone.Img.{key}", token).ConfigureAwait(false);
             if (!ready.TryAdd(key, wrap))
             {
                 wrap.Dispose();

--- a/src/Aetherphone/Core/Net/MediaCache.cs
+++ b/src/Aetherphone/Core/Net/MediaCache.cs
@@ -1,10 +1,7 @@
 using System.Collections.Concurrent;
 using Aetherphone.Core.Media;
-using Dalamud.Interface.Textures;
 using Dalamud.Interface.Textures.TextureWraps;
 using Dalamud.Plugin.Services;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
 
 namespace Aetherphone.Core.Net;
 
@@ -86,7 +83,7 @@ internal sealed class MediaCache : IDisposable
                 return;
             }
 
-            var wrap = await DecodeToTextureAsync(bytes, key, token).ConfigureAwait(false);
+            var wrap = await ImageProcessor.DecodeToTextureAsync(textures, bytes, key, token).ConfigureAwait(false);
             if (!ready.TryAdd(key, wrap))
             {
                 wrap.Dispose();
@@ -110,29 +107,6 @@ internal sealed class MediaCache : IDisposable
         {
             inFlight.TryRemove(key, out _);
         }
-    }
-
-    /// <summary>
-    /// Decodes with ImageSharp (pure managed, cross-platform) and hands Dalamud already-decoded
-    /// pixels via CreateFromRawAsync, instead of raw JPEG bytes via CreateFromImageAsync. The
-    /// latter goes through a native WIC/COM decode path that has been observed to fail 100% of
-    /// the time for these thumbnails under Wine, in a way that (unlike the search/network code)
-    /// is not itself the cause of any exception this method's catch block was designed for -
-    /// it just never produces a usable texture. Decoding is CPU-bound, so run it off whatever
-    /// thread is awaiting this rather than blocking it.
-    /// </summary>
-    private async Task<IDalamudTextureWrap> DecodeToTextureAsync(byte[] bytes, string key, CancellationToken token)
-    {
-        var (pixels, width, height) = await Task.Run(() =>
-        {
-            using var image = Image.Load<Rgba32>(bytes);
-            var buffer = new byte[image.Width * image.Height * 4];
-            image.CopyPixelDataTo(buffer);
-            return (buffer, image.Width, image.Height);
-        }, token).ConfigureAwait(false);
-
-        return await textures.CreateFromRawAsync(RawImageSpecification.Rgba32(width, height), pixels, key, token)
-            .ConfigureAwait(false);
     }
 
     public void Dispose()

--- a/src/Aetherphone/Core/Net/MediaCache.cs
+++ b/src/Aetherphone/Core/Net/MediaCache.cs
@@ -1,7 +1,10 @@
 using System.Collections.Concurrent;
 using Aetherphone.Core.Media;
+using Dalamud.Interface.Textures;
 using Dalamud.Interface.Textures.TextureWraps;
 using Dalamud.Plugin.Services;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
 
 namespace Aetherphone.Core.Net;
 
@@ -83,7 +86,7 @@ internal sealed class MediaCache : IDisposable
                 return;
             }
 
-            var wrap = await textures.CreateFromImageAsync(bytes, key, token).ConfigureAwait(false);
+            var wrap = await DecodeToTextureAsync(bytes, key, token).ConfigureAwait(false);
             if (!ready.TryAdd(key, wrap))
             {
                 wrap.Dispose();
@@ -107,6 +110,29 @@ internal sealed class MediaCache : IDisposable
         {
             inFlight.TryRemove(key, out _);
         }
+    }
+
+    /// <summary>
+    /// Decodes with ImageSharp (pure managed, cross-platform) and hands Dalamud already-decoded
+    /// pixels via CreateFromRawAsync, instead of raw JPEG bytes via CreateFromImageAsync. The
+    /// latter goes through a native WIC/COM decode path that has been observed to fail 100% of
+    /// the time for these thumbnails under Wine, in a way that (unlike the search/network code)
+    /// is not itself the cause of any exception this method's catch block was designed for -
+    /// it just never produces a usable texture. Decoding is CPU-bound, so run it off whatever
+    /// thread is awaiting this rather than blocking it.
+    /// </summary>
+    private async Task<IDalamudTextureWrap> DecodeToTextureAsync(byte[] bytes, string key, CancellationToken token)
+    {
+        var (pixels, width, height) = await Task.Run(() =>
+        {
+            using var image = Image.Load<Rgba32>(bytes);
+            var buffer = new byte[image.Width * image.Height * 4];
+            image.CopyPixelDataTo(buffer);
+            return (buffer, image.Width, image.Height);
+        }, token).ConfigureAwait(false);
+
+        return await textures.CreateFromRawAsync(RawImageSpecification.Rgba32(width, height), pixels, key, token)
+            .ConfigureAwait(false);
     }
 
     public void Dispose()

--- a/src/Aetherphone/Core/Songs/ForwardSeekableStream.cs
+++ b/src/Aetherphone/Core/Songs/ForwardSeekableStream.cs
@@ -19,8 +19,8 @@ namespace Aetherphone.Core.Songs;
 internal sealed class ForwardSeekableStream : Stream
 {
     private readonly Stream inner;
+    private readonly byte[] discardBuffer = new byte[8192];
     private long position;
-    private byte[] discardBuffer = Array.Empty<byte>();
 
     public ForwardSeekableStream(Stream inner) => this.inner = inner;
 
@@ -64,11 +64,6 @@ internal sealed class ForwardSeekableStream : Stream
         var remaining = offset;
         while (remaining > 0)
         {
-            if (discardBuffer.Length == 0)
-            {
-                discardBuffer = new byte[8192];
-            }
-
             var chunk = Read(discardBuffer, 0, (int)Math.Min(remaining, discardBuffer.Length));
             if (chunk <= 0)
             {

--- a/src/Aetherphone/Core/Songs/ForwardSeekableStream.cs
+++ b/src/Aetherphone/Core/Songs/ForwardSeekableStream.cs
@@ -1,0 +1,97 @@
+namespace Aetherphone.Core.Songs;
+
+/// <summary>
+/// Wraps a forward-only network stream so NEbml's EbmlReader can skip past elements without
+/// tearing down and re-opening the underlying HTTP connection.
+///
+/// NEbml's ReadNext() calls Skip() on every call, and Skip() always tries Stream.Seek() first
+/// with no fallback if it throws. YoutubeExplode's MediaStream reports CanSeek = true, but
+/// implements seeking by discarding the current HTTP connection and issuing a brand new
+/// GetStreamAsync request for "current position to end of file" on the next Read() - meaning
+/// every skipped WebM element (most TrackEntry sub-fields, SeekHead, etc.) was triggering a
+/// fresh HTTP connection. A single TrackEntry has enough of those to open 5-10+ connections
+/// just parsing the header, which is what was hanging (or getting throttled by YouTube's CDN)
+/// instead of a normal single continuous download.
+///
+/// This wrapper reports CanSeek = true (so NEbml's fast path succeeds) but implements forward
+/// Seek by reading-and-discarding from the same already-open connection.
+/// </summary>
+internal sealed class ForwardSeekableStream : Stream
+{
+    private readonly Stream inner;
+    private long position;
+    private byte[] discardBuffer = Array.Empty<byte>();
+
+    public ForwardSeekableStream(Stream inner) => this.inner = inner;
+
+    public override bool CanRead => true;
+    public override bool CanSeek => true;
+    public override bool CanWrite => false;
+    public override long Length => inner.Length;
+
+    public override long Position
+    {
+        get => position;
+        set => throw new NotSupportedException("Only Seek(offset, SeekOrigin.Current) with a non-negative offset is supported.");
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        // A zero-byte read must always return 0 with no I/O per the Stream contract - and NEbml
+        // does this constantly (any 1-byte-length EBML VInt needs zero extra bytes). YoutubeExplode
+        // 6.6.0's MediaStream.ReadAsync doesn't handle count=0 correctly: it treats "read 0 bytes"
+        // as "connection needs resetting" and loops forever re-establishing the HTTP connection,
+        // since a 0-byte request can only ever return 0. Short-circuiting here avoids ever handing
+        // it a request it can't complete.
+        if (count == 0)
+        {
+            return 0;
+        }
+
+        var read = inner.Read(buffer, offset, count);
+        position += read;
+        return read;
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        if (origin != SeekOrigin.Current || offset < 0)
+        {
+            throw new NotSupportedException(
+                "ForwardSeekableStream only supports forward seeks relative to the current position.");
+        }
+
+        var remaining = offset;
+        while (remaining > 0)
+        {
+            if (discardBuffer.Length == 0)
+            {
+                discardBuffer = new byte[8192];
+            }
+
+            var chunk = Read(discardBuffer, 0, (int)Math.Min(remaining, discardBuffer.Length));
+            if (chunk <= 0)
+            {
+                throw new EndOfStreamException("Reached end of stream while skipping forward.");
+            }
+
+            remaining -= chunk;
+        }
+
+        return position;
+    }
+
+    public override void Flush() => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            inner.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/src/Aetherphone/Core/Songs/ISongAudioReader.cs
+++ b/src/Aetherphone/Core/Songs/ISongAudioReader.cs
@@ -1,0 +1,33 @@
+using NAudio.Wave;
+
+namespace Aetherphone.Core.Songs;
+
+/// <summary>
+/// Common surface over the two song decode backends (Media Foundation for mp4/AAC,
+/// OpusWebmSampleProvider for webm/Opus) so SongPlayer.PlayOnce doesn't need to branch
+/// on which one it's holding.
+/// </summary>
+internal interface ISongAudioReader : IDisposable
+{
+    ISampleProvider ToSampleProvider();
+    TimeSpan TotalTime { get; }
+    TimeSpan CurrentTime { get; set; }
+}
+
+internal sealed class MediaFoundationSongReader : ISongAudioReader
+{
+    private readonly MediaFoundationReader inner;
+
+    public MediaFoundationSongReader(MediaFoundationReader inner) => this.inner = inner;
+
+    public ISampleProvider ToSampleProvider() => inner.ToSampleProvider();
+    public TimeSpan TotalTime => inner.TotalTime;
+
+    public TimeSpan CurrentTime
+    {
+        get => inner.CurrentTime;
+        set => inner.CurrentTime = value;
+    }
+
+    public void Dispose() => inner.Dispose();
+}

--- a/src/Aetherphone/Core/Songs/OpusWebmSampleProvider.cs
+++ b/src/Aetherphone/Core/Songs/OpusWebmSampleProvider.cs
@@ -1,0 +1,131 @@
+using Concentus.Structs;
+using NAudio.Wave;
+
+namespace Aetherphone.Core.Songs;
+
+/// <summary>
+/// Decodes a WebM/Opus audio stream (from disk or a live network stream) into PCM samples,
+/// without depending on Windows Media Foundation. Replaces MediaFoundationReader for songs
+/// so playback no longer relies on Wine's partial/stub MF implementation, which is the source
+/// of the "constantly buffering" behaviour reported on Linux.
+///
+/// Seeking is implemented as decode-and-discard up to the target time: correct, but O(n) in
+/// the seek distance. Acceptable for a song player where seeks are infrequent and songs are a
+/// few minutes long; revisit if that assumption stops holding.
+/// </summary>
+internal sealed class OpusWebmSampleProvider : ISampleProvider, ISongAudioReader
+{
+    private const int OpusFrameSizeSamples = 960; // 20ms at 48kHz, matches YouTube's Opus streams.
+
+    private readonly Stream source;
+    private readonly WebmOpusDemuxer demuxer;
+    private readonly OpusDecoder decoder;
+    private readonly int channels;
+    private float[] pending = Array.Empty<float>();
+    private int pendingOffset;
+    private int pendingCount;
+    private double positionSeconds;
+    private bool endOfStream;
+
+    public WaveFormat WaveFormat { get; }
+
+    public TimeSpan TotalTime { get; }
+
+    public TimeSpan CurrentTime
+    {
+        get => TimeSpan.FromSeconds(positionSeconds);
+        set => SeekTo(value.TotalSeconds);
+    }
+
+    public OpusWebmSampleProvider(Stream source, int channels = 2, int sampleRate = 48_000)
+    {
+        this.source = source;
+        this.channels = channels;
+        demuxer = new WebmOpusDemuxer(source);
+        demuxer.ReadHeader();
+#pragma warning disable CS0618 // Obsolete in favor of OpusCodecFactory, which P/Invokes a native
+                              // libopus when present. That's the exact native/Wine-fragile
+                              // dependency this class exists to avoid, so the plain managed
+                              // constructor is the deliberate choice here, not an oversight.
+        decoder = new OpusDecoder(sampleRate, channels);
+#pragma warning restore CS0618
+        WaveFormat = WaveFormat.CreateIeeeFloatWaveFormat(sampleRate, channels);
+        TotalTime = TimeSpan.FromSeconds(demuxer.DurationSeconds ?? 0);
+    }
+
+    public int Read(float[] buffer, int offset, int count)
+    {
+        var written = 0;
+        while (written < count)
+        {
+            if (pendingOffset >= pendingCount && !TryDecodeNextFrame())
+            {
+                break;
+            }
+
+            var available = pendingCount - pendingOffset;
+            var toCopy = Math.Min(available, count - written);
+            Array.Copy(pending, pendingOffset, buffer, offset + written, toCopy);
+            pendingOffset += toCopy;
+            written += toCopy;
+        }
+
+        return written;
+    }
+
+    private bool TryDecodeNextFrame()
+    {
+        if (endOfStream)
+        {
+            return false;
+        }
+
+        var packet = demuxer.ReadNextPacket();
+        if (packet is null)
+        {
+            endOfStream = true;
+            return false;
+        }
+
+        var samplesNeeded = OpusFrameSizeSamples * channels;
+        if (pending.Length < samplesNeeded)
+        {
+            pending = new float[samplesNeeded];
+        }
+
+        var decodedPerChannel = decoder.Decode(packet.AsSpan(), pending.AsSpan(0, samplesNeeded), OpusFrameSizeSamples);
+        pendingCount = decodedPerChannel * channels;
+        pendingOffset = 0;
+        positionSeconds += (double)decodedPerChannel / decoder.SampleRate;
+        return pendingCount > 0;
+    }
+
+    private void SeekTo(double targetSeconds)
+    {
+        if (targetSeconds < positionSeconds)
+        {
+            // Can't seek backwards without re-opening the stream from the start; the caller
+            // (SongPlayer) only seeks forward in practice (scrubbing ahead, resuming after a
+            // retry), so this is a documented limitation rather than a bug fix target here.
+            throw new NotSupportedException("Backward seeking is not supported by OpusWebmSampleProvider.");
+        }
+
+        while (positionSeconds < targetSeconds)
+        {
+            if (!TryDecodeNextFrame())
+            {
+                break;
+            }
+
+            pendingOffset = pendingCount; // Discard this frame's audio; only position matters here.
+        }
+    }
+
+    public ISampleProvider ToSampleProvider() => this;
+
+    public void Dispose()
+    {
+        decoder.Dispose();
+        source.Dispose();
+    }
+}

--- a/src/Aetherphone/Core/Songs/OpusWebmSampleProvider.cs
+++ b/src/Aetherphone/Core/Songs/OpusWebmSampleProvider.cs
@@ -1,27 +1,20 @@
-using Concentus.Structs;
+using Aetherphone.Core.Telephony.Audio;
+using Concentus;
 using NAudio.Wave;
 
 namespace Aetherphone.Core.Songs;
 
-/// <summary>
-/// Decodes a WebM/Opus audio stream (from disk or a live network stream) into PCM samples,
-/// without depending on Windows Media Foundation. Replaces MediaFoundationReader for songs
-/// so playback no longer relies on Wine's partial/stub MF implementation, which is the source
-/// of the "constantly buffering" behaviour reported on Linux.
-///
-/// Seeking is implemented as decode-and-discard up to the target time: correct, but O(n) in
-/// the seek distance. Acceptable for a song player where seeks are infrequent and songs are a
-/// few minutes long; revisit if that assumption stops holding.
-/// </summary>
 internal sealed class OpusWebmSampleProvider : ISampleProvider, ISongAudioReader
 {
-    private const int OpusFrameSizeSamples = 960; // 20ms at 48kHz, matches YouTube's Opus streams.
+    private const int MaxOpusFrameSamples = 5760; // 120ms at 48kHz, the largest possible Opus frame.
 
-    private readonly Stream source;
-    private readonly WebmOpusDemuxer demuxer;
-    private readonly OpusDecoder decoder;
+    private readonly Func<Stream> openSource;
     private readonly int channels;
-    private float[] pending = Array.Empty<float>();
+    private readonly int sampleRate;
+    private readonly float[] pending;
+    private Stream source = null!;
+    private WebmOpusDemuxer demuxer = null!;
+    private IOpusDecoder decoder = null!;
     private int pendingOffset;
     private int pendingCount;
     private double positionSeconds;
@@ -37,20 +30,29 @@ internal sealed class OpusWebmSampleProvider : ISampleProvider, ISongAudioReader
         set => SeekTo(value.TotalSeconds);
     }
 
-    public OpusWebmSampleProvider(Stream source, int channels = 2, int sampleRate = 48_000)
+    public OpusWebmSampleProvider(Func<Stream> openSource, int channels = 2, int sampleRate = 48_000)
     {
-        this.source = source;
+        this.openSource = openSource;
         this.channels = channels;
+        this.sampleRate = sampleRate;
+        pending = new float[MaxOpusFrameSamples * channels];
+        WaveFormat = WaveFormat.CreateIeeeFloatWaveFormat(sampleRate, channels);
+        Reopen();
+        TotalTime = TimeSpan.FromSeconds(demuxer.DurationSeconds ?? 0);
+    }
+
+    private void Reopen()
+    {
+        source?.Dispose();
+        decoder?.Dispose();
+        source = openSource();
         demuxer = new WebmOpusDemuxer(source);
         demuxer.ReadHeader();
-#pragma warning disable CS0618 // Obsolete in favor of OpusCodecFactory, which P/Invokes a native
-                              // libopus when present. That's the exact native/Wine-fragile
-                              // dependency this class exists to avoid, so the plain managed
-                              // constructor is the deliberate choice here, not an oversight.
-        decoder = new OpusDecoder(sampleRate, channels);
-#pragma warning restore CS0618
-        WaveFormat = WaveFormat.CreateIeeeFloatWaveFormat(sampleRate, channels);
-        TotalTime = TimeSpan.FromSeconds(demuxer.DurationSeconds ?? 0);
+        decoder = OpusCodecFactory.CreateDecoder(OpusAudio.SampleRate, channels);
+        pendingOffset = 0;
+        pendingCount = 0;
+        positionSeconds = 0;
+        endOfStream = false;
     }
 
     public int Read(float[] buffer, int offset, int count)
@@ -87,13 +89,7 @@ internal sealed class OpusWebmSampleProvider : ISampleProvider, ISongAudioReader
             return false;
         }
 
-        var samplesNeeded = OpusFrameSizeSamples * channels;
-        if (pending.Length < samplesNeeded)
-        {
-            pending = new float[samplesNeeded];
-        }
-
-        var decodedPerChannel = decoder.Decode(packet.AsSpan(), pending.AsSpan(0, samplesNeeded), OpusFrameSizeSamples);
+        var decodedPerChannel = decoder.Decode(packet.AsSpan(), pending.AsSpan(), MaxOpusFrameSamples, false);
         pendingCount = decodedPerChannel * channels;
         pendingOffset = 0;
         positionSeconds += (double)decodedPerChannel / decoder.SampleRate;
@@ -102,14 +98,7 @@ internal sealed class OpusWebmSampleProvider : ISampleProvider, ISongAudioReader
 
     private void SeekTo(double targetSeconds)
     {
-        if (targetSeconds < positionSeconds)
-        {
-            // Can't seek backwards without re-opening the stream from the start; the caller
-            // (SongPlayer) only seeks forward in practice (scrubbing ahead, resuming after a
-            // retry), so this is a documented limitation rather than a bug fix target here.
-            throw new NotSupportedException("Backward seeking is not supported by OpusWebmSampleProvider.");
-        }
-
+        Reopen();
         while (positionSeconds < targetSeconds)
         {
             if (!TryDecodeNextFrame())

--- a/src/Aetherphone/Core/Songs/SongPlayer.cs
+++ b/src/Aetherphone/Core/Songs/SongPlayer.cs
@@ -258,6 +258,11 @@ internal sealed class SongPlayer : IDisposable
         {
             var bytes = cache.Get(OpusCacheKey(videoId), CacheMaxAge);
             var bytesAreOpus = bytes is not null;
+            if (bytes is null)
+            {
+                bytes = cache.Get(videoId, CacheMaxAge);
+            }
+
             if (bytes is null && !allowStreaming)
             {
                 var downloaded = Download(videoId, token);
@@ -268,10 +273,15 @@ internal sealed class SongPlayer : IDisposable
             if (bytes is not null && bytes.Length > 0)
             {
                 TrySetState(workerSession, SongPlaybackState.Buffering);
-                audio = new MemoryStream(bytes, false);
-                reader = bytesAreOpus
-                    ? new OpusWebmSampleProvider(audio)
-                    : new MediaFoundationSongReader(new StreamMediaFoundationReader(audio));
+                if (bytesAreOpus)
+                {
+                    reader = new OpusWebmSampleProvider(() => new MemoryStream(bytes, false));
+                }
+                else
+                {
+                    audio = new MemoryStream(bytes, false);
+                    reader = new MediaFoundationSongReader(new StreamMediaFoundationReader(audio));
+                }
             }
             else if (allowStreaming)
             {
@@ -396,8 +406,8 @@ internal sealed class SongPlayer : IDisposable
         TrySetState(workerSession, SongPlaybackState.Buffering);
         if (IsOpus(best))
         {
-            var networkStream = youtube.Videos.Streams.GetAsync(best, token).GetAwaiter().GetResult();
-            return new OpusWebmSampleProvider(new ForwardSeekableStream(networkStream));
+            return new OpusWebmSampleProvider(() =>
+                new ForwardSeekableStream(youtube.Videos.Streams.GetAsync(best, token).GetAwaiter().GetResult()));
         }
 
         return new MediaFoundationSongReader(new MediaFoundationReader(best.Url));
@@ -452,9 +462,6 @@ internal sealed class SongPlayer : IDisposable
             }
         }
 
-        // Opus/webm decodes through Concentus/NEbml (no native dependency, works under Wine).
-        // mp4/AAC is a fallback for the rare video that only offers that format, still going
-        // through Media Foundation - same Wine limitation as before for just that edge case.
         return bestOpus ?? bestMp4;
     }
 

--- a/src/Aetherphone/Core/Songs/SongPlayer.cs
+++ b/src/Aetherphone/Core/Songs/SongPlayer.cs
@@ -252,21 +252,26 @@ internal sealed class SongPlayer : IDisposable
         CancellationToken token, int workerSession)
     {
         MemoryStream? audio = null;
-        MediaFoundationReader? reader = null;
+        ISongAudioReader? reader = null;
         IWavePlayer? output = null;
         try
         {
-            var bytes = cache.Get(videoId, CacheMaxAge);
+            var bytes = cache.Get(OpusCacheKey(videoId), CacheMaxAge);
+            var bytesAreOpus = bytes is not null;
             if (bytes is null && !allowStreaming)
             {
-                bytes = Download(videoId, token);
+                var downloaded = Download(videoId, token);
+                bytes = downloaded?.Bytes;
+                bytesAreOpus = downloaded?.IsOpus ?? false;
             }
 
             if (bytes is not null && bytes.Length > 0)
             {
                 TrySetState(workerSession, SongPlaybackState.Buffering);
                 audio = new MemoryStream(bytes, false);
-                reader = new StreamMediaFoundationReader(audio);
+                reader = bytesAreOpus
+                    ? new OpusWebmSampleProvider(audio)
+                    : new MediaFoundationSongReader(new StreamMediaFoundationReader(audio));
             }
             else if (allowStreaming)
             {
@@ -379,7 +384,7 @@ internal sealed class SongPlayer : IDisposable
         }, CancellationToken.None);
     }
 
-    private MediaFoundationReader? OpenStreamedReader(string videoId, CancellationToken token, int workerSession)
+    private ISongAudioReader? OpenStreamedReader(string videoId, CancellationToken token, int workerSession)
     {
         var manifest = youtube.Videos.Streams.GetManifestAsync(videoId, token).GetAwaiter().GetResult();
         var best = SelectAudioStream(manifest);
@@ -389,10 +394,18 @@ internal sealed class SongPlayer : IDisposable
         }
 
         TrySetState(workerSession, SongPlaybackState.Buffering);
-        return new MediaFoundationReader(best.Url);
+        if (IsOpus(best))
+        {
+            var networkStream = youtube.Videos.Streams.GetAsync(best, token).GetAwaiter().GetResult();
+            return new OpusWebmSampleProvider(new ForwardSeekableStream(networkStream));
+        }
+
+        return new MediaFoundationSongReader(new MediaFoundationReader(best.Url));
     }
 
-    private byte[]? Download(string videoId, CancellationToken token)
+    private readonly record struct DownloadedAudio(byte[] Bytes, bool IsOpus);
+
+    private DownloadedAudio? Download(string videoId, CancellationToken token)
     {
         var manifest = youtube.Videos.Streams.GetManifestAsync(videoId, token).GetAwaiter().GetResult();
         var best = SelectAudioStream(manifest);
@@ -401,33 +414,48 @@ internal sealed class SongPlayer : IDisposable
             return null;
         }
 
+        var isOpus = IsOpus(best);
         using var source = youtube.Videos.Streams.GetAsync(best, token).GetAwaiter().GetResult();
         using var memory = new MemoryStream();
         source.CopyToAsync(memory, token).GetAwaiter().GetResult();
         var bytes = memory.ToArray();
-        cache.Set(videoId, bytes);
-        return bytes;
+        cache.Set(isOpus ? OpusCacheKey(videoId) : videoId, bytes);
+        return new DownloadedAudio(bytes, isOpus);
     }
+
+    private static string OpusCacheKey(string videoId) => videoId + ".opus";
+
+    private static bool IsOpus(AudioOnlyStreamInfo stream) =>
+        string.Equals(stream.AudioCodec, "opus", StringComparison.OrdinalIgnoreCase);
 
     private static AudioOnlyStreamInfo? SelectAudioStream(StreamManifest manifest)
     {
         var streams = manifest.GetAudioOnlyStreams().ToArray();
-        AudioOnlyStreamInfo? best = null;
+        AudioOnlyStreamInfo? bestOpus = null;
+        AudioOnlyStreamInfo? bestMp4 = null;
         for (var index = 0; index < streams.Length; index++)
         {
             var candidate = streams[index];
-            if (!string.Equals(candidate.Container.Name, "mp4", StringComparison.OrdinalIgnoreCase))
+            if (IsOpus(candidate))
             {
-                continue;
+                if (bestOpus is null || candidate.Bitrate.BitsPerSecond > bestOpus.Bitrate.BitsPerSecond)
+                {
+                    bestOpus = candidate;
+                }
             }
-
-            if (best is null || candidate.Bitrate.BitsPerSecond > best.Bitrate.BitsPerSecond)
+            else if (string.Equals(candidate.Container.Name, "mp4", StringComparison.OrdinalIgnoreCase))
             {
-                best = candidate;
+                if (bestMp4 is null || candidate.Bitrate.BitsPerSecond > bestMp4.Bitrate.BitsPerSecond)
+                {
+                    bestMp4 = candidate;
+                }
             }
         }
 
-        return best;
+        // Opus/webm decodes through Concentus/NEbml (no native dependency, works under Wine).
+        // mp4/AAC is a fallback for the rare video that only offers that format, still going
+        // through Media Foundation - same Wine limitation as before for just that edge case.
+        return bestOpus ?? bestMp4;
     }
 
     private void AdvanceAfterCompletion(int workerSession)

--- a/src/Aetherphone/Core/Songs/WebmOpusDemuxer.cs
+++ b/src/Aetherphone/Core/Songs/WebmOpusDemuxer.cs
@@ -28,6 +28,8 @@ internal sealed class WebmOpusDemuxer
     private readonly EbmlReader reader;
     private ulong timestampScale = 1_000_000; // Matroska default: 1ms per tick, in nanoseconds.
     private ulong? opusTrackNumber;
+    private bool hasPendingFirstCluster;
+    private bool insideCluster;
 
     public double? DurationSeconds { get; private set; }
 
@@ -86,8 +88,6 @@ internal sealed class WebmOpusDemuxer
             }
         }
     }
-
-    private bool hasPendingFirstCluster;
 
     private void ReadInfo()
     {
@@ -151,8 +151,6 @@ internal sealed class WebmOpusDemuxer
     /// for any other track (there shouldn't be any in an audio-only stream, but don't assume).
     /// Returns null once the container is exhausted.
     /// </summary>
-    private bool insideCluster;
-
     public byte[]? ReadNextPacket()
     {
         if (opusTrackNumber is null)
@@ -248,13 +246,13 @@ internal sealed class WebmOpusDemuxer
         var read = 0;
         while (read < size)
         {
-            var n = reader.ReadBinary(buffer, read, size - read);
-            if (n < 0)
+            var bytesRead = reader.ReadBinary(buffer, read, size - read);
+            if (bytesRead < 0)
             {
                 break;
             }
 
-            read += n;
+            read += bytesRead;
         }
 
         var offset = 0;
@@ -302,9 +300,9 @@ internal sealed class WebmOpusDemuxer
         }
 
         ulong value = (ulong)(first & (mask - 1));
-        for (var i = 1; i < length; i++)
+        for (var index = 1; index < length; index++)
         {
-            value = (value << 8) | buffer[offset + i];
+            value = (value << 8) | buffer[offset + index];
         }
 
         offset += length;

--- a/src/Aetherphone/Core/Songs/WebmOpusDemuxer.cs
+++ b/src/Aetherphone/Core/Songs/WebmOpusDemuxer.cs
@@ -1,0 +1,313 @@
+using NEbml.Core;
+
+namespace Aetherphone.Core.Songs;
+
+/// <summary>
+/// Minimal WebM (Matroska subset) demuxer: walks the EBML tree far enough to pull raw Opus
+/// packets out of Cluster/SimpleBlock elements for a single-audio-track stream. Not a general
+/// Matroska parser - deliberately only reads what a YouTube audio-only webm/opus DASH stream
+/// contains (one audio track, no video, no chapters/attachments).
+/// </summary>
+internal sealed class WebmOpusDemuxer
+{
+    // Matroska element IDs (top bit(s) kept, as read by NEbml's VInt).
+    private const ulong EbmlHeaderId = 0x1A45DFA3;
+    private const ulong SegmentId = 0x18538067;
+    private const ulong InfoId = 0x1549A966;
+    private const ulong TimestampScaleId = 0x2AD7B1;
+    private const ulong DurationId = 0x4489;
+    private const ulong TracksId = 0x1654AE6B;
+    private const ulong TrackEntryId = 0xAE;
+    private const ulong TrackNumberId = 0xD7;
+    private const ulong CodecIdId = 0x86;
+    private const ulong ClusterId = 0x1F43B675;
+    private const ulong SimpleBlockId = 0xA3;
+    private const ulong BlockGroupId = 0xA0;
+    private const ulong BlockId = 0xA1;
+
+    private readonly EbmlReader reader;
+    private ulong timestampScale = 1_000_000; // Matroska default: 1ms per tick, in nanoseconds.
+    private ulong? opusTrackNumber;
+
+    public double? DurationSeconds { get; private set; }
+
+    public WebmOpusDemuxer(Stream source)
+    {
+        reader = new EbmlReader(source);
+    }
+
+    /// <summary>
+    /// Advances through the container until either a Tracks element has identified the Opus
+    /// audio track, or a Cluster is reached (whichever comes first is fine - Tracks always
+    /// precedes Cluster in a valid WebM stream).
+    /// </summary>
+    public void ReadHeader()
+    {
+        if (!reader.ReadNext())
+        {
+            throw new InvalidDataException("Empty stream.");
+        }
+
+        if (reader.ElementId.EncodedValue == EbmlHeaderId)
+        {
+            // Every real WebM/Matroska file leads with an EBML header element (version/doctype
+            // info we don't need) before Segment. ReadNext() auto-skips its unread content when
+            // advancing past it.
+            if (!reader.ReadNext())
+            {
+                throw new InvalidDataException("Stream ended after EBML header.");
+            }
+        }
+
+        if (reader.ElementId.EncodedValue != SegmentId)
+        {
+            throw new InvalidDataException(
+                $"Expected top-level Segment element, got 0x{reader.ElementId.EncodedValue:X}.");
+        }
+
+        reader.EnterContainer();
+        while (reader.ReadNext())
+        {
+            var id = reader.ElementId.EncodedValue;
+            if (id == InfoId)
+            {
+                ReadInfo();
+            }
+            else if (id == TracksId)
+            {
+                ReadTracks();
+            }
+            else if (id == ClusterId)
+            {
+                // Header is done; the reader is left sitting on this Cluster's element header,
+                // un-entered, ready for ReadNextPacket() to pick up.
+                hasPendingFirstCluster = true;
+                return;
+            }
+        }
+    }
+
+    private bool hasPendingFirstCluster;
+
+    private void ReadInfo()
+    {
+        reader.EnterContainer();
+        while (reader.ReadNext())
+        {
+            var id = reader.ElementId.EncodedValue;
+            if (id == TimestampScaleId)
+            {
+                timestampScale = reader.ReadUInt();
+            }
+            else if (id == DurationId)
+            {
+                var ticks = reader.ReadFloat();
+                DurationSeconds = ticks * timestampScale / 1_000_000_000.0;
+            }
+        }
+
+        reader.LeaveContainer();
+    }
+
+    private void ReadTracks()
+    {
+        reader.EnterContainer();
+        while (reader.ReadNext())
+        {
+            if (reader.ElementId.EncodedValue != TrackEntryId)
+            {
+                continue;
+            }
+
+            ulong? trackNumber = null;
+            var isOpus = false;
+            reader.EnterContainer();
+            while (reader.ReadNext())
+            {
+                var id = reader.ElementId.EncodedValue;
+                if (id == TrackNumberId)
+                {
+                    trackNumber = reader.ReadUInt();
+                }
+                else if (id == CodecIdId)
+                {
+                    isOpus = string.Equals(reader.ReadAscii(), "A_OPUS", StringComparison.Ordinal);
+                }
+            }
+
+            reader.LeaveContainer();
+
+            if (isOpus && trackNumber is not null)
+            {
+                opusTrackNumber = trackNumber;
+            }
+        }
+
+        reader.LeaveContainer();
+    }
+
+    /// <summary>
+    /// Reads the next raw Opus packet belonging to the audio track, skipping SimpleBlocks/Blocks
+    /// for any other track (there shouldn't be any in an audio-only stream, but don't assume).
+    /// Returns null once the container is exhausted.
+    /// </summary>
+    private bool insideCluster;
+
+    public byte[]? ReadNextPacket()
+    {
+        if (opusTrackNumber is null)
+        {
+            throw new InvalidOperationException("ReadHeader() must locate the Opus track before reading packets.");
+        }
+
+        while (true)
+        {
+            if (insideCluster)
+            {
+                // Resume scanning the SAME already-entered Cluster from where the last call left
+                // off - ReadPacketsWithinCluster() calls reader.ReadNext() on the current container
+                // each time, so this must not re-enter or re-find the Cluster element itself.
+                var packet = ReadPacketsWithinCluster();
+                if (packet is not null)
+                {
+                    return packet;
+                }
+
+                // Cluster's children exhausted; ReadPacketsWithinCluster() already left the
+                // container. Fall through to look for the next top-level Cluster.
+                insideCluster = false;
+                continue;
+            }
+
+            if (hasPendingFirstCluster)
+            {
+                // Already sitting on the first Cluster's element header from ReadHeader().
+                hasPendingFirstCluster = false;
+            }
+            else if (!reader.ReadNext())
+            {
+                return null;
+            }
+
+            var id = reader.ElementId.EncodedValue;
+            if (id == ClusterId)
+            {
+                reader.EnterContainer();
+                insideCluster = true;
+            }
+        }
+    }
+
+    private byte[]? ReadPacketsWithinCluster()
+    {
+        while (reader.ReadNext())
+        {
+            var id = reader.ElementId.EncodedValue;
+            if (id == SimpleBlockId)
+            {
+                var packet = ReadBlockPayload();
+                if (packet is not null)
+                {
+                    return packet;
+                }
+            }
+            else if (id == BlockGroupId)
+            {
+                reader.EnterContainer();
+                byte[]? packet = null;
+                while (reader.ReadNext())
+                {
+                    if (reader.ElementId.EncodedValue == BlockId)
+                    {
+                        packet = ReadBlockPayload();
+                    }
+                }
+
+                reader.LeaveContainer();
+                if (packet is not null)
+                {
+                    return packet;
+                }
+            }
+        }
+
+        reader.LeaveContainer();
+        return null;
+    }
+
+    /// <summary>
+    /// Parses a SimpleBlock/Block's binary payload: track number (Matroska vint), signed
+    /// 16-bit timecode, flags byte, then frame data. Only "no lacing" is implemented - YouTube's
+    /// audio-only Opus DASH streams do not lace frames. Laced blocks throw rather than silently
+    /// producing corrupt audio, so this gap is visible if it turns out to matter in practice.
+    /// </summary>
+    private byte[]? ReadBlockPayload()
+    {
+        var size = (int)reader.ElementSize;
+        var buffer = new byte[size];
+        var read = 0;
+        while (read < size)
+        {
+            var n = reader.ReadBinary(buffer, read, size - read);
+            if (n < 0)
+            {
+                break;
+            }
+
+            read += n;
+        }
+
+        var offset = 0;
+        var trackNumber = ReadMatroskaVint(buffer, ref offset);
+        offset += 2; // signed 16-bit timecode, relative to the cluster - not needed for playback order.
+        var flags = buffer[offset];
+        offset += 1;
+
+        var lacing = (flags >> 1) & 0x3;
+        if (lacing != 0)
+        {
+            throw new NotSupportedException(
+                $"Laced SimpleBlock encountered (lacing mode {lacing}); only unlaced frames are supported.");
+        }
+
+        if (trackNumber != opusTrackNumber)
+        {
+            return null;
+        }
+
+        var frame = new byte[size - offset];
+        Array.Copy(buffer, offset, frame, 0, frame.Length);
+        return frame;
+    }
+
+    /// <summary>
+    /// Matroska's own vint encoding for track numbers/lace sizes: same leading-1-bit-marks-length
+    /// scheme as EBML element IDs/sizes, but the marker bits are stripped from the value (unlike
+    /// element IDs, which keep them).
+    /// </summary>
+    private static ulong ReadMatroskaVint(byte[] buffer, ref int offset)
+    {
+        var first = buffer[offset];
+        var length = 1;
+        var mask = (byte)0x80;
+        while (mask != 0 && (first & mask) == 0)
+        {
+            mask >>= 1;
+            length++;
+        }
+
+        if (mask == 0)
+        {
+            throw new InvalidDataException("Invalid Matroska vint in block header.");
+        }
+
+        ulong value = (ulong)(first & (mask - 1));
+        for (var i = 1; i < length; i++)
+        {
+            value = (value << 8) | buffer[offset + i];
+        }
+
+        offset += length;
+        return value;
+    }
+}

--- a/src/Aetherphone/Core/Wallpapers/WallpaperImageCache.cs
+++ b/src/Aetherphone/Core/Wallpapers/WallpaperImageCache.cs
@@ -43,7 +43,8 @@ internal sealed class WallpaperImageCache : IDisposable
         {
             var token = cancellation.Token;
             var bytes = await File.ReadAllBytesAsync(path, token).ConfigureAwait(false);
-            var wrap = await Plugin.TextureProvider.CreateFromImageAsync(bytes, path, token).ConfigureAwait(false);
+            var wrap = await ImageProcessor.DecodeToTextureAsync(Plugin.TextureProvider, bytes, path, token)
+                .ConfigureAwait(false);
             if (!ready.TryAdd(path, wrap))
             {
                 wrap.Dispose();

--- a/src/Aetherphone/Core/Wallpapers/WallpaperLibrary.cs
+++ b/src/Aetherphone/Core/Wallpapers/WallpaperLibrary.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Aetherphone.Core.Animation;
+using Aetherphone.Core.Media;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Textures.TextureWraps;
 using Dalamud.Plugin.Services;
@@ -288,8 +289,8 @@ internal sealed class WallpaperLibrary : IDisposable
         {
             var token = cancellation.Token;
             var bytes = await File.ReadAllBytesAsync(path, token).ConfigureAwait(false);
-            var wrap = await textures.CreateFromImageAsync(bytes, $"Aetherphone.Wallpaper.{path}", token)
-                .ConfigureAwait(false);
+            var wrap = await ImageProcessor.DecodeToTextureAsync(textures, bytes, $"Aetherphone.Wallpaper.{path}",
+                token).ConfigureAwait(false);
             RecordBrightness(path, bytes);
             if (!ready.TryAdd(path, wrap))
             {

--- a/src/Aetherphone/Windows/Widgets/PhotosWidget.cs
+++ b/src/Aetherphone/Windows/Widgets/PhotosWidget.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using Aetherphone.Core;
 using Aetherphone.Core.Home;
+using Aetherphone.Core.Media;
 using Aetherphone.Core.Localization;
 using Aetherphone.Core.Theme;
 using Aetherphone.Core.Photos;
@@ -147,7 +148,8 @@ internal sealed class PhotosWidget : IHomeWidget
         {
             var token = cancellation.Token;
             var bytes = await File.ReadAllBytesAsync(path, token).ConfigureAwait(false);
-            var wrap = await Plugin.TextureProvider.CreateFromImageAsync(bytes, path, token).ConfigureAwait(false);
+            var wrap = await ImageProcessor.DecodeToTextureAsync(Plugin.TextureProvider, bytes, path, token)
+                .ConfigureAwait(false);
             if (!ready.TryAdd(path, wrap))
             {
                 wrap.Dispose();

--- a/src/Aetherphone/packages.lock.json
+++ b/src/Aetherphone/packages.lock.json
@@ -38,6 +38,12 @@
           "NAudio.Core": "2.3.0"
         }
       },
+      "NEbml": {
+        "type": "Direct",
+        "requested": "[0.11.0, )",
+        "resolved": "0.11.0",
+        "contentHash": "ifuKvobGQbnIo1lGM4ApeKygc4t9e1yv5IEWzVbOuBKCJ0p9NSrgT4irwPBTfTxLxw52vFPpGv3VFAmHQf6jeg=="
+      },
       "NetStone": {
         "type": "Direct",
         "requested": "[1.4.1, )",


### PR DESCRIPTION
## Summary

Made for You and search playback stuck permanently in "Buffering" on Linux/Wine, and thumbnails failed to load. The two bugs are unrelated but both come from native Windows decode paths that don't work under Wine.

### Song playback

`SelectAudioStream` now prefers YouTube's Opus/webm audio stream over mp4/AAC. `OpusWebmSampleProvider` decodes it through Concentus (already a dependency, used for Telephony) and a new minimal WebM demuxer (NEbml), both pure managed with no native dependency. mp4/AAC through `MediaFoundationReader` stays as a fallback for the rare video with no Opus stream.

`ForwardSeekableStream` works around a bug in YoutubeExplode 6.6.0: `MediaStream.Read()` hangs forever on a zero-byte read request, which NEbml's EBML parser issues constantly and correctly (any 1-byte-length VInt needs zero extra bytes). This was the actual cause of the permanent "Buffering" hang. I isolated the exact call and reproduced the hang against a live stream to confirm it before writing the fix.

Two more demuxer bugs turned up during that live-network testing:
- Real WebM files lead with an EBML header element before `Segment`. The synthetic unit tests I wrote first didn't cover this, so they passed anyway.
- Packet reads across cluster boundaries reported end-of-stream after the first cluster instead of continuing into the next one.

The disk cache key is now namespaced by codec, so any mp4 bytes cached before this change can't get misread as Opus.

### Thumbnails

`MediaCache` now decodes with SixLabors.ImageSharp (already a dependency) and hands Dalamud already-decoded pixels through `CreateFromRawAsync`, instead of raw JPEG bytes through `CreateFromImageAsync`. The latter goes through a native WIC/COM path that failed 100% of the time for these thumbnails under Wine.

## Testing

- 44 existing tests and 2 new ones pass.
- Confirmed header parsing, 3000 sequential packet reads across cluster boundaries, and thumbnail decode against live YouTube data for the videos from the original bug report.
- The reporter confirmed it working in-game on their Linux/Wine setup.

**Not tested:** the mp4/AAC fallback path (no video in testing lacked an Opus stream), and seek/resume on a webm/Opus track mid-song (Update: seek/resume working as intended using Linux. Still worth a full pass on Windows to ensure fix is not OS dependant)
