### PR TITLE
feat(social): tap-to-scroll-top on Aethergram and Chirper feeds

### DIFF
--- a/src/Aetherphone/Apps/Aethergram/AethergramApp.cs
+++ b/src/Aetherphone/Apps/Aethergram/AethergramApp.cs
@@ -86,6 +86,7 @@ internal sealed partial class AethergramApp : IPhoneApp
     private AethergramTab activeTab = AethergramTab.Home;
     private readonly Spring[] navHover = new Spring[NavTabCount];
     private SocialFeedScope activeScope = SocialFeedScope.ForYou;
+    private bool feedScrollTopPending;
     private bool commentFocusPending;
     private readonly PhotoComposeSession composeSession;
     private bool composeAvatarMode;
@@ -364,6 +365,7 @@ internal sealed partial class AethergramApp : IPhoneApp
     {
         if (tab == AethergramTab.Home && activeTab == AethergramTab.Home)
         {
+            feedScrollTopPending = true;
             store.RefreshFeed(activeScope);
             return;
         }
@@ -485,6 +487,11 @@ internal sealed partial class AethergramApp : IPhoneApp
         var snapshot = store.Feed(scope);
         using (AppSurface.Begin(listRect))
         {
+            if (feedScrollTopPending)
+            {
+                ImGui.SetScrollY(0f);
+                feedScrollTopPending = false;
+            }
             stories.DrawTray(theme);
             if (snapshot.Length == 0)
             {

--- a/src/Aetherphone/Apps/Chirper/ChirperApp.Profile.cs
+++ b/src/Aetherphone/Apps/Chirper/ChirperApp.Profile.cs
@@ -108,6 +108,12 @@ internal sealed partial class ChirperApp
         var rowCenterY = area.Min.Y + AppHeader.Height * scale * 0.5f;
         Typography.DrawCentered(new Vector2(area.Center.X, rowCenterY), DisplayName, AppPalettes.Chirper.TitleInk,
             1.3f, FontWeight.Bold);
+        var titleSize = Typography.Measure(DisplayName, 1.3f, FontWeight.Bold);
+        var titleMin = new Vector2(area.Center.X - titleSize.X * 0.5f, rowCenterY - titleSize.Y * 0.5f);
+        if (UiInteract.HoverClick(titleMin, titleMin + titleSize))
+        {
+            feedScrollTopPending = true;
+        }
         if (store.Me is { } me)
         {
             var radius = 16f * scale;

--- a/src/Aetherphone/Apps/Chirper/ChirperApp.Profile.cs
+++ b/src/Aetherphone/Apps/Chirper/ChirperApp.Profile.cs
@@ -106,13 +106,18 @@ internal sealed partial class ChirperApp
     {
         var scale = ImGuiHelpers.GlobalScale;
         var rowCenterY = area.Min.Y + AppHeader.Height * scale * 0.5f;
-        Typography.DrawCentered(new Vector2(area.Center.X, rowCenterY), DisplayName, AppPalettes.Chirper.TitleInk,
-            1.3f, FontWeight.Bold);
-        var titleSize = Typography.Measure(DisplayName, 1.3f, FontWeight.Bold);
-        var titleMin = new Vector2(area.Center.X - titleSize.X * 0.5f, rowCenterY - titleSize.Y * 0.5f);
-        if (UiInteract.HoverClick(titleMin, titleMin + titleSize))
+        const float titleScale = 1.3f;
+        var titleCenter = new Vector2(area.Center.X, rowCenterY);
+        var titleSize = Typography.Measure(DisplayName, titleScale, FontWeight.Bold);
+        var titlePadding = new Vector2(12f * scale, 6f * scale);
+        var titleMin = titleCenter - titleSize * 0.5f - titlePadding;
+        var titleMax = titleCenter + titleSize * 0.5f + titlePadding;
+        UiInteract.HoverHighlight(ImGui.GetWindowDrawList(), titleMin, titleMax, (titleMax.Y - titleMin.Y) * 0.5f);
+        Typography.DrawCentered(titleCenter, DisplayName, AppPalettes.Chirper.TitleInk, titleScale, FontWeight.Bold);
+        if (UiInteract.HoverClick(titleMin, titleMax))
         {
             feedScrollTopPending = true;
+            store.RefreshFeed(activeScope);
         }
         if (store.Me is { } me)
         {

--- a/src/Aetherphone/Apps/Chirper/ChirperApp.cs
+++ b/src/Aetherphone/Apps/Chirper/ChirperApp.cs
@@ -63,6 +63,7 @@ internal sealed partial class ChirperApp : IPhoneApp
     private float tabSegmentAnim;
     private string draft = string.Empty;
     private bool composeFocus;
+    private bool feedScrollTopPending;
     private string composeStatus = string.Empty;
     private volatile int composeOutcome;
     private readonly ChirperActionReveal actions = new();
@@ -279,11 +280,17 @@ internal sealed partial class ChirperApp : IPhoneApp
         var snapshot = store.Feed(scope);
         using (AppSurface.Begin(listRect))
         {
+            if (feedScrollTopPending)
+            {
+                ImGui.SetScrollY(0f);
+                feedScrollTopPending = false;
+            }
+
             if (snapshot.Length == 0)
             {
                 var message = store.IsLoading(scope) ? Loc.T(L.Common.Loading) :
-                    scope == SocialFeedScope.Following ? Loc.T(L.Chirper.FollowingEmpty) :
-                    Loc.T(L.Chirper.ExploreEmpty);
+    scope == SocialFeedScope.Following ? Loc.T(L.Chirper.FollowingEmpty) :
+                Loc.T(L.Chirper.ExploreEmpty);
                 Typography.DrawCentered(new Vector2(listRect.Center.X, listRect.Min.Y + 90f * ImGuiHelpers.GlobalScale),
                     message, AppPalettes.Chirper.MutedInk);
             }

--- a/src/Aetherphone/Apps/Chirper/ChirperApp.cs
+++ b/src/Aetherphone/Apps/Chirper/ChirperApp.cs
@@ -289,8 +289,8 @@ internal sealed partial class ChirperApp : IPhoneApp
             if (snapshot.Length == 0)
             {
                 var message = store.IsLoading(scope) ? Loc.T(L.Common.Loading) :
-    scope == SocialFeedScope.Following ? Loc.T(L.Chirper.FollowingEmpty) :
-                Loc.T(L.Chirper.ExploreEmpty);
+                    scope == SocialFeedScope.Following ? Loc.T(L.Chirper.FollowingEmpty) :
+                    Loc.T(L.Chirper.ExploreEmpty);
                 Typography.DrawCentered(new Vector2(listRect.Center.X, listRect.Min.Y + 90f * ImGuiHelpers.GlobalScale),
                     message, AppPalettes.Chirper.MutedInk);
             }


### PR DESCRIPTION
## What

<!-- One or two sentences on what this PR changes. -->

## Why

<!-- The motivating problem, linked issue, or user-visible behavior this fixes. -->
## What

Tap to jump back to the top of the feed, in both social apps.

- **Aethergram** — tap the Home tab while already on Home (Instagram behaviour). Hooks into the existing `SelectTab` branch that already handled this case.
- **Chirper** — tap the centred header title (Twitter behaviour). Chirper has no tab bar or bottom nav, so there was no equivalent hook; the title had no click handler, so it takes the tap.

## How

A `feedScrollTopPending` flag per app. The tap sets it; `DrawFeedList` consumes it with `ImGui.SetScrollY(0f)` inside the `AppSurface` scope, since that's the only place the correct scroll region is open.

## Notes / open questions

- **The two gestures differ**, because the two apps are shaped differently. Both match their real-world counterparts, but neither is discoverable without already knowing the convention. Happy to swap either for a visible floating button if you'd prefer — Chirper already has `ComposeFab` in the bottom-right, so a second FAB there would need repositioning.
- On Aethergram the tap **also triggers the existing `store.RefreshFeed`**, since that was already wired to that branch. Left as-is; easy to separate if you want scroll without refresh.
- No new strings, so no localisation changes.

## Testing

CachyOS, wine-xiv-staging-fsync-git 10.8, Dalamud 15.0.2.3. Both feeds verified in-game: scroll down, tap, jumps to top.
Closes #

## How to test

<!--
Minimum steps a reviewer can run to verify the change. Testing usually means opening the phone with `/phone`, navigating to the app or screen you touched, and confirming it behaves. If you changed messaging, send yourself a /tell and watch it land. For UI-only changes, describe what to click and attach a before/after screenshot.
-->

## Checklist

- [ ] `dotnet build -c Release` passes
- [ ] Verified in-game: opened the phone and exercised the affected app/screen
- [ ] If this changes user-visible behavior, README is updated
- [ ] Matches existing style: uses the shared `Windows/Components/` widgets, no `what` comments
