### PR TITLE
feat(settings): add 12/24-hour clock toggle

### DIFF
--- a/src/Aetherphone/Apps/Clock/ClockApp.World.cs
+++ b/src/Aetherphone/Apps/Clock/ClockApp.World.cs
@@ -38,7 +38,7 @@ internal sealed partial class ClockApp
 
             var utc = DateTime.UtcNow;
             var utcSeconds = utc.Second + utc.Millisecond / 1000f;
-            DrawWorldRow(RowAt(card, 1, WorldRowHeight, scale), Loc.T(L.Clock.Server), "UTC", utc.ToString("HH:mm"),
+            DrawWorldRow(RowAt(card, 1, WorldRowHeight, scale), Loc.T(L.Clock.Server), "UTC", TimeText.Clock(utc),
                 utc.Hour, utc.Minute, utcSeconds);
 
             for (var index = 0; index < cities.Count; index++)
@@ -69,7 +69,7 @@ internal sealed partial class ClockApp
         AnalogClock.Draw(clockCenter, clockRadius, local.Hour, local.Minute, localSeconds, theme);
 
         var textX = clockCenter.X + clockRadius + 22f * scale;
-        var digital = local.ToString("HH:mm");
+        var digital = TimeText.Clock(local);
         var date = local.ToString("ddd d MMM", Loc.Culture);
         var zone = $"{Loc.T(L.Clock.Local)} · {LocalOffsetLabel()}";
         var digitalSize = Typography.Measure(digital, TextStyles.LargeTitle);
@@ -111,7 +111,7 @@ internal sealed partial class ClockApp
 
         var cityNow = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, zone);
         var citySeconds = cityNow.Second + cityNow.Millisecond / 1000f;
-        DrawWorldRow(row, entry.City, CityOffsetLabel(zone, cityNow), cityNow.ToString("HH:mm"), cityNow.Hour,
+        DrawWorldRow(row, entry.City, CityOffsetLabel(zone, cityNow), TimeText.Clock(cityNow), cityNow.Hour,
             cityNow.Minute, citySeconds);
     }
 

--- a/src/Aetherphone/Apps/Settings/Pages/AppearancePage.cs
+++ b/src/Aetherphone/Apps/Settings/Pages/AppearancePage.cs
@@ -97,6 +97,17 @@ internal sealed class AppearancePage : ISettingsPage
                 configuration.Save();
             }
 
+            SettingsSection.Header(Loc.T(L.Settings.ClockFormat), theme);
+            var clockCard = GroupCard.Begin(theme, 1);
+            var use24 = SettingsRow.Bool(clockCard.NextRow(), Loc.T(L.Settings.Use24HourClock),
+                                         configuration.Use24HourClock, theme);
+            clockCard.End();
+            if (use24 != configuration.Use24HourClock)
+            {
+                configuration.Use24HourClock = use24;
+                TimeText.Use24Hour = use24;
+                configuration.Save();
+            }
             DrawHomeSection(theme);
         }
     }

--- a/src/Aetherphone/Configuration.cs
+++ b/src/Aetherphone/Configuration.cs
@@ -128,6 +128,7 @@ internal sealed class Configuration : IPluginConfiguration
     public Dictionary<ulong, List<string>> MutedLinkshellsByCharacter { get; set; } = new();
     public bool LinkshellMutesPerCharacterMigrated { get; set; }
     public long DevChatLastSeenUnix { get; set; }
+    public bool Use24HourClock { get; set; } = true;
     public bool TimeZoneManual { get; set; }
     public int ManualUtcOffsetMinutes { get; set; }
     public bool RegionManual { get; set; }

--- a/src/Aetherphone/Core/Localization/L.cs
+++ b/src/Aetherphone/Core/Localization/L.cs
@@ -468,6 +468,8 @@ internal static class L
         public static readonly LocString Wallpaper = new("settings.wallpaper", "Wallpaper");
         public static readonly LocString TextSize = new("settings.textSize", "Text Size");
         public static readonly LocString PhoneSize = new("settings.phoneSize", "Phone Size");
+        public static readonly LocString ClockFormat = new("settings.clockFormat", "Clock");
+        public static readonly LocString Use24HourClock = new("settings.use24HourClock", "24-hour time");
         public static readonly LocString Notifications = new("settings.notifications", "Notifications");
         public static readonly LocString DoNotDisturb = new("settings.doNotDisturb", "Do Not Disturb");
         public static readonly LocString Vibration = new("settings.vibration", "Vibration");

--- a/src/Aetherphone/Core/Localization/TimeText.cs
+++ b/src/Aetherphone/Core/Localization/TimeText.cs
@@ -2,6 +2,20 @@ namespace Aetherphone.Core.Localization;
 
 internal static class TimeText
 {
+    private static bool use24Hour = true;
+
+    public static bool Use24Hour
+    {
+        get => use24Hour;
+        set => use24Hour = value;
+    }
+
+    public static string ClockPattern => use24Hour ? "HH:mm" : "h:mm tt";
+
+    public static string Clock(DateTime moment) => moment.ToString(ClockPattern, Loc.Culture);
+
+    public static string Clock(DateTimeOffset moment) => moment.ToString(ClockPattern, Loc.Culture);
+
     public static string Ago(DateTime utcMoment)
     {
         if (utcMoment == default)
@@ -100,7 +114,7 @@ internal static class TimeText
             return string.Empty;
         }
 
-        return DateTimeOffset.FromUnixTimeSeconds(unixSeconds).ToLocalTime().ToString("t", Loc.Culture);
+    return Clock(DateTimeOffset.FromUnixTimeSeconds(unixSeconds).ToLocalTime());
     }
 
     public static string DayLabel(long unixSeconds)

--- a/src/Aetherphone/Core/News/NewsFormat.cs
+++ b/src/Aetherphone/Core/News/NewsFormat.cs
@@ -16,10 +16,10 @@ internal static class NewsFormat
     {
         var localStart = start.ToLocalTime();
         var localEnd = end.ToLocalTime();
-        var startText = localStart.ToString("MMM d, HH:mm", Loc.Culture);
+        var startText = localStart.ToString("MMM d, " + TimeText.ClockPattern, Loc.Culture);
         var endText = localStart.Date == localEnd.Date
-            ? localEnd.ToString("HH:mm", Loc.Culture)
-            : localEnd.ToString("MMM d, HH:mm", Loc.Culture);
+        ? TimeText.Clock(localEnd)
+        : localEnd.ToString("MMM d, " + TimeText.ClockPattern, Loc.Culture);
         return string.Concat(startText, " – ", endText);
     }
 

--- a/src/Aetherphone/Core/Shell/StatusBar.cs
+++ b/src/Aetherphone/Core/Shell/StatusBar.cs
@@ -1,3 +1,4 @@
+using Aetherphone.Core.Localization;
 using Aetherphone.Core.Theme;
 using Aetherphone.Windows.Components;
 using Dalamud.Bindings.ImGui;
@@ -22,15 +23,17 @@ internal static class StatusBar
     private const float IslandTop = 9f;
     private static string cachedTime = string.Empty;
     private static int cachedTimeKey = -1;
+    private static bool cachedUse24Hour = true;
 
     private static string CurrentTime()
     {
         var now = DateTime.Now;
         var key = now.Hour * 60 + now.Minute;
-        if (key != cachedTimeKey)
+        if (key != cachedTimeKey || cachedUse24Hour != TimeText.Use24Hour)
         {
             cachedTimeKey = key;
-            cachedTime = now.ToString("HH:mm");
+            cachedUse24Hour = TimeText.Use24Hour;
+            cachedTime = TimeText.Clock(now);
         }
 
         return cachedTime;

--- a/src/Aetherphone/Core/Venues/VenueFormat.cs
+++ b/src/Aetherphone/Core/Venues/VenueFormat.cs
@@ -1,5 +1,5 @@
 using System.Globalization;
-
+using Aetherphone.Core.Localization;
 namespace Aetherphone.Core.Venues;
 
 internal static class VenueFormat
@@ -7,10 +7,10 @@ internal static class VenueFormat
     public static string Range(VenueEvent venue)
     {
         var start = venue.StartUtc.ToLocalTime();
-        var startText = start.ToString("HH:mm", CultureInfo.InvariantCulture);
+        var startText = TimeText.Clock(start);
         if (!IsToday(start))
         {
-            startText = start.ToString("dd/MM HH:mm", CultureInfo.InvariantCulture);
+            startText = start.ToString("dd/MM " + TimeText.ClockPattern, CultureInfo.InvariantCulture);
         }
 
         if (venue.EndUtc is not { } endUtc)
@@ -19,7 +19,7 @@ internal static class VenueFormat
         }
 
         var end = endUtc.ToLocalTime();
-        return $"{startText} – {end:HH:mm}";
+        return $"{startText} – {TimeText.Clock(end)}";
     }
 
     public static string EndsAt(VenueEvent venue)
@@ -29,7 +29,7 @@ internal static class VenueFormat
             return string.Empty;
         }
 
-        return endUtc.ToLocalTime().ToString("HH:mm", CultureInfo.InvariantCulture);
+        return TimeText.Clock(endUtc.ToLocalTime());
     }
 
     public static string Starts(VenueEvent venue, DateTime nowUtc)

--- a/src/Aetherphone/Plugin.cs
+++ b/src/Aetherphone/Plugin.cs
@@ -273,6 +273,7 @@ public sealed class Plugin : IDalamudPlugin
         }
 
         Loc.Initialize(Cfg.Language, directory);
+        TimeText.Use24Hour = Cfg.Use24HourClock;
     }
 
     private static string DetectLanguage()

--- a/src/Aetherphone/Windows/Widgets/CalendarWidget.cs
+++ b/src/Aetherphone/Windows/Widgets/CalendarWidget.cs
@@ -177,10 +177,10 @@ internal sealed class CalendarWidget : IHomeWidget
     {
         if (begin.Date == DateTime.Today)
         {
-            return begin.ToString("HH:mm");
+            return TimeText.Clock(begin);
         }
 
-        return string.Concat(begin.ToString("ddd"), " ", begin.ToString("HH:mm"));
+        return string.Concat(begin.ToString("ddd"), " ", TimeText.Clock(begin));
     }
 
     public void Dispose()

--- a/src/Aetherphone/Windows/Widgets/ClockWidget.cs
+++ b/src/Aetherphone/Windows/Widgets/ClockWidget.cs
@@ -45,7 +45,7 @@ internal sealed class ClockWidget : IHomeWidget
         var bell = EorzeaTime.Now();
         var bellSeconds = EorzeaTime.CurrentSeconds() % 60;
         DrawFace(context, new Vector2(bounds.Min.X + bounds.Width * 0.27f, faceCenterY), radius, now.Hour, now.Minute,
-            now.Second + now.Millisecond / 1000f, Loc.T(L.Home.Local), now.ToString("HH:mm"), context.Theme, scale);
+            now.Second + now.Millisecond / 1000f, Loc.T(L.Home.Local), TimeText.Clock(now), context.Theme, scale);
         DrawFace(context, new Vector2(bounds.Min.X + bounds.Width * 0.73f, faceCenterY), radius, bell.Hour,
             bell.Minute, bellSeconds, Loc.T(L.Home.Eorzea), bell.Formatted, context.Theme, scale);
     }


### PR DESCRIPTION
Adds a 12/24-hour clock toggle, from the feature-request board (11 votes).

## Change

- `Use24HourClock` on `Configuration`, defaulting to **true** so nothing changes for anyone who doesn't touch it
- A static `Use24Hour` and `ClockPattern` on `TimeText`, mirroring how `Loc.Culture` already works, so the formatter stays free of a config dependency
- Set from config at startup next to `Loc.Initialize`, and updated live when toggled
- Thirteen hardcoded `"HH:mm"` sites repointed at `TimeText.Clock` / `ClockPattern` — status bar, clock widget, Clock app, calendar widget, news and venue formatting
- Toggle on Settings → Appearance, in its own Clock section
- `StatusBar`'s minute cache now also busts on format change, so the toggle applies instantly rather than at the next minute

## Two behaviour changes worth flagging

- **Venue times now use `Loc.Culture`.** `VenueFormat` was using `InvariantCulture` while `NewsFormat` used `Loc.Culture` — the two were inconsistent. Going through `TimeText.Clock` unifies them, but it does mean venue times now localise where they previously didn't.
- **Chat timestamps.** `TimeText.Clock(long)` used the `"t"` pattern, which already picks 12- or 24-hour from culture. It now follows the explicit setting instead, which is the point of the feature but is a change for anyone on a 12-hour locale.

One spot left inconsistent on purpose: `VenueFormat` line 13 composes `ClockPattern` with `InvariantCulture`, so AM/PM there stays English. Happy to unify if you'd rather.

Eorzea time in the Skywatcher widget is untouched — that felt like it should stay 24-hour regardless.

## Testing

CachyOS, wine-xiv-staging-fsync-git 10.8, Dalamud 15.0.2.3. Toggle verified against the status bar and Clock app, flipping instantly both ways, and persisting across a plugin reload.