### PR TITLE
Fix Music app favorite star not working on station rows

### DIFF
--- a/src/Aetherphone/Apps/Music/MusicApp.Home.cs
+++ b/src/Aetherphone/Apps/Music/MusicApp.Home.cs
@@ -432,6 +432,7 @@ internal sealed partial class MusicApp
         }
 
         var favoriteStar = false;
+        var overStar = false;
         var isFavoriteStation = favoriteRadioStations.Contains(station);
 
         if (isFavoriteStation || hovered)
@@ -439,6 +440,9 @@ internal sealed partial class MusicApp
             var tooltip = Loc.T(isFavoriteStation ? L.Music.RemoveFavoriteStation : L.Music.AddFavoriteStation);
 
             var starX = current ? max.X - 36f * scale : max.X - 18f * scale;
+            var starY = min.Y + rowHeight * 0.5f;
+            overStar = UiInteract.Hover(new Vector2(starX - 14f * scale, starY - 14f * scale),
+                new Vector2(starX + 14f * scale, starY + 14f * scale));
             favoriteStar = ui.IconButton(new Vector2(starX, min.Y + rowHeight * 0.5f), 14f * scale,
                 FontAwesomeIcon.Star.ToIconString(), isFavoriteStation ? ui.Accent : ui.MutedInk, AppSkin.Transparent,
                 0.82f, tooltip);
@@ -450,8 +454,7 @@ internal sealed partial class MusicApp
 
         ImGui.SetCursorScreenPos(origin);
         ImGui.Dummy(new Vector2(width, rowHeight));
-        var rowClicked = UiInteract.Click(min, max, hovered);
-        if (favoriteStar || !rowClicked)
+        if (overStar || !UiInteract.Click(min, max, hovered))
         {
             return;
         }


### PR DESCRIPTION
## What

Change star click detection to UiInteract and check for it before play check is done.

## Why

UiInteract.Click was claiming the click before star's logic happened after https://github.com/XeldarAlz/FFXIV-Aetherphone/pull/42 which made the star completely ignored on station list view

## Test

1. open phone
2. navigate to Music app
3. navigate to any radio category
4. click on the star next to any radio station


## Checklist

- [x] `dotnet build -c Release` passes
- [x] Verified in-game: opened the phone and exercised the affected app/screen
- [x] If this changes user-visible behavior, README is updated
- [x] Matches existing style: uses the shared `Windows/Components/` widgets, no `what` comments
