### PR TITLE
Add App Library screen and folder tinting

### DIFF
--- a/src/Aetherphone.Tests/HomeLayoutServiceLibraryTests.cs
+++ b/src/Aetherphone.Tests/HomeLayoutServiceLibraryTests.cs
@@ -1,0 +1,181 @@
+using Aetherphone.Core.Apps;
+using Aetherphone.Core.Home;
+using Aetherphone.Core.Shell;
+using Xunit;
+
+namespace Aetherphone.Tests;
+
+public sealed class HomeLayoutServiceLibraryTests
+{
+    [Fact]
+    public void FreshInstall_AlwaysHasAReachableLibraryPage()
+    {
+        var apps = MakeApps();
+        var widgets = new WidgetRegistry(Array.Empty<IHomeWidget>(), apps);
+        var configuration = new Configuration();
+
+        var layout = new HomeLayoutService(apps, widgets, configuration);
+
+        Assert.True(layout.TotalPageCount > layout.HomePageCount,
+            $"Expected TotalPageCount ({layout.TotalPageCount}) > HomePageCount ({layout.HomePageCount})");
+    }
+
+    [Fact]
+    public void ExistingFullyPlacedSave_StillGetsAReachableLibraryPage()
+    {
+        var apps = MakeApps();
+        var widgets = new WidgetRegistry(Array.Empty<IHomeWidget>(), apps);
+        var configuration = new Configuration
+        {
+            Home = new HomeLayout
+            {
+                Dock = new List<string> { "a" },
+                Pages = new List<HomePage>
+                {
+                    new()
+                    {
+                        Items = new List<HomeItem>
+                        {
+                            new() { Kind = "app", AppId = "b" },
+                            new() { Kind = "app", AppId = "c" },
+                        },
+                    },
+                },
+                LibraryPages = new List<HomePage>(),
+            },
+        };
+
+        var layout = new HomeLayoutService(apps, widgets, configuration);
+
+        Assert.Equal(1, layout.HomePageCount);
+        Assert.True(layout.TotalPageCount > layout.HomePageCount,
+            $"Expected TotalPageCount ({layout.TotalPageCount}) > HomePageCount ({layout.HomePageCount}) for a legacy fully-placed save");
+    }
+
+    [Fact]
+    public void UnplacedApp_LandsInLibraryNotHome()
+    {
+        var apps = MakeApps();
+        var widgets = new WidgetRegistry(Array.Empty<IHomeWidget>(), apps);
+        var configuration = new Configuration
+        {
+            Home = new HomeLayout
+            {
+                Dock = new List<string> { "a" },
+                Pages = new List<HomePage>
+                {
+                    new() { Items = new List<HomeItem> { new() { Kind = "app", AppId = "b" } } },
+                },
+                LibraryPages = new List<HomePage>(),
+            },
+        };
+
+        var layout = new HomeLayoutService(apps, widgets, configuration);
+
+        var foundOnHome = false;
+        for (var page = 0; page < layout.HomePageCount; page++)
+        {
+            var tiles = layout.Page(page);
+            for (var index = 0; index < tiles.Count; index++)
+            {
+                if (tiles[index].App?.Id == "c")
+                {
+                    foundOnHome = true;
+                }
+            }
+        }
+
+        var foundInLibrary = false;
+        for (var page = layout.HomePageCount; page < layout.TotalPageCount; page++)
+        {
+            var tiles = layout.Page(page);
+            for (var index = 0; index < tiles.Count; index++)
+            {
+                if (tiles[index].App?.Id == "c")
+                {
+                    foundInLibrary = true;
+                }
+            }
+        }
+
+        Assert.False(foundOnHome, "App 'c' was never placed anywhere and should not be force-appended to Home");
+        Assert.True(foundInLibrary, "App 'c' should have been auto-appended to the Library section");
+    }
+
+    [Fact]
+    public void ExistingSaveWithTwoFullHomePages_ArrowStillReachesLibrary()
+    {
+        // Mirrors a real account: two home pages, every app already placed, nothing unplaced.
+        var apps = new List<IPhoneApp>
+        {
+            new FakeApp("a"), new FakeApp("b"), new FakeApp("c"), new FakeApp("d"),
+            new FakeApp("e"), new FakeApp("f"), new FakeApp("g"), new FakeApp("h"),
+        };
+        var widgets = new WidgetRegistry(Array.Empty<IHomeWidget>(), apps);
+        var configuration = new Configuration
+        {
+            Home = new HomeLayout
+            {
+                Dock = new List<string>(),
+                Pages = new List<HomePage>
+                {
+                    new()
+                    {
+                        Items = new List<HomeItem>
+                        {
+                            new() { Kind = "app", AppId = "a" },
+                            new() { Kind = "app", AppId = "b" },
+                            new() { Kind = "app", AppId = "c" },
+                            new() { Kind = "app", AppId = "d" },
+                        },
+                    },
+                    new()
+                    {
+                        Items = new List<HomeItem>
+                        {
+                            new() { Kind = "app", AppId = "e" },
+                            new() { Kind = "app", AppId = "f" },
+                            new() { Kind = "app", AppId = "g" },
+                            new() { Kind = "app", AppId = "h" },
+                        },
+                    },
+                },
+                LibraryPages = new List<HomePage>(),
+            },
+        };
+
+        var layout = new HomeLayoutService(apps, widgets, configuration);
+
+        Assert.Equal(2, layout.HomePageCount);
+        Assert.True(layout.TotalPageCount > layout.HomePageCount,
+            $"Expected a reachable Library page after the last of {layout.HomePageCount} home pages, " +
+            $"but TotalPageCount was {layout.TotalPageCount}");
+
+        // Simulate the page-arrow gate: on the last home page, target = HomePageCount must still be < TotalPageCount.
+        var onLastHomePage = layout.HomePageCount - 1;
+        var arrowTarget = onLastHomePage + 1;
+        Assert.True(arrowTarget <= layout.TotalPageCount - 1,
+            "The right-arrow on the last home page would not render — TotalPageCount didn't grow past HomePageCount");
+    }
+
+    private static List<IPhoneApp> MakeApps() =>
+        new()
+        {
+            new FakeApp("a"),
+            new FakeApp("b"),
+            new FakeApp("c"),
+        };
+
+    private sealed class FakeApp : IPhoneApp
+    {
+        public FakeApp(string id) => Id = id;
+        public string Id { get; }
+        public string DisplayName => Id;
+        public string Glyph => string.Empty;
+        public int BadgeCount => 0;
+        public void OnOpened() { }
+        public void OnClosed() { }
+        public void Draw(in PhoneContext context) { }
+        public void Dispose() { }
+    }
+}

--- a/src/Aetherphone.Tests/HomeLayoutServiceLibraryTests.cs
+++ b/src/Aetherphone.Tests/HomeLayoutServiceLibraryTests.cs
@@ -1,6 +1,5 @@
 using Aetherphone.Core.Apps;
 using Aetherphone.Core.Home;
-using Aetherphone.Core.Shell;
 using Xunit;
 
 namespace Aetherphone.Tests;
@@ -12,7 +11,7 @@ public sealed class HomeLayoutServiceLibraryTests
     {
         var apps = MakeApps();
         var widgets = new WidgetRegistry(Array.Empty<IHomeWidget>(), apps);
-        var configuration = new Configuration();
+        var configuration = new FakeHomeConfiguration();
 
         var layout = new HomeLayoutService(apps, widgets, configuration);
 
@@ -25,7 +24,7 @@ public sealed class HomeLayoutServiceLibraryTests
     {
         var apps = MakeApps();
         var widgets = new WidgetRegistry(Array.Empty<IHomeWidget>(), apps);
-        var configuration = new Configuration
+        var configuration = new FakeHomeConfiguration
         {
             Home = new HomeLayout
             {
@@ -57,7 +56,7 @@ public sealed class HomeLayoutServiceLibraryTests
     {
         var apps = MakeApps();
         var widgets = new WidgetRegistry(Array.Empty<IHomeWidget>(), apps);
-        var configuration = new Configuration
+        var configuration = new FakeHomeConfiguration
         {
             Home = new HomeLayout
             {
@@ -112,7 +111,7 @@ public sealed class HomeLayoutServiceLibraryTests
             new FakeApp("e"), new FakeApp("f"), new FakeApp("g"), new FakeApp("h"),
         };
         var widgets = new WidgetRegistry(Array.Empty<IHomeWidget>(), apps);
-        var configuration = new Configuration
+        var configuration = new FakeHomeConfiguration
         {
             Home = new HomeLayout
             {
@@ -177,5 +176,15 @@ public sealed class HomeLayoutServiceLibraryTests
         public void OnClosed() { }
         public void Draw(in PhoneContext context) { }
         public void Dispose() { }
+    }
+
+    // Deliberately not `Configuration` — that type implements Dalamud's IPluginConfiguration, which
+    // pulls in the Dalamud assembly the moment it's loaded. This satisfies only the narrow surface
+    // HomeLayoutService actually needs, so these tests stay Dalamud-free like the rest of the suite.
+    private sealed class FakeHomeConfiguration : IHomeConfiguration
+    {
+        public HomeLayout? Home { get; set; }
+        public int HomeGridRows { get; set; }
+        public void Save() { }
     }
 }

--- a/src/Aetherphone/Configuration.cs
+++ b/src/Aetherphone/Configuration.cs
@@ -20,7 +20,7 @@ using Dalamud.Configuration;
 namespace Aetherphone;
 
 [Serializable]
-internal sealed class Configuration : IPluginConfiguration
+internal sealed class Configuration : IPluginConfiguration, IHomeConfiguration
 {
     public int Version { get; set; } = 1;
     public bool OpenOnStartup { get; set; } = true;

--- a/src/Aetherphone/Core/Home/HomeLayout.cs
+++ b/src/Aetherphone/Core/Home/HomeLayout.cs
@@ -4,6 +4,7 @@ namespace Aetherphone.Core.Home;
 internal sealed class HomeLayout
 {
     public List<HomePage> Pages { get; set; } = new();
+    public List<HomePage> LibraryPages { get; set; } = new();
     public List<string>? Dock { get; set; }
 }
 
@@ -19,6 +20,7 @@ internal sealed class HomeItem
     public string Kind { get; set; } = "app";
     public string AppId { get; set; } = string.Empty;
     public string FolderName { get; set; } = string.Empty;
+    public string FolderTint { get; set; } = string.Empty;
     public List<string> AppIds { get; set; } = new();
     public string WidgetId { get; set; } = string.Empty;
     public string WidgetSize { get; set; } = string.Empty;

--- a/src/Aetherphone/Core/Home/HomeLayoutService.cs
+++ b/src/Aetherphone/Core/Home/HomeLayoutService.cs
@@ -40,6 +40,7 @@ internal sealed class HomeLayoutService
     private int rows;
     private int folderCounter;
     private int widgetCounter;
+    private int homePageCount;
     private bool placementsDirty = true;
 
     public HomeLayoutService(IReadOnlyList<IPhoneApp> apps, WidgetRegistry widgets, Configuration configuration)
@@ -58,7 +59,8 @@ internal sealed class HomeLayoutService
         Load();
     }
 
-    public int PageCount => pages.Count;
+    public int HomePageCount => homePageCount;
+    public int TotalPageCount => pages.Count;
     public int Rows => rows;
     public IReadOnlyList<HomeTile> Page(int index) => pages[index];
     public IReadOnlyList<HomeTile> Dock => dock;
@@ -129,7 +131,7 @@ internal sealed class HomeLayoutService
 
     public void MoveTile(HomeTile tile, int targetPage, int insertIndex)
     {
-        if (targetPage < 0 || targetPage > pages.Count)
+        if (targetPage < 0 || targetPage >= pages.Count)
         {
             return;
         }
@@ -137,11 +139,6 @@ internal sealed class HomeLayoutService
         if (!Detach(tile))
         {
             return;
-        }
-
-        if (targetPage == pages.Count)
-        {
-            pages.Add(new List<HomeTile>());
         }
 
         var page = pages[targetPage];
@@ -219,6 +216,17 @@ internal sealed class HomeLayoutService
         Save();
     }
 
+    public void SetFolderTint(HomeTile folder, string tint)
+    {
+        if (!folder.IsFolder)
+        {
+            return;
+        }
+
+        folder.FolderTint = tint;
+        Save();
+    }
+
     public bool AddWidget(IHomeWidget widget, WidgetSize size, int pageIndex)
     {
         if (!WidgetSizes.Contains(widget.Sizes, size))
@@ -226,7 +234,7 @@ internal sealed class HomeLayoutService
             return false;
         }
 
-        pageIndex = Math.Clamp(pageIndex, 0, Math.Max(0, pages.Count - 1));
+        pageIndex = Math.Clamp(pageIndex, 0, Math.Max(0, homePageCount - 1));
         pages[pageIndex].Insert(0, HomeTile.ForWidget(NextWidgetKey(widget.Id), widget, size));
         Commit();
         return true;
@@ -330,19 +338,11 @@ internal sealed class HomeLayoutService
 
         if (saved is not null && saved.Pages.Count > 0)
         {
-            LoadPages(saved, placed);
+            LoadPages(saved.Pages, placed);
         }
         else if (saved is null)
         {
             SeedDefaultLayout(placed);
-        }
-
-        for (var index = 0; index < apps.Count; index++)
-        {
-            if (apps[index].IsAvailable && placed.Add(apps[index].Id))
-            {
-                Append(HomeTile.ForApp(apps[index]));
-            }
         }
 
         if (saved is null)
@@ -353,6 +353,28 @@ internal sealed class HomeLayoutService
         if (pages.Count == 0)
         {
             pages.Add(new List<HomeTile>());
+        }
+
+        homePageCount = pages.Count;
+
+        if (saved is not null && saved.LibraryPages.Count > 0)
+        {
+            LoadPages(saved.LibraryPages, placed);
+        }
+
+        var unplaced = new List<IPhoneApp>();
+        for (var index = 0; index < apps.Count; index++)
+        {
+            if (apps[index].IsAvailable && placed.Add(apps[index].Id))
+            {
+                unplaced.Add(apps[index]);
+            }
+        }
+
+        unplaced.Sort((a, b) => string.Compare(a.DisplayName, b.DisplayName, StringComparison.OrdinalIgnoreCase));
+        for (var index = 0; index < unplaced.Count; index++)
+        {
+            AppendToLibrary(HomeTile.ForApp(unplaced[index]));
         }
 
         Normalize();
@@ -375,12 +397,12 @@ internal sealed class HomeLayoutService
         return defaults;
     }
 
-    private void LoadPages(HomeLayout saved, HashSet<string> placed)
+    private void LoadPages(List<HomePage> source, HashSet<string> placed)
     {
-        for (var pageIndex = 0; pageIndex < saved.Pages.Count; pageIndex++)
+        for (var pageIndex = 0; pageIndex < source.Count; pageIndex++)
         {
             var page = new List<HomeTile>();
-            var items = saved.Pages[pageIndex].Items;
+            var items = source[pageIndex].Items;
             for (var itemIndex = 0; itemIndex < items.Count; itemIndex++)
             {
                 if (LoadItem(items[itemIndex], placed) is { } tile)
@@ -408,7 +430,7 @@ internal sealed class HomeLayoutService
 
             return contents.Count == 1
                 ? HomeTile.ForApp(contents[0])
-                : HomeTile.ForFolder(NextFolderKey(), item.FolderName, contents);
+                : HomeTile.ForFolder(NextFolderKey(), item.FolderName, contents, item.FolderTint);
         }
 
         if (string.Equals(item.Kind, "widget", StringComparison.Ordinal))
@@ -505,11 +527,39 @@ internal sealed class HomeLayoutService
         pages.Add(new List<HomeTile> { tile });
     }
 
+    private void AppendToLibrary(HomeTile tile)
+    {
+        if (pages.Count == homePageCount)
+        {
+            pages.Add(new List<HomeTile>());
+        }
+
+        var last = pages[^1];
+        last.Add(tile);
+        if (HomeGridSolver.Fits(last, Columns, rows))
+        {
+            return;
+        }
+
+        last.RemoveAt(last.Count - 1);
+        pages.Add(new List<HomeTile> { tile });
+    }
+
     private void Normalize()
     {
         FoldDegenerateFolders();
         var scratch = new List<GridCell>();
-        for (var page = 0; page < pages.Count; page++)
+        homePageCount = NormalizeRange(scratch, 0, homePageCount);
+        var libraryEnd = NormalizeRange(scratch, homePageCount, pages.Count);
+        if (libraryEnd == homePageCount)
+        {
+            pages.Add(new List<HomeTile>());
+        }
+    }
+
+    private int NormalizeRange(List<GridCell> scratch, int start, int end)
+    {
+        for (var page = start; page < end; page++)
         {
             var tiles = pages[page];
             var fitCount = HomeGridSolver.Solve(tiles, Columns, rows, scratch);
@@ -518,9 +568,10 @@ internal sealed class HomeLayoutService
                 continue;
             }
 
-            if (page + 1 >= pages.Count)
+            if (page + 1 >= end)
             {
-                pages.Add(new List<HomeTile>());
+                pages.Insert(page + 1, new List<HomeTile>());
+                end++;
             }
 
             var overflow = tiles.GetRange(fitCount, tiles.Count - fitCount);
@@ -528,13 +579,16 @@ internal sealed class HomeLayoutService
             pages[page + 1].InsertRange(0, overflow);
         }
 
-        for (var page = pages.Count - 1; page > 0; page--)
+        for (var page = end - 1; page > start; page--)
         {
             if (pages[page].Count == 0)
             {
                 pages.RemoveAt(page);
+                end--;
             }
         }
+
+        return end;
     }
 
     private void FoldDegenerateFolders()
@@ -585,19 +639,26 @@ internal sealed class HomeLayoutService
             layout.Dock.Add(dock[index].App!.Id);
         }
 
-        for (var page = 0; page < pages.Count; page++)
-        {
-            var stored = new HomePage();
-            for (var index = 0; index < pages[page].Count; index++)
-            {
-                stored.Items.Add(SerializeTile(pages[page][index]));
-            }
-
-            layout.Pages.Add(stored);
-        }
+        SerializePages(layout.Pages, 0, homePageCount);
+        SerializePages(layout.LibraryPages, homePageCount, pages.Count);
 
         configuration.Home = layout;
         configuration.Save();
+    }
+
+    private void SerializePages(List<HomePage> target, int start, int end)
+    {
+        for (var page = start; page < end; page++)
+        {
+            var stored = new HomePage();
+            var tiles = pages[page];
+            for (var index = 0; index < tiles.Count; index++)
+            {
+                stored.Items.Add(SerializeTile(tiles[index]));
+            }
+
+            target.Add(stored);
+        }
     }
 
     private static HomeItem SerializeTile(HomeTile tile)
@@ -614,7 +675,7 @@ internal sealed class HomeLayoutService
 
         if (tile.IsFolder)
         {
-            var item = new HomeItem { Kind = "folder", FolderName = tile.FolderName };
+            var item = new HomeItem { Kind = "folder", FolderName = tile.FolderName, FolderTint = tile.FolderTint };
             for (var appIndex = 0; appIndex < tile.Apps.Count; appIndex++)
             {
                 item.AppIds.Add(tile.Apps[appIndex].Id);

--- a/src/Aetherphone/Core/Home/HomeLayoutService.cs
+++ b/src/Aetherphone/Core/Home/HomeLayoutService.cs
@@ -31,7 +31,7 @@ internal sealed class HomeLayoutService
 
     private readonly IReadOnlyList<IPhoneApp> apps;
     private readonly WidgetRegistry widgets;
-    private readonly Configuration configuration;
+    private readonly IHomeConfiguration configuration;
     private readonly Dictionary<string, IPhoneApp> byId = new();
     private readonly List<List<HomeTile>> pages = new();
     private readonly List<HomeTile> dock = new();
@@ -43,7 +43,7 @@ internal sealed class HomeLayoutService
     private int homePageCount;
     private bool placementsDirty = true;
 
-    public HomeLayoutService(IReadOnlyList<IPhoneApp> apps, WidgetRegistry widgets, Configuration configuration)
+    public HomeLayoutService(IReadOnlyList<IPhoneApp> apps, WidgetRegistry widgets, IHomeConfiguration configuration)
     {
         this.apps = apps;
         this.widgets = widgets;

--- a/src/Aetherphone/Core/Home/HomeTile.cs
+++ b/src/Aetherphone/Core/Home/HomeTile.cs
@@ -9,6 +9,7 @@ internal sealed class HomeTile : IGridTile
     public IHomeWidget? Widget { get; init; }
     public WidgetSize Size { get; set; } = WidgetSize.Medium;
     public string FolderName { get; set; } = string.Empty;
+    public string FolderTint { get; set; } = string.Empty;
     public List<IPhoneApp> Apps { get; } = new();
     public bool IsWidget => Widget is not null;
     public bool IsFolder => App is null && Widget is null;
@@ -20,9 +21,9 @@ internal sealed class HomeTile : IGridTile
     public static HomeTile ForWidget(string key, IHomeWidget widget, WidgetSize size) =>
         new() { Key = key, Widget = widget, Size = size };
 
-    public static HomeTile ForFolder(string key, string name, IReadOnlyList<IPhoneApp> apps)
+    public static HomeTile ForFolder(string key, string name, IReadOnlyList<IPhoneApp> apps, string tint = "")
     {
-        var tile = new HomeTile { Key = key, App = null, FolderName = name };
+        var tile = new HomeTile { Key = key, App = null, FolderName = name, FolderTint = tint };
         for (var index = 0; index < apps.Count; index++)
         {
             tile.Apps.Add(apps[index]);

--- a/src/Aetherphone/Core/Home/IHomeConfiguration.cs
+++ b/src/Aetherphone/Core/Home/IHomeConfiguration.cs
@@ -1,0 +1,8 @@
+namespace Aetherphone.Core.Home;
+
+internal interface IHomeConfiguration
+{
+    HomeLayout? Home { get; set; }
+    int HomeGridRows { get; }
+    void Save();
+}

--- a/src/Aetherphone/Core/Localization/L.cs
+++ b/src/Aetherphone/Core/Localization/L.cs
@@ -1882,6 +1882,9 @@ internal static class L
     {
         public static readonly LocString Done = new("home.done", "Done");
         public static readonly LocString NewFolder = new("home.newFolder", "Folder");
+        public static readonly LocString AppLibrary = new("home.appLibrary", "App Library");
+        public static readonly LocString AppLibraryEmpty = new("home.appLibraryEmpty",
+            "Drag apps here to keep them off your Home Screen");
         public static readonly LocString Widgets = new("home.widgets", "Widgets");
         public static readonly LocString AddWidget = new("home.addWidget", "Add Widget");
         public static readonly LocString Remove = new("home.remove", "Remove");

--- a/src/Aetherphone/Core/Shell/Home/FolderOverlay.cs
+++ b/src/Aetherphone/Core/Shell/Home/FolderOverlay.cs
@@ -11,6 +11,7 @@ namespace Aetherphone.Core.Shell.Home;
 internal sealed class FolderOverlay
 {
     private const float OpenSmoothTime = 0.20f;
+    private static readonly Vector4 NoTintSwatch = new(0.55f, 0.56f, 0.60f, 1f);
 
     private readonly HomeLayoutService layout;
     private HomeTile? folder;
@@ -18,6 +19,7 @@ internal sealed class FolderOverlay
     private Spring anim;
     private Rect origin;
     private string nameBuffer = string.Empty;
+    private float scrollY;
 
     public FolderOverlay(HomeLayoutService layout)
     {
@@ -34,6 +36,7 @@ internal sealed class FolderOverlay
         anim.SnapTo(0f);
         origin = originRect;
         nameBuffer = tile.FolderName;
+        scrollY = 0f;
     }
 
     public void RequestClose()
@@ -77,8 +80,9 @@ internal sealed class FolderOverlay
         var cellWidth = (panelWidth - pad * 2f) / columns;
         var iconSize = MathF.Min(cellWidth * 0.62f, 52f * scale);
         var cellHeight = iconSize + 26f * scale;
-        var headerHeight = 48f * scale;
-        var panelHeight = headerHeight + rows * cellHeight + pad;
+        var swatchRowHeight = 34f * scale;
+        var headerHeight = 48f * scale + swatchRowHeight;
+        var panelHeight = MathF.Min(headerHeight + rows * cellHeight + pad, content.Height * 0.82f);
         var targetMin = new Vector2(content.Center.X - panelWidth * 0.5f, content.Center.Y - panelHeight * 0.5f);
         var target = new Rect(targetMin, targetMin + new Vector2(panelWidth, panelHeight));
         var panel = new Rect(Vector2.Lerp(origin.Min, target.Min, eased), Vector2.Lerp(origin.Max, target.Max, eased));
@@ -110,13 +114,32 @@ internal sealed class FolderOverlay
             ApplyRename();
         }
 
+        DrawTintRow(panel, current, pad, scale);
+
         var gridTop = panel.Min.Y + headerHeight;
+        var gridView = new Rect(new Vector2(panel.Min.X, gridTop), panel.Max);
+        var drawList = ImGui.GetWindowDrawList();
+        drawList.PushClipRect(gridView.Min, gridView.Max, true);
+        if (ImGui.IsMouseHoveringRect(gridView.Min, gridView.Max))
+        {
+            scrollY -= ImGui.GetIO().MouseWheel * 40f * scale;
+        }
+
+        var rows = (current.Apps.Count + columns - 1) / columns;
+        var contentHeight = rows * cellHeight;
+        scrollY = Math.Clamp(scrollY, 0f, MathF.Max(0f, contentHeight - gridView.Height));
+
         for (var index = 0; index < current.Apps.Count; index++)
         {
             var column = index % columns;
             var row = index / columns;
             var center = new Vector2(panel.Min.X + pad + (column + 0.5f) * cellWidth,
-                gridTop + (row + 0.5f) * cellHeight);
+                gridTop - scrollY + (row + 0.5f) * cellHeight);
+            if (center.Y + cellHeight * 0.5f < gridView.Min.Y || center.Y - cellHeight * 0.5f > gridView.Max.Y)
+            {
+                continue;
+            }
+
             var app = current.Apps[index];
             HomeTileView.DrawApp(center, iconSize, app, theme, 1f, 1f, cellWidth);
             var half = iconSize * 0.5f;
@@ -133,6 +156,7 @@ internal sealed class FolderOverlay
                         RequestClose();
                     }
 
+                    drawList.PopClipRect();
                     return;
                 }
             }
@@ -143,8 +167,42 @@ internal sealed class FolderOverlay
                 {
                     RequestClose();
                     navigation.OpenAppFrom(app, iconRect);
+                    drawList.PopClipRect();
                     return;
                 }
+            }
+        }
+
+        drawList.PopClipRect();
+    }
+
+    private void DrawTintRow(Rect panel, HomeTile current, float pad, float scale)
+    {
+        var drawList = ImGui.GetWindowDrawList();
+        var rowY = panel.Min.Y + 48f * scale + 17f * scale;
+        var innerLeft = panel.Min.X + pad;
+        var innerRight = panel.Max.X - pad;
+        var accents = ThemeCatalog.Accents;
+        var totalSwatches = accents.Count + 1;
+        var cell = (innerRight - innerLeft) / totalSwatches;
+        var swatchRadius = MathF.Min(cell * 0.32f, 11f * scale);
+
+        var noneCenter = new Vector2(innerLeft + cell * 0.5f, rowY);
+        var noneSelected = string.IsNullOrEmpty(current.FolderTint);
+        if (ControlTile.Swatch(drawList, noneCenter, swatchRadius, NoTintSwatch, noneSelected, 1f, true) &&
+            !noneSelected)
+        {
+            layout.SetFolderTint(current, string.Empty);
+        }
+
+        for (var index = 0; index < accents.Count; index++)
+        {
+            var accent = accents[index];
+            var center = new Vector2(innerLeft + cell * (index + 1.5f), rowY);
+            var selected = current.FolderTint == accent.Name;
+            if (ControlTile.Swatch(drawList, center, swatchRadius, accent.Color, selected, 1f, true) && !selected)
+            {
+                layout.SetFolderTint(current, accent.Name);
             }
         }
     }

--- a/src/Aetherphone/Core/Shell/Home/HomeGridRenderer.cs
+++ b/src/Aetherphone/Core/Shell/Home/HomeGridRenderer.cs
@@ -33,7 +33,7 @@ internal sealed class HomeGridRenderer
         drawList.PushClipRect(metrics.Content.Min, new Vector2(metrics.Content.Max.X, metrics.DockBar.Min.Y), true);
         var scroll = pager.Value;
         var first = Math.Max(0, (int)MathF.Floor(scroll) - 1);
-        var last = Math.Min(layout.PageCount - 1, (int)MathF.Ceiling(scroll) + 1);
+        var last = Math.Min(layout.TotalPageCount - 1, (int)MathF.Ceiling(scroll) + 1);
         for (var page = first; page <= last; page++)
         {
             DrawPage(metrics, theme, page, delta, labelAlpha, motion);
@@ -66,6 +66,29 @@ internal sealed class HomeGridRenderer
             DrawTile(metrics, theme, tile, rect, labelAlpha, delta, motion,
                 ReferenceEquals(tile, interaction.FolderTarget));
         }
+
+        if (page >= layout.HomePageCount && tiles.Count == 0)
+        {
+            DrawLibraryEmptyState(metrics, theme, pageOffset, labelAlpha);
+        }
+    }
+
+    private static void DrawLibraryEmptyState(in HomeMetrics metrics, PhoneTheme theme, Vector2 pageOffset,
+        float labelAlpha)
+    {
+        if (labelAlpha <= 0.01f)
+        {
+            return;
+        }
+
+        var center = metrics.Grid.Center + pageOffset;
+        var scale = metrics.Scale;
+        var titleColor = Palette.WithAlpha(theme.TextStrong, 0.7f * labelAlpha);
+        var subtitleColor = Palette.WithAlpha(theme.TextStrong, 0.4f * labelAlpha);
+        Typography.DrawCentered(center - new Vector2(0f, 10f * scale), Loc.T(L.Home.AppLibrary), titleColor, 1.05f,
+            FontWeight.SemiBold);
+        Typography.DrawCentered(center + new Vector2(0f, 12f * scale), Loc.T(L.Home.AppLibraryEmpty), subtitleColor,
+            0.78f);
     }
 
     private void DrawTile(in HomeMetrics metrics, PhoneTheme theme, HomeTile tile, Rect rect, float labelAlpha,

--- a/src/Aetherphone/Core/Shell/Home/HomeInteractionController.cs
+++ b/src/Aetherphone/Core/Shell/Home/HomeInteractionController.cs
@@ -57,7 +57,6 @@ internal sealed class HomeInteractionController
     private HomeTile? dragTile;
     private bool dragFromDock;
     private int dragPage;
-    private bool extraPage;
     private Vector2 dragPos;
     private Vector2 grabOffset;
     private Spring lift;
@@ -96,7 +95,7 @@ internal sealed class HomeInteractionController
 
     public void Advance(float delta) => editClock += delta;
 
-    public int DisplayPageCount() => layout.PageCount + (dragTile is not null && extraPage ? 1 : 0);
+    public int DisplayPageCount() => layout.TotalPageCount;
 
     public void Suspend()
     {
@@ -111,7 +110,6 @@ internal sealed class HomeInteractionController
         if (dragTile is not null)
         {
             dragTile = null;
-            extraPage = false;
         }
     }
 
@@ -226,7 +224,11 @@ internal sealed class HomeInteractionController
 
         if (HomeChrome.AddRect(content, metrics).Contains(mouse))
         {
-            gallery.Open(pager.Page);
+            if (pager.Page < layout.HomePageCount)
+            {
+                gallery.Open(pager.Page);
+            }
+
             pressActive = false;
             return true;
         }
@@ -296,7 +298,7 @@ internal sealed class HomeInteractionController
             return null;
         }
 
-        var page = Math.Clamp((int)MathF.Round(pager.Value), 0, layout.PageCount - 1);
+        var page = Math.Clamp((int)MathF.Round(pager.Value), 0, layout.TotalPageCount - 1);
         var cell = metrics.CellFromPoint(page, pager.Value, mouse);
         var tiles = layout.Page(page);
         var cells = layout.Placements(page);
@@ -319,7 +321,6 @@ internal sealed class HomeInteractionController
         dragTile = tile;
         dragFromDock = pressFromDock;
         dragPage = dragFromDock ? pager.Page : LocatePage(tile);
-        extraPage = false;
         var center = CommittedRect(metrics, tile)?.Center ?? mouse;
         grabOffset = mouse - center;
         dragPos = center;
@@ -398,21 +399,12 @@ internal sealed class HomeInteractionController
                 edgeDwell = 0f;
             }
         }
-        else if (mouse.X > content.Max.X - edge)
+        else if (mouse.X > content.Max.X - edge && dragPage < layout.TotalPageCount - 1)
         {
             edgeDwell += delta;
             if (edgeDwell > EdgeFlipSeconds)
             {
-                if (dragPage < layout.PageCount - 1)
-                {
-                    dragPage++;
-                }
-                else if (!extraPage && dragPage == layout.PageCount - 1 && PageHasOthers(dragPage))
-                {
-                    extraPage = true;
-                    dragPage = layout.PageCount;
-                }
-
+                dragPage++;
                 pager.AnimateTo(dragPage, DisplayPageCount());
                 edgeDwell = 0f;
             }
@@ -423,7 +415,7 @@ internal sealed class HomeInteractionController
         }
 
         folderTarget = null;
-        if (dragPage >= layout.PageCount)
+        if (dragPage >= layout.TotalPageCount)
         {
             insertIndex = 0;
             return;
@@ -458,7 +450,7 @@ internal sealed class HomeInteractionController
 
     private bool PageContainsTile(int page, HomeTile tile)
     {
-        if (page >= layout.PageCount)
+        if (page >= layout.TotalPageCount)
         {
             return false;
         }
@@ -467,20 +459,6 @@ internal sealed class HomeInteractionController
         for (var index = 0; index < tiles.Count; index++)
         {
             if (ReferenceEquals(tiles[index], tile))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private bool PageHasOthers(int page)
-    {
-        var tiles = layout.Page(page);
-        for (var index = 0; index < tiles.Count; index++)
-        {
-            if (!ReferenceEquals(tiles[index], dragTile))
             {
                 return true;
             }
@@ -509,7 +487,7 @@ internal sealed class HomeInteractionController
     private void BuildSiblings(int page)
     {
         previewTiles.Clear();
-        if (page >= layout.PageCount)
+        if (page >= layout.TotalPageCount)
         {
             return;
         }
@@ -569,9 +547,8 @@ internal sealed class HomeInteractionController
 
         dragTile = null;
         folderTarget = null;
-        extraPage = false;
         overDock = false;
-        pager.AnimateTo(pager.Page, layout.PageCount);
+        pager.AnimateTo(pager.Page, layout.TotalPageCount);
     }
 
     private void BeginSettle(HomeTile tile, in HomeMetrics metrics)

--- a/src/Aetherphone/Core/Shell/HomeScreen.cs
+++ b/src/Aetherphone/Core/Shell/HomeScreen.cs
@@ -31,6 +31,8 @@ internal sealed class HomeScreen
         chrome = new HomeChrome(pager, interaction);
     }
 
+    public bool Editing => interaction.Editing;
+
     public void Draw(Rect screen, Rect content, PhoneTheme theme, INavigator navigation, in HomeMotion motion)
     {
         layout.EnsureCurrent();
@@ -78,7 +80,7 @@ internal sealed class HomeScreen
         var page = PageContaining(appId);
         if (page >= 0)
         {
-            pager.SnapTo(page, layout.PageCount);
+            pager.SnapTo(page, layout.TotalPageCount);
         }
     }
 
@@ -95,7 +97,7 @@ internal sealed class HomeScreen
             }
         }
 
-        for (var page = 0; page < layout.PageCount; page++)
+        for (var page = 0; page < layout.TotalPageCount; page++)
         {
             var tiles = layout.Page(page);
             var cells = layout.Placements(page);
@@ -136,7 +138,7 @@ internal sealed class HomeScreen
 
     private int PageContaining(string appId)
     {
-        for (var page = 0; page < layout.PageCount; page++)
+        for (var page = 0; page < layout.TotalPageCount; page++)
         {
             var tiles = layout.Page(page);
             for (var index = 0; index < tiles.Count; index++)

--- a/src/Aetherphone/Core/Shell/PhoneShell.cs
+++ b/src/Aetherphone/Core/Shell/PhoneShell.cs
@@ -45,6 +45,7 @@ internal sealed class PhoneShell : IDisposable
     private readonly ShellTransitionRenderer transition;
     private readonly MinimizeMorphView morph;
     private readonly ShellOverlayCoordinator overlays;
+    private readonly HomeScreen home;
     private NotificationShake shake = new(ShakeDuration, ShakeFrequency, ShakeAmplitude);
     private bool closeRequested;
     private bool indicatorPressActive;
@@ -75,7 +76,7 @@ internal sealed class PhoneShell : IDisposable
         var controlCenter = new ControlCenter(configuration, themes, services.Playback, calls, navigation,
             notifications, router);
         minimizedView = new MinimizedPhone(notifications, configuration);
-        var home = new HomeScreen(apps, bundle.Widgets, configuration);
+        home = new HomeScreen(apps, bundle.Widgets, configuration);
         navigation.ReturningHome += home.PrepareReveal;
         var incomingOverlay = new IncomingCallOverlay(calls);
         var banOverlay = new BanOverlay(services.AethernetSession);
@@ -126,6 +127,8 @@ internal sealed class PhoneShell : IDisposable
     }
 
     public bool MinimizedResting => minimize.MinimizedResting;
+
+    public bool HomeEditing => home.Editing;
 
     public MinimizePhase MinimizePhase => minimize.Phase;
 

--- a/src/Aetherphone/Windows/Components/HomeTileView.cs
+++ b/src/Aetherphone/Windows/Components/HomeTileView.cs
@@ -47,7 +47,7 @@ internal static class HomeTileView
         var max = new Vector2(center.X + drawHalf, center.Y + drawHalf);
         var radius = size * 0.26f * drawScale;
         Elevation.IconRest(dl, min, max, radius, scale);
-        Squircle.Fill(dl, min, max, radius, ImGui.GetColorU32(new Vector4(1f, 1f, 1f, 0.16f)));
+        Squircle.Fill(dl, min, max, radius, ImGui.GetColorU32(FolderFill(folder.FolderTint)));
         Material.EdgeSquircle(dl, min, max, radius, scale);
         var pad = drawHalf * 0.28f;
         var inner = drawHalf * 2f - pad * 2f;
@@ -98,6 +98,10 @@ internal static class HomeTileView
             DrawBadge(center, size, 1, true, theme, scale);
         }
     }
+
+    private static Vector4 FolderFill(string tint) => string.IsNullOrEmpty(tint)
+        ? new Vector4(1f, 1f, 1f, 0.16f)
+        : Palette.WithAlpha(ThemeCatalog.ResolveAccent(tint), 0.34f);
 
     private static void DrawBadge(Vector2 center, float size, int count, bool asDot, PhoneTheme theme, float scale)
     {

--- a/src/Aetherphone/Windows/PhoneWindow.cs
+++ b/src/Aetherphone/Windows/PhoneWindow.cs
@@ -116,7 +116,9 @@ internal sealed class PhoneWindow : Window
         var size = minimized ? MinimizeTransition.MinimizedSize : PhoneSizeCatalog.SizeFor(configuration.PhoneScale);
         Size = size;
         SizeCondition = ImGuiCond.Always;
-        Flags = !minimized && configuration.LockPosition ? BaseFlags | ImGuiWindowFlags.NoMove : BaseFlags;
+        Flags = !minimized && (configuration.LockPosition || shell.HomeEditing)
+            ? BaseFlags | ImGuiWindowFlags.NoMove
+            : BaseFlags;
 
         if (recenterFrames > 0)
         {


### PR DESCRIPTION
## What

Adds an iPhone-style App Library — a screen reached by swiping past the last Home page, listing apps that aren't placed on Home — with drag in/out support, plus folder tinting and an open-folder panel that no longer has an effective size limit.

## Why

Requested to bring Home screen management closer to iOS. Previously every registered app was force-appended to a Home page the moment it existed — there was no way to keep an app installed but off Home. Folders also had no way to be visually organized, and the open-folder view grew unbounded with app count, so a big enough folder would render past the edge of the screen.

## How to test

1. Swipe past your last Home page — you should land on a Library page (an "App Library" title + hint line if it's empty)
2. Long-press an app on Home to enter edit mode, drag it onto the Library page and release — it should disappear from Home
3. Drag an app from Library onto a Home page to place it back
4. Drag one Library app onto another to form a folder there, then disband it (edit mode → remove badge) and confirm the apps return individually, not deleted
5. Open any folder, tap a color swatch under the name field — the folder icon should tint; tap the gray "none" swatch to clear it
6. Add many apps to one folder and confirm the panel scrolls (mouse wheel) instead of growing past the screen
7. Enter icon-edit mode and confirm the phone window itself doesn't drag around until Done is tapped

## Implementation notes

**Library pages are just more pages.** `HomeLayoutService.pages` already treated every page generically by index; a new `homePageCount` field marks where Home ends and Library begins inside that same list. `MakeFolder`, `DisbandFolder`, and cross-page dragging needed zero new code — they already operate on page index and tile reference, never on "is this a Home page."

**`Normalize()` had to become boundary-aware.** The old single pass over `0..pages.Count` handled grid overflow and empty-page cleanup for one list. Split into two bounded ranges (`NormalizeRange`) so `homePageCount` stays correct as pages are inserted or removed, and so the Library section can never collapse to zero pages — it's a permanent fixture, same as real iOS, never "nothing there."

**New apps land in Library, not Home.** `Load()` used to force-append every unplaced app onto a trailing Home page; that loop is gone. Anything not found in the saved layout — new installs, or an app a future update ships that an existing user hasn't placed — goes to `AppendToLibrary` instead. Existing users' saved Home layouts are untouched.

**The blank-page-via-drag gesture is gone.** Dragging to the edge of the last page used to spawn a manual blank page (`extraPage`). Since Library always has at least one page now, that branch became unreachable, so it — and the now-unused `PageHasOthers` — were deleted rather than left as dead code.

**Folder tint reuses the phone's own accent palette** (`ThemeCatalog.Accents`) rather than inventing a new color set: the five existing named colors plus a "none" swatch, persisted as a string on `HomeItem.FolderTint`, blended into the folder icon fill in `HomeTileView.DrawFolder`.

**Folders can't overflow the screen anymore.** No app-count cap ever existed in `MakeFolder`/`AddApps`, but the open-folder panel grew unbounded with the grid. It's now capped at 82% of screen height with a scrollable region, so a folder of any size renders safely.

**`Configuration` doesn't leak into layout logic.** `HomeLayoutService` originally took the concrete `Configuration` class, which implements Dalamud's `IPluginConfiguration` — merely loading that type pulls in `Dalamud.dll`, which CI doesn't have on disk (it's provided by the host at runtime). Extracted `IHomeConfiguration` (just `Home`, `HomeGridRows`, `Save()`) so the layout logic, and its tests, never need Dalamud loaded at all.

## Checklist

- [x] `dotnet build -c Release` passes
- [x] Verified in-game: opened the phone and exercised the affected app/screen
- [ ] If this changes user-visible behavior, README is updated
- [x] Matches existing style: uses the shared `Windows/Components/` widgets, no `what` comments