### PR TITLE
perf(social): cap feed length to stop long browsing sessions going ch…

### DIFF
--- a/src/Aetherphone/Apps/Aethergram/AethergramApp.cs
+++ b/src/Aetherphone/Apps/Aethergram/AethergramApp.cs
@@ -485,6 +485,10 @@ internal sealed partial class AethergramApp : IPhoneApp
         var snapshot = store.Feed(scope);
         using (AppSurface.Begin(listRect))
         {
+            if (ImGui.GetScrollY() < 1f)
+            {
+                store.TrimFeed(scope, SocialFeedStore.FeedCap);
+            }
             stories.DrawTray(theme);
             if (snapshot.Length == 0)
             {

--- a/src/Aetherphone/Apps/Chirper/ChirperApp.cs
+++ b/src/Aetherphone/Apps/Chirper/ChirperApp.cs
@@ -279,6 +279,11 @@ internal sealed partial class ChirperApp : IPhoneApp
         var snapshot = store.Feed(scope);
         using (AppSurface.Begin(listRect))
         {
+            if (ImGui.GetScrollY() < 1f)
+            {
+                store.TrimFeed(scope, SocialFeedStore.FeedCap);
+
+            }
             if (snapshot.Length == 0)
             {
                 var message = store.IsLoading(scope) ? Loc.T(L.Common.Loading) :

--- a/src/Aetherphone/Core/Social/FeedLane.cs
+++ b/src/Aetherphone/Core/Social/FeedLane.cs
@@ -60,6 +60,26 @@ internal sealed class FeedLane<TPost> where TPost : class, IIdentified
         }
     }
 
+    public void Trim(int max)
+    {
+        if (max <= 0)
+        {
+            return;
+        }
+
+        lock (gate)
+        {
+            if (items.Length <= max)
+            {
+                return;
+            }
+
+            var trimmed = new TPost[max];
+            Array.Copy(items, trimmed, max);
+            items = trimmed;
+        }
+    }
+
     public void Clear()
     {
         lock (gate)

--- a/src/Aetherphone/Core/Social/SocialFeedStore.cs
+++ b/src/Aetherphone/Core/Social/SocialFeedStore.cs
@@ -105,6 +105,10 @@ internal abstract class SocialFeedStore : IDisposable
 
     public bool LoadingMore(SocialFeedScope scope) => Lane(scope).LoadingMore;
 
+    public const int FeedCap = 300;
+
+    public void TrimFeed(SocialFeedScope scope, int max) => Lane(scope).Trim(max);
+
     private FeedLane<PostDto> Lane(SocialFeedScope scope) =>
         scope == SocialFeedScope.ForYou ? forYouLane : followingLane;
 


### PR DESCRIPTION
Fixes #43.

## Cause

`FeedLane.items` only ever grows — `ApplyRefresh` merges new posts in at the head, `ApplyMore` appends older ones at the tail, and nothing is ever removed.

Memory isn't really the issue. `DrawFeedList` loops over every loaded post each frame and calls `FeedVirtualizer.Skip` on each one. Even when culling works, that's two ImGui cursor calls plus a dictionary lookup per post per frame — a couple of thousand posts at 60fps is a lot of work to step over invisible rows.

`FeedVirtualizer.BeginFrame` also clears its whole height cache when content width or font generation changes. Nothing can be skipped on the frame after that clear, so everything loaded gets drawn at once — probably the more visible hitch.

`RichTextCache` was the other suspect but it's already capped at 256 and clears itself, so it isn't leaking.

## Change

`FeedLane.Trim(max)` keeps the newest `max` items (the lane is sorted newest-first). `SocialFeedStore` exposes `TrimFeed(scope, max)` and a `FeedCap` constant; both apps call it from `DrawFeedList`, guarded on `ImGui.GetScrollY() < 1f`.

The scroll guard matters — trimming only when the user is parked at the top means everything removed is far below the viewport, so there's no jolt. Trimming inside `ApplyMore` would be wrong: items are newest-first, so it would immediately drop the page infinite scroll had just fetched.

Both apps go through `SocialFeedStore`/`FeedLane`, so Chirper is covered by the same change.

## Constraint worth knowing

**The cap must sit comfortably above the server's page size.** Testing at 5 produced a visible loop: trim to 5 → next refresh merges a full page → back over the cap → trim again, with the scrollbar flashing each cycle. 300 is well clear of this.

## Open question

`cursor` is a single value pointing past the oldest post loaded, and there's no way to rewind it. So after a trim, scrolling back down far enough fetches from the cursor and leaves a gap where the trimmed posts were.

Options as I see them:

1. Cap generously and accept the gap — only affects someone who browses all day *and* scrolls back down deep, and the missing posts are ones they already scrolled past. **This is what's implemented.**
2. Null the cursor on trim, so the feed cleanly ends instead of gapping. Honest, but infinite scroll stops.
3. Store per-page cursors so a trim can rewind properly. Correct, but a real change to how paging works.

Happy to do 3 instead if you'd prefer — it touches paging more broadly, so it felt like your call rather than mine.

## Testing

CachyOS, wine-xiv-staging-fsync-git 10.8, Dalamud 15.0.2.3. Verified with a temporarily lowered cap: trim fires on returning to the top, infinite scroll still fetches afterwards, both apps behave the same.