### PR TITLE
fix(app/dailies): Use RowId instead of CompletionArrayIndex

### DIFF
--- a/src/Aetherphone/Core/Game/GameData.cs
+++ b/src/Aetherphone/Core/Game/GameData.cs
@@ -416,7 +416,7 @@ internal sealed class GameData
                 continue;
             }
 
-            indices.Add((byte)row.CompletionArrayIndex);
+            indices.Add((byte)row.RowId);
         }
 
         dailyBonusRouletteIndices = indices.Count > 0 ? indices.ToArray() : Array.Empty<byte>();


### PR DESCRIPTION
## What

This makes the `DailyBonusRouleteIndices` method return the `RowId` of a row instead of the `CompletionArrayIndex`.

## Why

`CompletionArrayIndex` is used in `IPlayerState`, and not in the native struct methods. Those methods use the `RowId` instead.

This closes the bug report posted on [discord](https://discord.com/channels/1527213298087493732/1529524429044973689).

## How to test

1. Open the phone via any preferred method of choice
2. Navigate to the Dailies App
3. Check on both a character that did not do the roulette, and one that did do it.

## Checklist

- [x] `dotnet build -c Release` passes
- [x] Verified in-game: opened the phone and exercised the affected app/screen
- [x] If this changes user-visible behavior, README is updated
- [x] Matches existing style: uses the shared `Windows/Components/` widgets, no `what` comments
