### PR TITLE
feat(gallery): Add a button to open the photos folder

### DIFF
--- a/src/Aetherphone/Apps/Photos/PhotosApp.Grid.cs
+++ b/src/Aetherphone/Apps/Photos/PhotosApp.Grid.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using Aetherphone.Core;
 using Aetherphone.Core.Localization;
 using Aetherphone.Core.Onboarding;
+using Aetherphone.Windows;
 using Aetherphone.Windows.Components;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface;
@@ -299,12 +300,7 @@ internal sealed partial class PhotosApp
         if (!ComposeFab.Draw(rect, "##openFolderFab", Accent, FontAwesomeIcon.Folder.ToIconString(),
                              Loc.T(L.Photos.OpenFolder), "photos.openFolder")) return;
         
-        Process.Start(new ProcessStartInfo
-        {
-            FileName = "explorer.exe",
-            Arguments = $"\"{library.GetDirectory()}\"",
-            UseShellExecute = true
-        });
+        UrlActions.OpenFolder(library.GetDirectory());
     }
 
     private bool DrawAlbumCard(ImDrawListPtr drawList, Rect rect, string title, int coverStart, int coverCount,

--- a/src/Aetherphone/Apps/Photos/PhotosApp.Grid.cs
+++ b/src/Aetherphone/Apps/Photos/PhotosApp.Grid.cs
@@ -297,7 +297,7 @@ internal sealed partial class PhotosApp
 
     private void DrawOpenFolder(Rect rect)
     {
-        if (!ComposeFab.Draw(rect, "##openFolderFab", Accent, FontAwesomeIcon.Folder.ToIconString(),
+        if (ComposeFab.Draw(rect, "##openFolderFab", Accent, FontAwesomeIcon.Folder.ToIconString(),
                              Loc.T(L.Photos.OpenFolder), "photos.openFolder"))
         {
             UrlActions.OpenFolder(library.DirectoryPath);

--- a/src/Aetherphone/Apps/Photos/PhotosApp.Grid.cs
+++ b/src/Aetherphone/Apps/Photos/PhotosApp.Grid.cs
@@ -298,9 +298,10 @@ internal sealed partial class PhotosApp
     private void DrawOpenFolder(Rect rect)
     {
         if (!ComposeFab.Draw(rect, "##openFolderFab", Accent, FontAwesomeIcon.Folder.ToIconString(),
-                             Loc.T(L.Photos.OpenFolder), "photos.openFolder")) return;
-        
-        UrlActions.OpenFolder(library.GetDirectory());
+                             Loc.T(L.Photos.OpenFolder), "photos.openFolder"))
+        {
+            UrlActions.OpenFolder(library.DirectoryPath);
+        }
     }
 
     private bool DrawAlbumCard(ImDrawListPtr drawList, Rect rect, string title, int coverStart, int coverCount,

--- a/src/Aetherphone/Apps/Photos/PhotosApp.Grid.cs
+++ b/src/Aetherphone/Apps/Photos/PhotosApp.Grid.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Aetherphone.Core;
 using Aetherphone.Core.Localization;
 using Aetherphone.Core.Onboarding;
@@ -39,6 +40,7 @@ internal sealed partial class PhotosApp
             }
 
             DrawPhotoGrid(body, 0, entries.Length);
+            DrawOpenFolder(body);
             return;
         }
 
@@ -290,6 +292,19 @@ internal sealed partial class PhotosApp
             ImGui.SetCursorScreenPos(origin);
             ImGui.Dummy(new Vector2(width, heightTotal + 12f * scale));
         }
+    }
+
+    private void DrawOpenFolder(Rect rect)
+    {
+        if (!ComposeFab.Draw(rect, "##openFolderFab", Accent, FontAwesomeIcon.Folder.ToIconString(),
+                             Loc.T(L.Photos.OpenFolder), "photos.openFolder")) return;
+        
+        Process.Start(new ProcessStartInfo
+        {
+            FileName = "explorer.exe",
+            Arguments = $"\"{library.GetDirectory()}\"",
+            UseShellExecute = true
+        });
     }
 
     private bool DrawAlbumCard(ImDrawListPtr drawList, Rect rect, string title, int coverStart, int coverCount,

--- a/src/Aetherphone/Core/Localization/L.cs
+++ b/src/Aetherphone/Core/Localization/L.cs
@@ -2139,7 +2139,7 @@ internal static class L
         public static readonly LocString Recents = new("photos.recents", "Recents");
         public static readonly LocString Today = new("photos.today", "Today");
         public static readonly LocString Yesterday = new("photos.yesterday", "Yesterday");
-        public static readonly LocString OpenFolder = new("photos.openFolder", "Open Folder");
+        public static readonly LocString OpenFolder = new("photos.openFolder", "Open folder");
     }
 
     internal static class Skywatcher

--- a/src/Aetherphone/Core/Localization/L.cs
+++ b/src/Aetherphone/Core/Localization/L.cs
@@ -2139,6 +2139,7 @@ internal static class L
         public static readonly LocString Recents = new("photos.recents", "Recents");
         public static readonly LocString Today = new("photos.today", "Today");
         public static readonly LocString Yesterday = new("photos.yesterday", "Yesterday");
+        public static readonly LocString OpenFolder = new("photos.openFolder", "Open Folder");
     }
 
     internal static class Skywatcher

--- a/src/Aetherphone/Core/Photos/PhotoLibrary.cs
+++ b/src/Aetherphone/Core/Photos/PhotoLibrary.cs
@@ -10,6 +10,8 @@ internal sealed class PhotoLibrary
         Directory.CreateDirectory(directory);
     }
 
+    public string GetDirectory() => directory;
+
     public void Save(byte[] pixels, int width, int height)
     {
         var fileName = $"AEP_{DateTime.Now:yyyyMMdd_HHmmss_fff}.png";

--- a/src/Aetherphone/Core/Photos/PhotoLibrary.cs
+++ b/src/Aetherphone/Core/Photos/PhotoLibrary.cs
@@ -10,7 +10,7 @@ internal sealed class PhotoLibrary
         Directory.CreateDirectory(directory);
     }
 
-    public string GetDirectory() => directory;
+    public string DirectoryPath => directory;
 
     public void Save(byte[] pixels, int width, int height)
     {

--- a/src/Aetherphone/Localization/de.json
+++ b/src/Aetherphone/Localization/de.json
@@ -1722,6 +1722,7 @@
   "photos.recents": "Zuletzt",
   "photos.today": "Heute",
   "photos.yesterday": "Gestern",
+  "photos.openFolder": "Ordner öffnen",
   "skywatcher.nextFewHours": "Nächste Stunden",
   "skywatcher.forecast": "Vorhersage",
   "skywatcher.now": "Jetzt",

--- a/src/Aetherphone/Localization/en.json
+++ b/src/Aetherphone/Localization/en.json
@@ -1721,6 +1721,7 @@
   "photos.recents": "Recents",
   "photos.today": "Today",
   "photos.yesterday": "Yesterday",
+  "photos.openFolder": "Open folder",
   "skywatcher.nextFewHours": "Next Few Hours",
   "skywatcher.forecast": "Forecast",
   "skywatcher.now": "Now",

--- a/src/Aetherphone/Localization/es.json
+++ b/src/Aetherphone/Localization/es.json
@@ -1722,6 +1722,7 @@
   "photos.recents": "Recientes",
   "photos.today": "Hoy",
   "photos.yesterday": "Ayer",
+  "photos.openFolder": "",
   "skywatcher.nextFewHours": "Próximas horas",
   "skywatcher.forecast": "Pronóstico",
   "skywatcher.now": "Ahora",

--- a/src/Aetherphone/Localization/es.json
+++ b/src/Aetherphone/Localization/es.json
@@ -1722,7 +1722,7 @@
   "photos.recents": "Recientes",
   "photos.today": "Hoy",
   "photos.yesterday": "Ayer",
-  "photos.openFolder": "",
+  "photos.openFolder": "Abrir carpeta",
   "skywatcher.nextFewHours": "Próximas horas",
   "skywatcher.forecast": "Pronóstico",
   "skywatcher.now": "Ahora",

--- a/src/Aetherphone/Localization/fr.json
+++ b/src/Aetherphone/Localization/fr.json
@@ -1722,7 +1722,7 @@
   "photos.recents": "Récents",
   "photos.today": "Aujourd'hui",
   "photos.yesterday": "Hier",
-  "photos.openFolder": "",
+  "photos.openFolder": "Ouvrir le dossier",
   "skywatcher.nextFewHours": "Prochaines heures",
   "skywatcher.forecast": "Prévisions",
   "skywatcher.now": "Maintenant",

--- a/src/Aetherphone/Localization/fr.json
+++ b/src/Aetherphone/Localization/fr.json
@@ -1722,6 +1722,7 @@
   "photos.recents": "Récents",
   "photos.today": "Aujourd'hui",
   "photos.yesterday": "Hier",
+  "photos.openFolder": "",
   "skywatcher.nextFewHours": "Prochaines heures",
   "skywatcher.forecast": "Prévisions",
   "skywatcher.now": "Maintenant",

--- a/src/Aetherphone/Localization/ja.json
+++ b/src/Aetherphone/Localization/ja.json
@@ -1722,6 +1722,7 @@
   "photos.recents": "最近の項目",
   "photos.today": "今日",
   "photos.yesterday": "昨日",
+  "photos.openFolder": "",
   "skywatcher.nextFewHours": "数時間後",
   "skywatcher.forecast": "天気予報",
   "skywatcher.now": "現在",

--- a/src/Aetherphone/Localization/ja.json
+++ b/src/Aetherphone/Localization/ja.json
@@ -1722,7 +1722,7 @@
   "photos.recents": "最近の項目",
   "photos.today": "今日",
   "photos.yesterday": "昨日",
-  "photos.openFolder": "",
+  "photos.openFolder": "フォルダを開く",
   "skywatcher.nextFewHours": "数時間後",
   "skywatcher.forecast": "天気予報",
   "skywatcher.now": "現在",

--- a/src/Aetherphone/Localization/pt.json
+++ b/src/Aetherphone/Localization/pt.json
@@ -1722,7 +1722,7 @@
   "photos.recents": "Recentes",
   "photos.today": "Hoje",
   "photos.yesterday": "Ontem",
-  "photos.openFolder": "",
+  "photos.openFolder": "Abrir pasta",
   "skywatcher.nextFewHours": "Próximas horas",
   "skywatcher.forecast": "Previsão",
   "skywatcher.now": "Agora",

--- a/src/Aetherphone/Localization/pt.json
+++ b/src/Aetherphone/Localization/pt.json
@@ -1722,6 +1722,7 @@
   "photos.recents": "Recentes",
   "photos.today": "Hoje",
   "photos.yesterday": "Ontem",
+  "photos.openFolder": "",
   "skywatcher.nextFewHours": "Próximas horas",
   "skywatcher.forecast": "Previsão",
   "skywatcher.now": "Agora",

--- a/src/Aetherphone/Localization/ru.json
+++ b/src/Aetherphone/Localization/ru.json
@@ -1722,7 +1722,7 @@
   "photos.recents": "Недавние",
   "photos.today": "Сегодня",
   "photos.yesterday": "Вчера",
-  "photos.openFolder": "",
+  "photos.openFolder": "Открыть папку",
   "skywatcher.nextFewHours": "Ближайшие часы",
   "skywatcher.forecast": "Прогноз",
   "skywatcher.now": "Сейчас",

--- a/src/Aetherphone/Localization/ru.json
+++ b/src/Aetherphone/Localization/ru.json
@@ -1722,6 +1722,7 @@
   "photos.recents": "Недавние",
   "photos.today": "Сегодня",
   "photos.yesterday": "Вчера",
+  "photos.openFolder": "",
   "skywatcher.nextFewHours": "Ближайшие часы",
   "skywatcher.forecast": "Прогноз",
   "skywatcher.now": "Сейчас",

--- a/src/Aetherphone/Localization/tr.json
+++ b/src/Aetherphone/Localization/tr.json
@@ -1722,6 +1722,7 @@
   "photos.recents": "Son Öğeler",
   "photos.today": "Bugün",
   "photos.yesterday": "Dün",
+  "photos.openFolder": "",
   "skywatcher.nextFewHours": "Önümüzdeki Saatler",
   "skywatcher.forecast": "Tahmin",
   "skywatcher.now": "Şimdi",

--- a/src/Aetherphone/Localization/tr.json
+++ b/src/Aetherphone/Localization/tr.json
@@ -1722,7 +1722,7 @@
   "photos.recents": "Son Öğeler",
   "photos.today": "Bugün",
   "photos.yesterday": "Dün",
-  "photos.openFolder": "",
+  "photos.openFolder": "Klasörü aç",
   "skywatcher.nextFewHours": "Önümüzdeki Saatler",
   "skywatcher.forecast": "Tahmin",
   "skywatcher.now": "Şimdi",

--- a/src/Aetherphone/Localization/zh.json
+++ b/src/Aetherphone/Localization/zh.json
@@ -1722,7 +1722,7 @@
   "photos.recents": "最近项目",
   "photos.today": "今天",
   "photos.yesterday": "昨天",
-  "photos.openFolder": "",
+  "photos.openFolder": "打开文件夹",
   "skywatcher.nextFewHours": "接下来的几个小时",
   "skywatcher.forecast": "天气预报",
   "skywatcher.now": "当前",

--- a/src/Aetherphone/Localization/zh.json
+++ b/src/Aetherphone/Localization/zh.json
@@ -1722,6 +1722,7 @@
   "photos.recents": "最近项目",
   "photos.today": "今天",
   "photos.yesterday": "昨天",
+  "photos.openFolder": "",
   "skywatcher.nextFewHours": "接下来的几个小时",
   "skywatcher.forecast": "天气预报",
   "skywatcher.now": "当前",

--- a/src/Aetherphone/Windows/UrlActions.cs
+++ b/src/Aetherphone/Windows/UrlActions.cs
@@ -24,6 +24,23 @@ internal static class UrlActions
         }
     }
 
+    public static void OpenFolder(string path)
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = path,
+                UseShellExecute = true
+            });
+
+        }
+        catch (Exception e)
+        {
+            Plugin.Log.Error($"Failed to open the folder: {path}", e);
+        }
+    }
+
     private static bool IsWebUrl(string url)
     {
         if (!Uri.TryCreate(url, UriKind.Absolute, out var parsed))

--- a/src/Aetherphone/Windows/UrlActions.cs
+++ b/src/Aetherphone/Windows/UrlActions.cs
@@ -35,9 +35,9 @@ internal static class UrlActions
             });
 
         }
-        catch (Exception e)
+        catch (Exception exception)
         {
-            Plugin.Log.Error($"Failed to open the folder: {path}", e);
+            Plugin.Log.Error(exception, $"Failed to open the folder: {path}");
         }
     }
 


### PR DESCRIPTION
## What

This adds a simple button in the photos app that allows the user to open the folder where the images are stored in.

## Why

It was suggested in one or more feature requests.

## Important
The translation keys exist, but **are not filled out** for all languages except english and german.

## How to test

1. Open the phone via any preferred method
2. Open the Photos app
3. Click the wonderful button in the bottom right **while** on the library tab.

## Checklist

- [x] `dotnet build -c Release` passes
- [x] Verified in-game: opened the phone and exercised the affected app/screen
- [x] If this changes user-visible behavior, README is updated
- [x] Matches existing style: uses the shared `Windows/Components/` widgets, no `what` comments
