### PR TITLE
feat(jobs): add Jobs app with gearset swapping and custom backgrounds

### DIFF
--- a/src/Aetherphone/Apps/Jobs/JobsApp.cs
+++ b/src/Aetherphone/Apps/Jobs/JobsApp.cs
@@ -1,0 +1,532 @@
+using Aetherphone.Core;
+using Aetherphone.Core.Apps;
+using Aetherphone.Core.Confirm;
+using Aetherphone.Core.Game;
+using Aetherphone.Core.Jobs;
+using Aetherphone.Core.Localization;
+using Aetherphone.Core.Theme;
+using Aetherphone.Windows.Components;
+using Dalamud.Bindings.ImGui;
+using Dalamud.Interface;
+using Dalamud.Interface.Textures;
+using Dalamud.Interface.Utility;
+using Dalamud.Interface.Utility.Raii;
+using Dalamud.Plugin.Services;
+
+namespace Aetherphone.Apps.Jobs;
+
+internal sealed class JobsApp : IPhoneApp
+{
+    private const float RefreshIntervalSeconds = 2f;
+    private const float RowHeight = 64f;
+    private const float CardRounding = 18f;
+    private const float SectionGap = 12f;
+    private const string ColorMenuId = "jobs.color";
+
+    private const ImGuiWindowFlags HostFlags = ImGuiWindowFlags.NoBackground | ImGuiWindowFlags.NoDecoration |
+                                                ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse |
+                                                ImGuiWindowFlags.NoMove;
+
+    public string Id => "jobs";
+    public string DisplayName => Loc.T(L.Apps.Jobs);
+    public string Glyph => "J";
+    public int BadgeCount => 0;
+
+    public Vector4 Accent => HexColor.TryParse(configuration.JobsAccentName, out var custom)
+        ? custom
+        : ThemeCatalog.ResolveAccent(configuration.JobsAccentName);
+
+    private readonly GameData gameData;
+    private readonly ITextureProvider textures;
+    private readonly Configuration configuration;
+    private readonly ConfirmService confirm;
+    private readonly AppSkin ui = new(AppPalettes.JobsFor(ThemeCatalog.ResolveAccent("Blue")));
+    private readonly DropdownMenu colorMenu = new();
+    private JobRoleSection[] sections = Array.Empty<JobRoleSection>();
+    private bool loaded;
+    private float sinceRefresh;
+    private Rect colorButtonRect;
+    private bool showHexInput;
+    private string hexDigits = string.Empty;
+    private string hexColorName = string.Empty;
+    private string lastAppliedHexDigits = string.Empty;
+    private int hexInputOpenedFrame;
+    private int editingSavedColorIndex = -1;
+
+    public JobsApp(GameData gameData, ITextureProvider textures, Configuration configuration, ConfirmService confirm)
+    {
+        this.gameData = gameData;
+        this.textures = textures;
+        this.configuration = configuration;
+        this.confirm = confirm;
+    }
+
+    public void OnOpened() => Rebuild();
+
+    public void OnClosed()
+    {
+        sections = Array.Empty<JobRoleSection>();
+        loaded = false;
+        colorMenu.Close();
+        showHexInput = false;
+        editingSavedColorIndex = -1;
+    }
+
+    private void Rebuild()
+    {
+        sections = gameData.LocalPlayer is null ? Array.Empty<JobRoleSection>() : JobsReader.Build(gameData);
+        loaded = true;
+        sinceRefresh = 0f;
+    }
+
+    public void Draw(in PhoneContext context)
+    {
+        var scale = ImGuiHelpers.GlobalScale;
+        var theme = context.Theme;
+        var content = context.Content;
+        ui.Theme = theme;
+        ui.Palette = AppPalettes.JobsFor(Accent);
+        ui.Backdrop(SceneChrome.ScreenFrom(content, theme, scale));
+        colorMenu.Gate();
+        if (showHexInput)
+        {
+            UiInteract.BlockThisFrame();
+        }
+
+        DrawHeader(content, scale);
+
+        var body = new Rect(new Vector2(content.Min.X, content.Min.Y + AppHeader.Height * scale), content.Max);
+        if (!loaded)
+        {
+            Rebuild();
+        }
+
+        if (gameData.LocalPlayer is null)
+        {
+            Typography.DrawCentered(body.Center, Loc.T(L.Jobs.LogInToView), ui.MutedInk, TextStyles.Subheadline);
+        }
+        else
+        {
+            sinceRefresh += ImGui.GetIO().DeltaTime;
+            if (sinceRefresh >= RefreshIntervalSeconds)
+            {
+                Rebuild();
+            }
+
+            using (AppSurface.Begin(body))
+            {
+                if (sections.Length == 0)
+                {
+                    DrawHint();
+                }
+                else
+                {
+                    for (var index = 0; index < sections.Length; index++)
+                    {
+                        var section = sections[index];
+                        ui.SectionHeading(Loc.T(section.Title), index == 0 ? 8f : 4f);
+                        DrawSectionCard(section, scale);
+                        ImGui.Dummy(new Vector2(0f, SectionGap * scale));
+                    }
+
+                    ImGui.Dummy(new Vector2(0f, 8f * scale));
+                }
+            }
+        }
+
+        // Mirrors AethergramApp.DrawRoot: menus are drawn last, after the content they float above.
+        DrawColorMenu(content, theme);
+        if (showHexInput)
+        {
+            DrawHexInput(scale);
+        }
+    }
+
+    private void DrawHeader(Rect content, float scale)
+    {
+        var rowCenterY = content.Min.Y + AppHeader.Height * scale * 0.5f;
+        Typography.DrawCentered(new Vector2(content.Center.X, rowCenterY), DisplayName, ui.TitleInk, 1.15f,
+            FontWeight.SemiBold);
+        var radius = 15f * scale;
+        var buttonCenter = new Vector2(content.Max.X - Metrics.Space.Lg * scale - radius, rowCenterY);
+        colorButtonRect = new Rect(buttonCenter - new Vector2(radius, radius), buttonCenter + new Vector2(radius, radius));
+        if (ui.IconButton(buttonCenter, radius, FontAwesomeIcon.Palette.ToIconString(), ui.TitleInk,
+                Palette.WithAlpha(ui.TitleInk, 0.12f), 0.55f, Loc.T(L.Jobs.BackgroundColor)))
+        {
+            colorMenu.Toggle(ColorMenuId, colorButtonRect);
+        }
+    }
+
+    private void DrawColorMenu(Rect content, PhoneTheme theme)
+    {
+        if (!colorMenu.IsOpenFor(ColorMenuId))
+        {
+            return;
+        }
+
+        var savedColors = configuration.JobsCustomColors;
+        var savedOffset = ThemeCatalog.Accents.Count;
+        var customIndex = savedOffset + savedColors.Count;
+        var items = new DropdownMenu.Item[customIndex + 1];
+        for (var index = 0; index < ThemeCatalog.Accents.Count; index++)
+        {
+            var swatch = ThemeCatalog.Accents[index];
+            items[index] = new DropdownMenu.Item(CatalogLabels.Accent(swatch.Name),
+                Selected: swatch.Name == configuration.JobsAccentName);
+        }
+
+        for (var index = 0; index < savedColors.Count; index++)
+        {
+            items[savedOffset + index] = new DropdownMenu.Item(savedColors[index].Name,
+                Selected: savedColors[index].Hex == configuration.JobsAccentName, CanEdit: true, CanDelete: true);
+        }
+
+        items[customIndex] = new DropdownMenu.Item(Loc.T(L.Jobs.CustomColor),
+            Glyph: FontAwesomeIcon.EyeDropper.ToIconString());
+
+        var picked = colorMenu.Draw(content, theme, items, out var rowAction);
+        if (picked < 0)
+        {
+            return;
+        }
+
+        if (picked == customIndex)
+        {
+            OpenHexEditor(-1);
+            return;
+        }
+
+        if (picked >= savedOffset && rowAction == DropdownMenu.RowAction.Delete)
+        {
+            DeleteSavedColor(picked - savedOffset);
+            return;
+        }
+
+        if (picked >= savedOffset && rowAction == DropdownMenu.RowAction.Edit)
+        {
+            OpenHexEditor(picked - savedOffset);
+            return;
+        }
+
+        configuration.JobsAccentName = picked < savedOffset
+            ? ThemeCatalog.Accents[picked].Name
+            : savedColors[picked - savedOffset].Hex;
+        configuration.Save();
+    }
+
+    private void OpenHexEditor(int savedIndex)
+    {
+        editingSavedColorIndex = savedIndex;
+        var startColor = savedIndex >= 0 &&
+                          HexColor.TryParse(configuration.JobsCustomColors[savedIndex].Hex, out var saved)
+            ? saved
+            : Accent;
+        hexDigits = HexColor.ToDigits(startColor);
+        hexColorName = savedIndex >= 0 ? configuration.JobsCustomColors[savedIndex].Name : string.Empty;
+        lastAppliedHexDigits = string.Empty;
+        hexInputOpenedFrame = ImGui.GetFrameCount();
+        showHexInput = true;
+    }
+
+    private void DeleteSavedColor(int index)
+    {
+        if (index < 0 || index >= configuration.JobsCustomColors.Count)
+        {
+            return;
+        }
+
+        var entry = configuration.JobsCustomColors[index];
+        confirm.Ask(new ConfirmRequest
+        {
+            Message = Loc.T(L.Jobs.DeleteColorConfirm, entry.Name),
+            ConfirmLabel = Loc.T(L.Jobs.DeleteColor),
+            CancelLabel = Loc.T(L.Common.Cancel),
+            Danger = true,
+            Confirm = () =>
+            {
+                configuration.JobsCustomColors.Remove(entry);
+                configuration.Save();
+            },
+        });
+    }
+
+    private void DrawHexInput(float scale)
+    {
+        var width = 220f * scale;
+        var pad = Metrics.Space.Lg * scale;
+        var swatchRadius = 14f * scale;
+        var hexRowHeight = swatchRadius * 2f;
+        var nameRowHeight = 26f * scale;
+        var saveRowHeight = 30f * scale;
+        var rowGap = 10f * scale;
+        var height = pad * 2f + hexRowHeight + rowGap + nameRowHeight + rowGap + saveRowHeight;
+        var top = colorButtonRect.Max.Y + 8f * scale;
+        var min = new Vector2(colorButtonRect.Max.X - width, top);
+        var max = min + new Vector2(width, height);
+        var justOpened = hexInputOpenedFrame == ImGui.GetFrameCount();
+
+        var hexRowTop = min.Y + pad;
+        var nameRowTop = hexRowTop + hexRowHeight + rowGap;
+        var saveRowTop = nameRowTop + nameRowHeight + rowGap;
+
+        // Real (but fully transparent) InputText widgets host the actual keyboard capture: ImGui/Dalamud only
+        // routes keystrokes away from the game while an active widget holds focus, which our own hand-drawn
+        // rectangles never would. The visible card is drawn separately below, on the foreground list, so it
+        // still stays on top of the job cards regardless of these host windows' place in the draw order.
+        using (ImRaii.PushColor(ImGuiCol.FrameBg, default(Vector4))
+                   .Push(ImGuiCol.FrameBgHovered, default(Vector4))
+                   .Push(ImGuiCol.FrameBgActive, default(Vector4))
+                   .Push(ImGuiCol.Text, default(Vector4))
+                   .Push(ImGuiCol.Border, default(Vector4)))
+        {
+            var hexHostMin = new Vector2(min.X + pad + hexRowHeight + 12f * scale, hexRowTop);
+            var hexHostSize = new Vector2(max.X - pad - hexHostMin.X, hexRowHeight);
+            ImGui.SetCursorScreenPos(hexHostMin);
+            using (ImRaii.Child("##jobsHexHost", hexHostSize, false, HostFlags))
+            {
+                if (justOpened)
+                {
+                    ImGui.SetKeyboardFocusHere();
+                }
+
+                ImGui.SetNextItemWidth(-1f);
+                ImGui.InputText("##jobsHexField", ref hexDigits, 6,
+                    ImGuiInputTextFlags.CharsHexadecimal | ImGuiInputTextFlags.CharsUppercase);
+            }
+
+            var nameHostMin = new Vector2(min.X + pad, nameRowTop);
+            var nameHostSize = new Vector2(width - pad * 2f, nameRowHeight);
+            ImGui.SetCursorScreenPos(nameHostMin);
+            using (ImRaii.Child("##jobsColorNameHost", nameHostSize, false, HostFlags))
+            {
+                ImGui.SetNextItemWidth(-1f);
+                ImGui.InputText("##jobsColorNameField", ref hexColorName, 24);
+            }
+        }
+
+        if (hexDigits.Length == 6 && hexDigits != lastAppliedHexDigits)
+        {
+            lastAppliedHexDigits = hexDigits;
+            configuration.JobsAccentName = "#" + hexDigits;
+            configuration.Save();
+        }
+
+        var drawList = ImGui.GetForegroundDrawList();
+        Elevation.Floating(drawList, min, max, 16f * scale, scale, 0.85f);
+        ui.Card(drawList, min, max, 16f * scale, elevated: true);
+
+        var swatchCenter = new Vector2(min.X + pad + swatchRadius, hexRowTop + swatchRadius);
+        var validHex = HexColor.TryParse(hexDigits, out var previewColor);
+        drawList.AddCircleFilled(swatchCenter, swatchRadius,
+            ImGui.GetColorU32(validHex ? previewColor : Palette.WithAlpha(ui.MutedInk, 0.25f)), 24);
+        drawList.AddCircle(swatchCenter, swatchRadius, ImGui.GetColorU32(Palette.WithAlpha(ui.TitleInk, 0.18f)), 24,
+            1.4f * scale);
+
+        var hexTextLeft = swatchCenter.X + swatchRadius + 12f * scale;
+        var hexDisplay = "#" + hexDigits.PadRight(6, '_');
+        Typography.Draw(drawList, new Vector2(hexTextLeft, hexRowTop + hexRowHeight * 0.5f - 8f * scale), hexDisplay,
+            ui.TitleInk, TextStyles.BodyEmphasized);
+
+        var nameDisplay = hexColorName.Length > 0 ? hexColorName : Loc.T(L.Jobs.ColorNamePlaceholder);
+        var nameInk = hexColorName.Length > 0 ? ui.TitleInk : Palette.WithAlpha(ui.MutedInk, 0.7f);
+        Typography.Draw(drawList, new Vector2(min.X + pad, nameRowTop + nameRowHeight * 0.5f - 8f * scale), nameDisplay,
+            nameInk, TextStyles.Body);
+
+        DrawSaveButton(drawList, new Rect(new Vector2(max.X - pad - 74f * scale, saveRowTop),
+            new Vector2(max.X - pad, saveRowTop + saveRowHeight)), validHex, scale);
+
+        if (!justOpened && (ImGui.IsKeyPressed(ImGuiKey.Escape) || ImGui.IsKeyPressed(ImGuiKey.Enter) ||
+                (ImGui.IsMouseClicked(ImGuiMouseButton.Left) && !ImGui.IsMouseHoveringRect(min, max))))
+        {
+            showHexInput = false;
+        }
+    }
+
+    private void DrawSaveButton(ImDrawListPtr drawList, Rect rect, bool enabled, float scale)
+    {
+        var editing = editingSavedColorIndex >= 0 && editingSavedColorIndex < configuration.JobsCustomColors.Count;
+        var hovered = enabled && ImGui.IsMouseHoveringRect(rect.Min, rect.Max);
+        var fillAlpha = !enabled ? 0.08f : hovered ? 0.30f : 0.20f;
+        drawList.AddRectFilled(rect.Min, rect.Max, ImGui.GetColorU32(Palette.WithAlpha(ui.Accent, fillAlpha)),
+            rect.Height * 0.5f);
+        var label = Loc.T(editing ? L.Jobs.UpdateColor : L.Jobs.SaveColor);
+        var labelSize = Typography.Measure(label, TextStyles.SubheadlineEmphasized);
+        var ink = enabled ? ui.Accent : Palette.WithAlpha(ui.MutedInk, 0.5f);
+        Typography.Draw(drawList, rect.Center - labelSize * 0.5f, label, ink, TextStyles.SubheadlineEmphasized);
+        if (!hovered)
+        {
+            return;
+        }
+
+        ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
+        if (!ImGui.IsMouseClicked(ImGuiMouseButton.Left))
+        {
+            return;
+        }
+
+        var name = hexColorName.Trim();
+        if (name.Length == 0)
+        {
+            name = "#" + hexDigits;
+        }
+
+        if (editing)
+        {
+            var entry = configuration.JobsCustomColors[editingSavedColorIndex];
+            entry.Name = name;
+            entry.Hex = "#" + hexDigits;
+        }
+        else
+        {
+            configuration.JobsCustomColors.Add(new JobsCustomColor { Name = name, Hex = "#" + hexDigits });
+        }
+
+        configuration.Save();
+        showHexInput = false;
+    }
+
+    private void DrawHint()
+    {
+        var scale = ImGuiHelpers.GlobalScale;
+        ImGui.Dummy(new Vector2(0f, 24f * scale));
+        var width = ImGui.GetContentRegionAvail().X;
+        var origin = ImGui.GetCursorScreenPos();
+        Typography.DrawWrappedCentered(new Vector2(origin.X + width * 0.5f, origin.Y + 4f * scale),
+            Loc.T(L.Jobs.NoGearsets), ui.MutedInk, TextStyles.Subheadline, width - 40f * scale);
+    }
+
+    private void DrawSectionCard(JobRoleSection section, float scale)
+    {
+        var width = ImGui.GetContentRegionAvail().X;
+        var rowCount = section.Entries.Length;
+        var rowHeight = RowHeight * scale;
+        var origin = ImGui.GetCursorScreenPos();
+        var min = origin;
+        var max = new Vector2(origin.X + width, origin.Y + rowCount * rowHeight);
+        var drawList = ImGui.GetWindowDrawList();
+        ui.Card(drawList, min, max, CardRounding * scale, elevated: true);
+
+        var padding = 16f * scale;
+        var separator = ImGui.GetColorU32(new Vector4(1f, 1f, 1f, 0.06f));
+        for (var index = 0; index < rowCount; index++)
+        {
+            var rowTop = min.Y + index * rowHeight;
+            var rowRect = new Rect(new Vector2(min.X, rowTop), new Vector2(max.X, rowTop + rowHeight));
+            var contentRect = new Rect(new Vector2(min.X + padding, rowTop), new Vector2(max.X - padding, rowTop + rowHeight));
+            DrawJobRow(drawList, rowRect, contentRect, section.Entries[index], scale);
+            if (index > 0)
+            {
+                drawList.AddLine(new Vector2(min.X + padding, rowTop), new Vector2(max.X - padding, rowTop), separator,
+                    Metrics.Stroke.Hairline);
+            }
+        }
+
+        ImGui.SetCursorScreenPos(min);
+        ImGui.Dummy(new Vector2(width, rowCount * rowHeight));
+    }
+
+    private void DrawJobRow(ImDrawListPtr drawList, Rect rowRect, Rect contentRect, JobEntry job, float scale)
+    {
+        var hovered = UiInteract.Hover(rowRect.Min, rowRect.Max);
+        if (hovered)
+        {
+            var alpha = ImGui.IsMouseDown(ImGuiMouseButton.Left) ? 0.14f : 0.07f;
+            drawList.AddRectFilled(rowRect.Min, rowRect.Max, ImGui.GetColorU32(new Vector4(1f, 1f, 1f, alpha)));
+        }
+
+        var iconSize = 42f * scale;
+        var iconMin = new Vector2(contentRect.Min.X, contentRect.Center.Y - iconSize * 0.5f);
+        var iconMax = iconMin + new Vector2(iconSize, iconSize);
+        Squircle.Fill(drawList, iconMin, iconMax, 10f * scale, ImGui.GetColorU32(Palette.WithAlpha(ui.TitleInk, 0.06f)));
+        if (job.IconId != 0)
+        {
+            var texture = textures.GetFromGameIcon(new GameIconLookup(job.IconId)).GetWrapOrEmpty();
+            drawList.AddImageRounded(texture.Handle, iconMin, iconMax, Vector2.Zero, Vector2.One, 0xFFFFFFFFu, 10f * scale);
+        }
+
+        Material.EdgeSquircle(drawList, iconMin, iconMax, 10f * scale, scale, 0.5f);
+
+        var textLeft = iconMax.X + 14f * scale;
+        var textRight = contentRect.Max.X - (job.IsActive ? 78f * scale : 0f);
+        var name = Fit(job.Name, textRight - textLeft, TextStyles.Headline);
+        Typography.Draw(drawList, new Vector2(textLeft, contentRect.Min.Y + 12f * scale), name, ui.TitleInk,
+            TextStyles.Headline);
+        var subtitle = job.ItemLevel >= 0
+            ? Loc.T(L.Jobs.LevelItemLevel, job.Abbreviation, job.Level, job.ItemLevel)
+            : Loc.T(L.Jobs.LevelOnly, job.Abbreviation, job.Level);
+        var fittedSubtitle = Fit(subtitle, textRight - textLeft, TextStyles.Footnote);
+        Typography.Draw(drawList, new Vector2(textLeft, contentRect.Min.Y + 36f * scale), fittedSubtitle, ui.MutedInk,
+            TextStyles.Footnote);
+
+        if (job.IsActive)
+        {
+            DrawActiveBadge(drawList, new Vector2(contentRect.Max.X, contentRect.Center.Y), scale);
+        }
+
+        if (hovered)
+        {
+            ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
+            if (!job.IsActive && ImGui.IsMouseClicked(ImGuiMouseButton.Left) && TryEquip(job))
+            {
+                Rebuild();
+            }
+        }
+    }
+
+    private bool TryEquip(JobEntry job) =>
+        job.Kind == JobEntryKind.Gearset
+            ? GearsetActions.Equip(job.GearsetId)
+            : GearsetActions.EquipTool(gameData, job.ClassJobId);
+
+    private void DrawActiveBadge(ImDrawListPtr drawList, Vector2 rightCenter, float scale)
+    {
+        var text = Loc.T(L.Jobs.Active);
+        var textSize = Typography.Measure(text, TextStyles.Caption2);
+        var padX = 8f * scale;
+        var padY = 4f * scale;
+        var width = textSize.X + padX * 2f;
+        var height = textSize.Y + padY * 2f;
+        var max = new Vector2(rightCenter.X, rightCenter.Y + height * 0.5f);
+        var min = new Vector2(max.X - width, rightCenter.Y - height * 0.5f);
+        Squircle.Fill(drawList, min, max, height * 0.5f, ImGui.GetColorU32(Palette.WithAlpha(ui.Accent, 0.2f)));
+        Typography.Draw(drawList, new Vector2(min.X + padX, rightCenter.Y - textSize.Y * 0.5f), text, ui.Accent,
+            TextStyles.Caption2);
+    }
+
+    private static string Fit(string text, float maxWidth, in TextStyle style)
+    {
+        if (text.Length == 0 || maxWidth <= 0f)
+        {
+            return text;
+        }
+
+        if (Typography.Measure(text, style).X <= maxWidth)
+        {
+            return text;
+        }
+
+        var low = 1;
+        var high = text.Length;
+        var best = "…";
+        while (low <= high)
+        {
+            var mid = (low + high) / 2;
+            var candidate = text.Substring(0, mid) + "…";
+            if (Typography.Measure(candidate, style).X <= maxWidth)
+            {
+                best = candidate;
+                low = mid + 1;
+            }
+            else
+            {
+                high = mid - 1;
+            }
+        }
+
+        return best;
+    }
+
+    public void Dispose()
+    {
+    }
+}

--- a/src/Aetherphone/Configuration.cs
+++ b/src/Aetherphone/Configuration.cs
@@ -8,6 +8,7 @@ using Aetherphone.Core.ControlCenter;
 using Aetherphone.Core.Dailies;
 using Aetherphone.Core.Games;
 using Aetherphone.Core.Home;
+using Aetherphone.Core.Jobs;
 using Aetherphone.Core.Market;
 using Aetherphone.Core.Notifications;
 using Aetherphone.Core.Songs;
@@ -54,6 +55,8 @@ internal sealed class Configuration : IPluginConfiguration
     public string Language { get; set; } = string.Empty;
     public ThemeMode ThemeMode { get; set; } = ThemeMode.Dark;
     public string AccentName { get; set; } = "Violet";
+    public string JobsAccentName { get; set; } = "Blue";
+    public List<JobsCustomColor> JobsCustomColors { get; set; } = new();
     public string LightWallpaperId { get; set; } = "DuskLight";
     public string DarkWallpaperId { get; set; } = "DuskDark";
     public List<CustomWallpaper> CustomWallpapers { get; set; } = new();

--- a/src/Aetherphone/Core/Apps/AppAccents.cs
+++ b/src/Aetherphone/Core/Apps/AppAccents.cs
@@ -28,6 +28,7 @@ internal static class AppAccents
         ["music"] = new(0.13f, 0.75f, 0.36f, 1f),
         ["wallet"] = new(0.26f, 0.78f, 0.52f, 1f),
         ["inventory"] = new(0.42f, 0.58f, 0.86f, 1f),
+        ["jobs"] = new(0.36f, 0.66f, 0.94f, 1f),
         ["clock"] = new(1.00f, 0.58f, 0.00f, 1f),
         ["timers"] = new(1.00f, 0.62f, 0.04f, 1f),
         ["calendar"] = new(1.00f, 0.231f, 0.188f, 1f),

--- a/src/Aetherphone/Core/Apps/AppRegistry.cs
+++ b/src/Aetherphone/Core/Apps/AppRegistry.cs
@@ -9,6 +9,7 @@ using Aetherphone.Apps.Dailies;
 using Aetherphone.Apps.Fishing;
 using Aetherphone.Apps.Games;
 using Aetherphone.Apps.Inventory;
+using Aetherphone.Apps.Jobs;
 using Aetherphone.Apps.Calculator;
 using Aetherphone.Apps.Maps;
 using Aetherphone.Apps.Market;
@@ -66,6 +67,7 @@ internal static class AppRegistry
         apps.Add(new MarketApp(services.Market, services.MarketIndex, services.MarketAlerts, services.MarketLauncher, services.GameData, services.Textures, services.Configuration));
         apps.Add(new WalletApp(services.GameData, services.Textures));
         apps.Add(new InventoryApp(services.InventoryCapture, services.GameData, services.Textures));
+        apps.Add(new JobsApp(services.GameData, services.Textures, services.Configuration, services.Confirm));
         apps.Add(new MusicApp(services.Radio, services.SongSearch, services.Playback, services.SongHistory, services.Playlists, services.Media, services.Http, services.Textures, new FeatureFlags(services.Http, services.AethernetSession), services.Confirm));
         apps.Add(new ClockApp(services.Configuration, services.Confirm));
         apps.Add(new NotesApp(services.Configuration, services.Confirm));

--- a/src/Aetherphone/Core/Game/GameData.cs
+++ b/src/Aetherphone/Core/Game/GameData.cs
@@ -78,6 +78,38 @@ internal sealed class GameData
         return string.Empty;
     }
 
+    public bool TryGetClassJobDivision(uint rowId, out byte jobType, out byte uiPriority, out uint classJobCategoryId)
+    {
+        jobType = 0;
+        uiPriority = 0;
+        classJobCategoryId = 0;
+        if (rowId != 0 && data.GetExcelSheet<ClassJob>().TryGetRow(rowId, out var job))
+        {
+            jobType = job.JobType;
+            uiPriority = job.UIPriority;
+            classJobCategoryId = job.ClassJobCategory.RowId;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>Enumerates every ClassJob row belonging to the given ClassJobCategory (e.g. Disciple of the Hand/Land).</summary>
+    public IEnumerable<uint> ClassJobIdsInCategory(uint classJobCategoryId)
+    {
+        foreach (var job in data.GetExcelSheet<ClassJob>())
+        {
+            if (job.RowId != 0 && job.ClassJobCategory.RowId == classJobCategoryId)
+            {
+                yield return job.RowId;
+            }
+        }
+    }
+
+    public bool ItemUsableByClassJob(uint itemId, uint classJobId) =>
+        itemId != 0 && classJobId != 0 && data.GetExcelSheet<Item>().TryGetRow(itemId, out var item) &&
+        item.ClassJobUse.RowId == classJobId;
+
     public int JobExpArrayIndex(uint rowId)
     {
         if (rowId != 0 && data.GetExcelSheet<ClassJob>().TryGetRow(rowId, out var job))

--- a/src/Aetherphone/Core/Home/HomeLayoutService.cs
+++ b/src/Aetherphone/Core/Home/HomeLayoutService.cs
@@ -24,7 +24,7 @@ internal sealed class HomeLayoutService
         "skywatcher", "collections", "inventory", "fishing",
         "clock", "notes", "calculator", "timers",
         "wallet", "dailies", "calendar", "news",
-        "character", "notifications",
+        "character", "notifications", "jobs",
     };
 
     private static readonly string[] DefaultTrailingApps = { "dev" };

--- a/src/Aetherphone/Core/Jobs/GearsetActions.cs
+++ b/src/Aetherphone/Core/Jobs/GearsetActions.cs
@@ -1,0 +1,51 @@
+using Aetherphone.Core.Game;
+using FFXIVClientStructs.FFXIV.Client.Game;
+using FFXIVClientStructs.FFXIV.Client.UI.Agent;
+using FFXIVClientStructs.FFXIV.Client.UI.Misc;
+
+namespace Aetherphone.Core.Jobs;
+
+internal static unsafe class GearsetActions
+{
+    public static bool Equip(int gearsetId)
+    {
+        var module = RaptureGearsetModule.Instance();
+        if (module is null || !module->IsValidGearset(gearsetId))
+        {
+            return false;
+        }
+
+        return module->EquipGearset(gearsetId) == 0;
+    }
+
+    /// <summary>Hand/Land jobs have no gearset, so switching jobs means equipping that job's tool straight from the Armoury Chest.</summary>
+    public static bool EquipTool(GameData gameData, uint classJobId)
+    {
+        var manager = InventoryManager.Instance();
+        var armory = manager is null ? null : manager->GetInventoryContainer(InventoryType.ArmoryMainHand);
+        if (armory is null || !armory->IsLoaded)
+        {
+            return false;
+        }
+
+        var agent = AgentInventoryContext.Instance();
+        if (agent is null)
+        {
+            return false;
+        }
+
+        for (var index = 0; index < armory->Size; index++)
+        {
+            var item = armory->GetInventorySlot(index);
+            if (item is null || item->ItemId == 0 || !gameData.ItemUsableByClassJob(item->ItemId, classJobId))
+            {
+                continue;
+            }
+
+            agent->UseItem(item->ItemId, InventoryType.ArmoryMainHand, (uint)index);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Aetherphone/Core/Jobs/JobsCustomColor.cs
+++ b/src/Aetherphone/Core/Jobs/JobsCustomColor.cs
@@ -1,0 +1,8 @@
+namespace Aetherphone.Core.Jobs;
+
+[Serializable]
+internal sealed class JobsCustomColor
+{
+    public string Name { get; set; } = string.Empty;
+    public string Hex { get; set; } = string.Empty;
+}

--- a/src/Aetherphone/Core/Jobs/JobsModel.cs
+++ b/src/Aetherphone/Core/Jobs/JobsModel.cs
@@ -1,0 +1,63 @@
+using Aetherphone.Core.Localization;
+
+namespace Aetherphone.Core.Jobs;
+
+internal enum JobRole
+{
+    Tank,
+    Healer,
+    Melee,
+    PhysicalRanged,
+    MagicalRanged,
+    Hand,
+    Land,
+}
+
+internal enum JobEntryKind
+{
+    Gearset,
+    Tool,
+}
+
+internal sealed class JobEntry
+{
+    public JobEntry(JobEntryKind kind, int gearsetId, uint classJobId, string abbreviation, string name, int level,
+        int itemLevel, uint iconId, bool isActive)
+    {
+        Kind = kind;
+        GearsetId = gearsetId;
+        ClassJobId = classJobId;
+        Abbreviation = abbreviation;
+        Name = name;
+        Level = level;
+        ItemLevel = itemLevel;
+        IconId = iconId;
+        IsActive = isActive;
+    }
+
+    public JobEntryKind Kind { get; }
+    public int GearsetId { get; }
+    public uint ClassJobId { get; }
+    public string Abbreviation { get; }
+    public string Name { get; }
+    public int Level { get; }
+
+    /// <summary>-1 when the item level is unknown (a Hand/Land job that isn't currently active).</summary>
+    public int ItemLevel { get; }
+    public uint IconId { get; }
+    public bool IsActive { get; }
+}
+
+internal sealed class JobRoleSection
+{
+    public JobRoleSection(JobRole role, LocString title, JobEntry[] entries)
+    {
+        Role = role;
+        Title = title;
+        Entries = entries;
+    }
+
+    public JobRole Role { get; }
+    public LocString Title { get; }
+    public JobEntry[] Entries { get; }
+}

--- a/src/Aetherphone/Core/Jobs/JobsReader.cs
+++ b/src/Aetherphone/Core/Jobs/JobsReader.cs
@@ -1,0 +1,190 @@
+using Aetherphone.Core.Game;
+using Aetherphone.Core.Localization;
+using FFXIVClientStructs.FFXIV.Client.Game;
+using FFXIVClientStructs.FFXIV.Client.Game.UI;
+using FFXIVClientStructs.FFXIV.Client.UI.Misc;
+
+namespace Aetherphone.Core.Jobs;
+
+internal static unsafe class JobsReader
+{
+    // ClassJobCategory sheet rows for the two crafting/gathering divisions in the Character window.
+    private const uint HandCategoryId = 33; // "Disciple of the Hand"
+    private const uint LandCategoryId = 32; // "Disciple of the Land"
+    private const int RoleCount = 7;
+
+    public static JobRoleSection[] Build(GameData gameData)
+    {
+        var playerState = PlayerState.Instance();
+        if (playerState is null)
+        {
+            return Array.Empty<JobRoleSection>();
+        }
+
+        var buckets = new List<(JobEntry Entry, byte UiPriority)>[RoleCount];
+        for (var index = 0; index < buckets.Length; index++)
+        {
+            buckets[index] = new List<(JobEntry, byte)>();
+        }
+
+        var levels = playerState->ClassJobLevels;
+        BuildGearsetEntries(gameData, levels, buckets);
+        BuildToolEntries(gameData, levels, buckets, HandCategoryId, (int)JobRole.Hand);
+        BuildToolEntries(gameData, levels, buckets, LandCategoryId, (int)JobRole.Land);
+
+        var sections = new List<JobRoleSection>(RoleCount);
+        for (var bucketIndex = 0; bucketIndex < buckets.Length; bucketIndex++)
+        {
+            var bucket = buckets[bucketIndex];
+            if (bucket.Count == 0)
+            {
+                continue;
+            }
+
+            bucket.Sort((a, b) => a.UiPriority != b.UiPriority
+                ? a.UiPriority.CompareTo(b.UiPriority)
+                : string.CompareOrdinal(a.Entry.Abbreviation, b.Entry.Abbreviation));
+            var role = (JobRole)bucketIndex;
+            var jobEntries = new JobEntry[bucket.Count];
+            for (var entryIndex = 0; entryIndex < bucket.Count; entryIndex++)
+            {
+                jobEntries[entryIndex] = bucket[entryIndex].Entry;
+            }
+
+            sections.Add(new JobRoleSection(role, TitleFor(role), jobEntries));
+        }
+
+        return sections.ToArray();
+    }
+
+    private static void BuildGearsetEntries(GameData gameData, Span<short> levels,
+        List<(JobEntry Entry, byte UiPriority)>[] buckets)
+    {
+        var module = RaptureGearsetModule.Instance();
+        if (module is null)
+        {
+            return;
+        }
+
+        var entries = module->Entries;
+        for (var index = 0; index < entries.Length; index++)
+        {
+            var entry = entries[index];
+            if ((entry.Flags & RaptureGearsetModule.GearsetFlag.Exists) == 0)
+            {
+                continue;
+            }
+
+            var classJobId = (uint)entry.ClassJob;
+            if (!gameData.TryGetClassJobDivision(classJobId, out var jobType, out var uiPriority, out _))
+            {
+                continue;
+            }
+
+            var bucketIndex = CombatBucketFor(jobType);
+            if (bucketIndex < 0)
+            {
+                continue;
+            }
+
+            var level = LevelFor(gameData, levels, classJobId);
+            var iconId = module->GetClassJobIconForGearset(entry.Id);
+            var isActive = module->CurrentGearsetIndex == entry.Id;
+            var jobEntry = new JobEntry(JobEntryKind.Gearset, entry.Id, classJobId, gameData.JobAbbreviation(classJobId),
+                gameData.JobName(classJobId), level, entry.ItemLevel, iconId > 0 ? (uint)iconId : 0u, isActive);
+            buckets[bucketIndex].Add((jobEntry, uiPriority));
+        }
+    }
+
+    private static void BuildToolEntries(GameData gameData, Span<short> levels,
+        List<(JobEntry Entry, byte UiPriority)>[] buckets, uint classJobCategoryId, int bucketIndex)
+    {
+        var currentJobId = gameData.LocalPlayer?.ClassJob.RowId ?? 0u;
+        foreach (var classJobId in gameData.ClassJobIdsInCategory(classJobCategoryId))
+        {
+            if (!gameData.TryGetClassJobDivision(classJobId, out _, out var uiPriority, out _))
+            {
+                continue;
+            }
+
+            var level = LevelFor(gameData, levels, classJobId);
+            var isActive = classJobId == currentJobId;
+            var itemLevel = isActive ? CurrentMainHandItemLevel(gameData) : -1;
+            var iconId = ToolIconId(gameData, classJobId);
+            var jobEntry = new JobEntry(JobEntryKind.Tool, -1, classJobId, gameData.JobAbbreviation(classJobId),
+                gameData.JobName(classJobId), level, itemLevel, iconId, isActive);
+            buckets[bucketIndex].Add((jobEntry, uiPriority));
+        }
+    }
+
+    private static int LevelFor(GameData gameData, Span<short> levels, uint classJobId)
+    {
+        var expArrayIndex = gameData.JobExpArrayIndex(classJobId);
+        return expArrayIndex >= 0 && expArrayIndex < levels.Length ? levels[expArrayIndex] : 0;
+    }
+
+    private static int CurrentMainHandItemLevel(GameData gameData)
+    {
+        var manager = InventoryManager.Instance();
+        var equipped = manager is null ? null : manager->GetInventoryContainer(InventoryType.EquippedItems);
+        if (equipped is null || !equipped->IsLoaded)
+        {
+            return -1;
+        }
+
+        var mainHand = equipped->GetInventorySlot((int)RaptureGearsetModule.GearsetItemIndex.MainHand);
+        if (mainHand is null || mainHand->ItemId == 0)
+        {
+            return -1;
+        }
+
+        return gameData.TryGetItem(mainHand->ItemId, out _, out _, out var itemLevel) ? itemLevel : -1;
+    }
+
+    private static uint ToolIconId(GameData gameData, uint classJobId)
+    {
+        var manager = InventoryManager.Instance();
+        var armory = manager is null ? null : manager->GetInventoryContainer(InventoryType.ArmoryMainHand);
+        if (armory is null || !armory->IsLoaded)
+        {
+            return 0;
+        }
+
+        for (var index = 0; index < armory->Size; index++)
+        {
+            var item = armory->GetInventorySlot(index);
+            if (item is null || item->ItemId == 0 || !gameData.ItemUsableByClassJob(item->ItemId, classJobId))
+            {
+                continue;
+            }
+
+            return gameData.TryGetItem(item->ItemId, out _, out var iconId, out _) ? iconId : 0u;
+        }
+
+        return 0;
+    }
+
+    private static int CombatBucketFor(byte jobType) =>
+        jobType switch
+        {
+            1 => (int)JobRole.Tank,
+            2 or 6 => (int)JobRole.Healer,
+            3 => (int)JobRole.Melee,
+            4 => (int)JobRole.PhysicalRanged,
+            5 => (int)JobRole.MagicalRanged,
+            _ => -1,
+        };
+
+    private static LocString TitleFor(JobRole role) =>
+        role switch
+        {
+            JobRole.Tank => L.Jobs.SectionTank,
+            JobRole.Healer => L.Jobs.SectionHealer,
+            JobRole.Melee => L.Jobs.SectionMelee,
+            JobRole.PhysicalRanged => L.Jobs.SectionPhysicalRanged,
+            JobRole.MagicalRanged => L.Jobs.SectionMagicalRanged,
+            JobRole.Hand => L.Jobs.SectionHand,
+            JobRole.Land => L.Jobs.SectionLand,
+            _ => L.Jobs.SectionTank,
+        };
+}

--- a/src/Aetherphone/Core/Localization/L.cs
+++ b/src/Aetherphone/Core/Localization/L.cs
@@ -158,6 +158,7 @@ internal static class L
         public static readonly LocString Calculator = new("app.calculator", "Calculator");
         public static readonly LocString Linkpearl = new("app.linkpearl", "Linkpearl");
         public static readonly LocString Message = new("app.message", "Message");
+        public static readonly LocString Jobs = new("app.jobs", "Jobs");
     }
 
     internal static class DirectMessages
@@ -1956,6 +1957,29 @@ internal static class L
         public static readonly LocString SectionPvp = new("wallet.sectionPvp", "PvP");
         public static readonly LocString SectionCrafting = new("wallet.sectionCrafting", "Crafting & Gathering");
         public static readonly LocString SectionOther = new("wallet.sectionOther", "Other");
+    }
+
+    internal static class Jobs
+    {
+        public static readonly LocString LogInToView = new("jobs.logInToView", "Log in to view your jobs");
+        public static readonly LocString NoGearsets = new("jobs.noGearsets", "Create a gearset for a job in-game to see it here.");
+        public static readonly LocString SectionTank = new("jobs.sectionTank", "Tank");
+        public static readonly LocString SectionHealer = new("jobs.sectionHealer", "Healer");
+        public static readonly LocString SectionMelee = new("jobs.sectionMelee", "Melee DPS");
+        public static readonly LocString SectionPhysicalRanged = new("jobs.sectionPhysicalRanged", "Physical Ranged DPS");
+        public static readonly LocString SectionMagicalRanged = new("jobs.sectionMagicalRanged", "Magical Ranged DPS");
+        public static readonly LocString SectionHand = new("jobs.sectionHand", "Disciples of the Hand");
+        public static readonly LocString SectionLand = new("jobs.sectionLand", "Disciples of the Land");
+        public static readonly LocString LevelItemLevel = new("jobs.levelItemLevel", "{0} · Lv{1} · iLv{2}");
+        public static readonly LocString LevelOnly = new("jobs.levelOnly", "{0} · Lv{1}");
+        public static readonly LocString Active = new("jobs.active", "ACTIVE");
+        public static readonly LocString BackgroundColor = new("jobs.backgroundColor", "Background color");
+        public static readonly LocString CustomColor = new("jobs.customColor", "Custom color…");
+        public static readonly LocString ColorNamePlaceholder = new("jobs.colorNamePlaceholder", "Name this color");
+        public static readonly LocString SaveColor = new("jobs.saveColor", "Save");
+        public static readonly LocString UpdateColor = new("jobs.updateColor", "Update");
+        public static readonly LocString DeleteColor = new("jobs.deleteColor", "Delete");
+        public static readonly LocString DeleteColorConfirm = new("jobs.deleteColorConfirm", "Delete \"{0}\"? This can't be undone.");
     }
 
     internal static class Inventory

--- a/src/Aetherphone/Core/Theme/HexColor.cs
+++ b/src/Aetherphone/Core/Theme/HexColor.cs
@@ -1,0 +1,29 @@
+using System.Globalization;
+
+namespace Aetherphone.Core.Theme;
+
+internal static class HexColor
+{
+    public static bool TryParse(string text, out Vector4 color)
+    {
+        color = default;
+        var trimmed = text.Trim().TrimStart('#');
+        if (trimmed.Length != 6 ||
+            !uint.TryParse(trimmed, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var value))
+        {
+            return false;
+        }
+
+        color = new Vector4(((value >> 16) & 0xFF) / 255f, ((value >> 8) & 0xFF) / 255f, (value & 0xFF) / 255f, 1f);
+        return true;
+    }
+
+    /// <summary>Formats as 6 hex digits without a leading '#'.</summary>
+    public static string ToDigits(Vector4 color)
+    {
+        var r = (int)Math.Clamp(MathF.Round(color.X * 255f), 0f, 255f);
+        var g = (int)Math.Clamp(MathF.Round(color.Y * 255f), 0f, 255f);
+        var b = (int)Math.Clamp(MathF.Round(color.Z * 255f), 0f, 255f);
+        return $"{r:X2}{g:X2}{b:X2}";
+    }
+}

--- a/src/Aetherphone/Windows/Components/AppPalettes.cs
+++ b/src/Aetherphone/Windows/Components/AppPalettes.cs
@@ -352,6 +352,25 @@ internal static class AppPalettes
         HoverTint = DefaultHover,
     };
 
+    /// <summary>The Jobs app lets the user pick its accent, so its palette is derived rather than fixed.</summary>
+    public static AppPalette JobsFor(Vector4 accent) => new()
+    {
+        Accent = accent,
+        TitleInk = new(0.96f, 0.98f, 1f, 1f),
+        BodyInk = new(0.88f, 0.92f, 0.99f, 0.96f),
+        MutedInk = new(0.67f, 0.75f, 0.87f, 0.86f),
+        HeaderInk = Palette.Lighten(accent, 0.35f),
+        HeadingInk = new(0.95f, 0.98f, 1f, 1f),
+        BackdropTop = Palette.Darken(accent, 0.90f),
+        BackdropBottom = Palette.Darken(accent, 0.965f),
+        BloomTop = Palette.WithAlpha(accent, 0.22f),
+        BloomBottom = Palette.WithAlpha(Palette.Darken(accent, 0.45f), 0f),
+        CardFill = new(1f, 1f, 1f, 0.05f),
+        CardStroke = new(1f, 1f, 1f, 0.07f),
+        FieldSurface = GlassField,
+        HoverTint = DefaultHover,
+    };
+
     public static readonly AppPalette Photos = new()
     {
         Accent = AppAccents.For("photos"),

--- a/src/Aetherphone/Windows/Components/DropdownMenu.cs
+++ b/src/Aetherphone/Windows/Components/DropdownMenu.cs
@@ -2,17 +2,28 @@ using Aetherphone.Core;
 using Aetherphone.Core.Animation;
 using Aetherphone.Core.Theme;
 using Dalamud.Bindings.ImGui;
+using Dalamud.Interface;
 using Dalamud.Interface.Utility;
 
 namespace Aetherphone.Windows.Components;
 
 internal sealed class DropdownMenu
 {
-    public readonly record struct Item(string Label, string Glyph = "", bool Danger = false, bool Selected = false);
+    public readonly record struct Item(string Label, string Glyph = "", bool Danger = false, bool Selected = false,
+        bool CanEdit = false, bool CanDelete = false);
+
+    public enum RowAction
+    {
+        Select,
+        Edit,
+        Delete,
+    }
 
     private const float RevealSeconds = 0.14f;
     private const float RowHeight = 36f;
     private const float MinWidth = 168f;
+    private const float ActionSlotWidth = 24f;
+    private const float ActionIconRadius = 11f;
     private string ownerId = string.Empty;
     private bool open;
     private Rect anchor;
@@ -52,8 +63,11 @@ internal sealed class DropdownMenu
         }
     }
 
-    public int Draw(Rect screen, PhoneTheme theme, ReadOnlySpan<Item> items)
+    public int Draw(Rect screen, PhoneTheme theme, ReadOnlySpan<Item> items) => Draw(screen, theme, items, out _);
+
+    public int Draw(Rect screen, PhoneTheme theme, ReadOnlySpan<Item> items, out RowAction action)
     {
+        action = RowAction.Select;
         if (!open || items.Length == 0)
         {
             return -1;
@@ -68,14 +82,17 @@ internal sealed class DropdownMenu
         var rowHeight = RowHeight * scale;
         var glyphReserve = 26f * scale;
         var checkReserve = 22f * scale;
+        var actionSlot = ActionSlotWidth * scale;
         var width = MinWidth * scale;
         var anyGlyph = false;
         var anySelected = false;
+        var anyEdit = false;
         for (var index = 0; index < items.Length; index++)
         {
             var textWidth = Typography.Measure(items[index].Label, 0.9f, FontWeight.Medium).X;
             anyGlyph |= items[index].Glyph.Length > 0;
             anySelected |= items[index].Selected;
+            anyEdit |= items[index].CanEdit;
             width = MathF.Max(width, textWidth + padX * 2f);
         }
 
@@ -87,6 +104,11 @@ internal sealed class DropdownMenu
         if (anySelected)
         {
             width += checkReserve;
+        }
+
+        if (anyEdit)
+        {
+            width += actionSlot;
         }
 
         var height = items.Length * rowHeight + padY * 2f;
@@ -112,21 +134,47 @@ internal sealed class DropdownMenu
             ImGui.GetColorU32(Palette.WithAlpha(theme.GroupedCard, MathF.Min(0.98f, theme.GroupedCard.W + 0.4f) * alpha)));
         Material.EdgeSquircle(drawList, min, max, 14f * scale, scale);
         var clicked = -1;
+        var clickedAction = RowAction.Select;
         for (var index = 0; index < items.Length; index++)
         {
             var item = items[index];
             var rowMin = new Vector2(min.X + padY, min.Y + padY * revealScale + index * rowHeight * revealScale);
             var rowMax = new Vector2(max.X - padY, rowMin.Y + rowHeight * revealScale);
             var centerY = (rowMin.Y + rowMax.Y) * 0.5f;
-            var hovered = ImGui.IsMouseHoveringRect(rowMin, rowMax);
-            if (hovered)
+
+            // Reserved slots are laid out right-to-left so every row's icons line up regardless of that
+            // row's own capabilities: checkmark, then edit. Delete has no icon of its own — it's a right-click
+            // anywhere on the row (confirmed by the caller before anything is actually removed).
+            var cursorRight = rowMax.X - 10f * scale;
+            if (anySelected)
+            {
+                cursorRight -= checkReserve;
+            }
+
+            Rect? editRect = null;
+            if (anyEdit)
+            {
+                var center = new Vector2(cursorRight - actionSlot * 0.5f, centerY);
+                editRect = new Rect(center - new Vector2(ActionIconRadius * scale), center + new Vector2(ActionIconRadius * scale));
+                cursorRight -= actionSlot;
+            }
+
+            var rowHovered = ImGui.IsMouseHoveringRect(rowMin, rowMax);
+            var editHovered = item.CanEdit && editRect is { } er && ImGui.IsMouseHoveringRect(er.Min, er.Max);
+            if (rowHovered)
             {
                 Squircle.Fill(drawList, rowMin, rowMax, 9f * scale,
                     ImGui.GetColorU32(Palette.WithAlpha(theme.TextStrong, 0.07f * alpha)));
                 ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
-                if (ImGui.IsMouseClicked(ImGuiMouseButton.Left))
+                if (item.CanDelete && ImGui.IsMouseClicked(ImGuiMouseButton.Right))
                 {
                     clicked = index;
+                    clickedAction = RowAction.Delete;
+                }
+                else if (ImGui.IsMouseClicked(ImGuiMouseButton.Left))
+                {
+                    clicked = index;
+                    clickedAction = editHovered ? RowAction.Edit : RowAction.Select;
                 }
             }
 
@@ -150,10 +198,17 @@ internal sealed class DropdownMenu
             {
                 DrawCheck(drawList, new Vector2(rowMax.X - 16f * scale, centerY), theme.Accent, alpha, scale);
             }
+
+            if (item.CanEdit && editRect is { } editIconRect)
+            {
+                var tint = editHovered ? theme.Accent : Palette.WithAlpha(theme.TextMuted, theme.TextMuted.W * alpha);
+                AppSkin.Icon(drawList, editIconRect.Center, FontAwesomeIcon.Pen.ToIconString(), tint, 0.7f);
+            }
         }
 
         if (clicked >= 0)
         {
+            action = clickedAction;
             Close();
             return clicked;
         }


### PR DESCRIPTION
## Summary
- New **Jobs** phone app, grouped by role — Tank/Healer/Melee/Physical Ranged/Magical Ranged (Disciples of War/Magic), plus Disciples of the Hand and Disciples of the Land. Groups are derived from the `ClassJob` sheet's `JobType`/`ClassJobCategory` fields rather than hardcoded job ID lists, so new jobs slot in automatically.
- Tapping a combat job's row swaps to its gearset (`RaptureGearsetModule.EquipGearset`); tapping a Hand/Land job equips its tool straight from the Armoury Chest (`AgentInventoryContext.UseItem`), since those classes have no gearset concept in-game.
- The app's background color is user-customizable: pick from the shared accent swatches (matching Settings → Appearance), or enter a custom hex code, with saved custom colors that can be renamed and deleted (right-click, with a confirm prompt).
- Extends the shared `DropdownMenu` component with optional per-row edit/delete actions, in a backward-compatible way (existing Aethergram menus unaffected).

## Test plan
- [x] Build via `dotnet build -c Release` with `DALAMUD_HOME` pointed at a Dalamud install (done in dev; `dotnet test` passes locally, 42/42).
- [x] In-game: open the Jobs app, confirm gearsets are grouped correctly and tapping a row swaps jobs.
- [x] In-game: confirm Hand/Land rows equip the correct tool from the Armoury Chest.
- [x] In-game: open the background color picker, pick a swatch, enter a custom hex, save/rename/delete a custom color.