### PR TITLE
Add Health: a first-party activity & wellness app for your character

### DIFF
--- a/src/Aetherphone/Apps/AppStore/AppStoreCatalog.cs
+++ b/src/Aetherphone/Apps/AppStore/AppStoreCatalog.cs
@@ -54,6 +54,7 @@ internal static class AppStoreCatalog
         ["inventory"] = new(L.StoreCopy.InventorySub, L.StoreCopy.InventoryBody, StoreCategory.Adventure),
         ["jobs"] = new(L.StoreCopy.JobsSub, L.StoreCopy.JobsBody, StoreCategory.Adventure),
         ["character"] = new(L.StoreCopy.CharacterSub, L.StoreCopy.CharacterBody, StoreCategory.Adventure),
+        ["health"] = new(L.StoreCopy.HealthSub, L.StoreCopy.HealthBody, StoreCategory.Adventure),
         ["wallet"] = new(L.StoreCopy.WalletSub, L.StoreCopy.WalletBody, StoreCategory.Adventure),
         ["market"] = new(L.StoreCopy.MarketSub, L.StoreCopy.MarketBody, StoreCategory.Adventure),
         ["dailies"] = new(L.StoreCopy.DailiesSub, L.StoreCopy.DailiesBody, StoreCategory.Adventure),

--- a/src/Aetherphone/Apps/Health/HealthApp.Pages.cs
+++ b/src/Aetherphone/Apps/Health/HealthApp.Pages.cs
@@ -1,0 +1,1214 @@
+using System.Globalization;
+using Aetherphone.Core;
+using Aetherphone.Core.Confirm;
+using Aetherphone.Core.Health;
+using Aetherphone.Windows.Components;
+using Dalamud.Bindings.ImGui;
+using Dalamud.Interface;
+using Dalamud.Interface.Utility.Raii;
+
+namespace Aetherphone.Apps.Health;
+
+internal sealed partial class HealthApp
+{
+    private static readonly string[] DrinkKinds = { "Water", "Tea", "Coffee", "Juice" };
+    private static readonly string[] UnitLabels = { "Eorzean", "Metric", "Imperial" };
+    private static readonly string[] ScopeLabels = { "Daily", "Weekly", "Session", "All-time" };
+
+    // ---- Setup (stepped registration wizard) --------------------------------
+
+    private const int SetupSteps = 5;
+    private int setupStep;
+
+    private static readonly string[] SetupSubtitles =
+    {
+        "Let's set up your adventurer's health profile.",
+        "Choose your daily expedition goals.",
+        "Optional fictional energy estimates.",
+        "Tune how travel becomes estimated steps.",
+        "Review your profile and begin.",
+    };
+
+    private void DrawSetup(float scale)
+    {
+        var width = ImGui.GetContentRegionAvail().X;
+        DrawStepDots(scale);
+
+        var origin = ImGui.GetCursorScreenPos();
+        var centerX = origin.X + width * 0.5f;
+        Typography.DrawCentered(new Vector2(centerX, origin.Y + 14f * scale), "Welcome, Adventurer!", Pal.TitleInk,
+            TextStyles.Title2);
+        Typography.DrawCentered(new Vector2(centerX, origin.Y + 40f * scale), SetupSubtitles[setupStep], Pal.MutedInk,
+            TextStyles.Subheadline);
+        ImGui.SetCursorScreenPos(origin);
+        ImGui.Dummy(new Vector2(width, 60f * scale));
+
+        switch (setupStep)
+        {
+            case 0: SetupUnits(scale); break;
+            case 1: SetupGoals(scale); break;
+            case 2: SetupEnergy(scale); break;
+            case 3: SetupMovement(scale); break;
+            default: SetupReview(scale); break;
+        }
+
+        ImGui.Dummy(new Vector2(0f, 8f * scale));
+        SetupNav(scale);
+    }
+
+    private void SetupUnits(float scale)
+    {
+        DrawSummaryCard(scale);
+        StepLabel("Preferred units", scale);
+        if (RadioRow("Eorzean", "Yalms / Malms / Ponz", U == HealthUnits.Eorzean, scale))
+        {
+            SetUnits(HealthUnits.Eorzean);
+        }
+
+        if (RadioRow("Metric", "Metres / km / kg / ml", U == HealthUnits.Metric, scale))
+        {
+            SetUnits(HealthUnits.Metric);
+        }
+
+        if (RadioRow("Imperial", "Feet / miles / lb / fl oz", U == HealthUnits.Imperial, scale))
+        {
+            SetUnits(HealthUnits.Imperial);
+        }
+    }
+
+    private void SetUnits(HealthUnits units)
+    {
+        if (Profile.Units == units)
+        {
+            return;
+        }
+
+        Profile.Units = units;
+        tracker.SaveNow();
+    }
+
+    private void SetupGoals(float scale)
+    {
+        StepLabel("Daily goals", scale);
+        var steps = IntField("Steps", "##hp.setup.steps", Profile.DailyStepGoal, 1000, 1000, 100000, scale);
+        if (steps != Profile.DailyStepGoal)
+        {
+            Profile.DailyStepGoal = steps;
+            tracker.MarkDirty();
+        }
+
+        var swim = FloatField("Swimming (yalms)", "##hp.setup.swim", Profile.DailySwimGoalYalms, 100, 100, 100000,
+            "%.0f", scale);
+        if (Math.Abs(swim - Profile.DailySwimGoalYalms) > 0.01)
+        {
+            Profile.DailySwimGoalYalms = swim;
+            tracker.MarkDirty();
+        }
+
+        var drinks = IntField("Hydration (drinks)", "##hp.setup.drinks", Profile.DailyHydrationGoal, 1, 1, 20, scale);
+        if (drinks != Profile.DailyHydrationGoal)
+        {
+            Profile.DailyHydrationGoal = drinks;
+            tracker.MarkDirty();
+        }
+    }
+
+    private void SetupEnergy(float scale)
+    {
+        StepLabel("Fictional energy", scale);
+        ui.HelpText("Character weight is optional and used only for fictional activity-energy estimates.");
+        ui.LabelValue("Current", Profile.WeightKg is { } kg ? HealthFormat.Weight(kg, U) : "not set");
+        ui.Field($"Weight ({WeightUnitLabel()})", "##health.setup.weight", ref weightBuffer, 8, false);
+        if (WideButton("Set weight", false, scale, 30f) &&
+            double.TryParse(weightBuffer, NumberStyles.Any, CultureInfo.CurrentCulture, out var value) && value > 0)
+        {
+            Profile.WeightKg = HealthFormat.WeightToKg(value, U);
+            tracker.SaveNow();
+        }
+
+        DrawWeightSuggestions(scale);
+
+        var calories = Profile.CaloriesEnabled;
+        ui.ToggleRow("Estimate activity energy", ref calories);
+        if (calories != Profile.CaloriesEnabled)
+        {
+            Profile.CaloriesEnabled = calories;
+            tracker.MarkDirty();
+        }
+    }
+
+    private void SetupMovement(float scale)
+    {
+        StepLabel("Movement", scale);
+        ui.LabelValue("Height", $"{HealthFormat.Height(tracker.HeightCm, U)} · {tracker.HeightSource}");
+        var strideDelta = StepperRow("Yalms per step",
+            Profile.StrideYalms.ToString("0.00", CultureInfo.CurrentCulture), scale);
+        if (strideDelta != 0)
+        {
+            Profile.StrideYalms = Math.Clamp(Profile.StrideYalms + strideDelta * 0.05, 0.30, 1.50);
+            tracker.MarkDirty();
+        }
+
+        if (WideButton("Suggest stride from height", false, scale, 30f))
+        {
+            Profile.StrideYalms = HealthFormat.SuggestStride(tracker.HeightCm);
+            tracker.SaveNow();
+        }
+
+        ui.HelpText("Only walking and running produce estimated steps. Raw distance is stored, so changing stride never loses progress.");
+    }
+
+    private void SetupReview(float scale)
+    {
+        StepLabel("Review", scale);
+        var card = BeginCard(6, 38f, scale);
+        KeyRow(CardRow(card, 0, 38f, scale), "Units", UnitLabels[(int)U], scale);
+        KeyRow(CardRow(card, 1, 38f, scale), "Steps goal", HealthFormat.Number(Profile.DailyStepGoal), scale);
+        KeyRow(CardRow(card, 2, 38f, scale), "Swim goal", Dist(Profile.DailySwimGoalYalms), scale);
+        KeyRow(CardRow(card, 3, 38f, scale), "Hydration goal", $"{Profile.DailyHydrationGoal} drinks", scale);
+        KeyRow(CardRow(card, 4, 38f, scale), "Weight",
+            Profile.WeightKg is { } kg ? HealthFormat.Weight(kg, U) : "not set", scale);
+        KeyRow(CardRow(card, 5, 38f, scale), "Energy estimates", Profile.CaloriesEnabled ? "On" : "Off", scale);
+        EndCard(card, scale);
+        ui.HelpText("Health tracks fictional activity performed by your FFXIV character. Its values are estimates intended for roleplay and statistics.");
+    }
+
+    private void SetupNav(float scale)
+    {
+        var width = ImGui.GetContentRegionAvail().X;
+        var origin = ImGui.GetCursorScreenPos();
+        var height = 44f * scale;
+        var gap = 10f * scale;
+        var last = setupStep >= SetupSteps - 1;
+
+        if (setupStep > 0)
+        {
+            var half = (width - gap) * 0.5f;
+            var backRect = new Rect(origin, origin + new Vector2(half, height));
+            var nextRect = new Rect(new Vector2(origin.X + half + gap, origin.Y),
+                new Vector2(origin.X + width, origin.Y + height));
+            if (AppSkin.PillButton(backRect, "Back", false, true, ui.Theme))
+            {
+                setupStep--;
+            }
+
+            if (AppSkin.PillButton(nextRect, last ? "Begin" : "Next", true, true, ui.Theme))
+            {
+                Advance(last);
+            }
+        }
+        else
+        {
+            var nextRect = new Rect(origin, origin + new Vector2(width, height));
+            if (AppSkin.PillButton(nextRect, "Next", true, true, ui.Theme))
+            {
+                Advance(false);
+            }
+        }
+
+        ImGui.SetCursorScreenPos(origin);
+        ImGui.Dummy(new Vector2(width, height + 8f * scale));
+    }
+
+    private void Advance(bool finish)
+    {
+        if (finish)
+        {
+            Profile.SetupCompleted = true;
+            if (Profile.Goals.Count == 0)
+            {
+                Profile.Goals = HealthTracker.DefaultGoals();
+            }
+
+            setupStep = 0;
+            tracker.SaveNow();
+            return;
+        }
+
+        setupStep = Math.Min(setupStep + 1, SetupSteps - 1);
+    }
+
+    private void DrawStepDots(float scale)
+    {
+        var width = ImGui.GetContentRegionAvail().X;
+        var origin = ImGui.GetCursorScreenPos();
+        var drawList = ImGui.GetWindowDrawList();
+        var radius = 12f * scale;
+        var padX = radius + 6f * scale;
+        var usable = width - 2f * padX;
+        var cy = origin.Y + radius + 4f * scale;
+        var accent = ImGui.GetColorU32(Pal.Accent);
+        var idle = ImGui.GetColorU32(Pal.FieldSurface);
+
+        for (var index = 0; index < SetupSteps - 1; index++)
+        {
+            var x0 = origin.X + padX + usable * (index / (float)(SetupSteps - 1));
+            var x1 = origin.X + padX + usable * ((index + 1) / (float)(SetupSteps - 1));
+            drawList.AddLine(new Vector2(x0, cy), new Vector2(x1, cy), index < setupStep ? accent : idle, 2f * scale);
+        }
+
+        for (var index = 0; index < SetupSteps; index++)
+        {
+            var cx = origin.X + padX + usable * (index / (float)(SetupSteps - 1));
+            var center = new Vector2(cx, cy);
+            var done = index <= setupStep;
+            drawList.AddCircleFilled(center, radius, done ? accent : idle, 24);
+            Typography.DrawCentered(center, (index + 1).ToString(CultureInfo.InvariantCulture),
+                done ? new Vector4(1f, 1f, 1f, 1f) : Pal.MutedInk, TextStyles.Caption1);
+        }
+
+        ImGui.SetCursorScreenPos(origin);
+        ImGui.Dummy(new Vector2(width, radius * 2f + 14f * scale));
+    }
+
+    private void DrawSummaryCard(float scale)
+    {
+        var player = gameData.LocalPlayer;
+        var name = player?.Name.TextValue ?? "Adventurer";
+        var world = player is not null ? gameData.WorldName(player.HomeWorld.RowId) : string.Empty;
+        ReadIdentity(out var race, out var clan);
+        var raceClan = race.Length > 0 && clan.Length > 0 ? $"{race} / {clan}" : race.Length > 0 ? race : "—";
+
+        ui.SectionLabel("Profile summary", TextStyles.FootnoteEmphasized, 4f);
+        var card = BeginCard(4, 40f, scale);
+        KeyRow(CardRow(card, 0, 40f, scale), "Name", name, scale);
+        KeyRow(CardRow(card, 1, 40f, scale), "World", world.Length > 0 ? world : "—", scale);
+        KeyRow(CardRow(card, 2, 40f, scale), "Race / Clan", raceClan, scale);
+        KeyRow(CardRow(card, 3, 40f, scale), "Height", $"{HealthFormat.Height(tracker.HeightCm, U)} · {tracker.HeightSource}",
+            scale);
+        EndCard(card, scale);
+    }
+
+    private void KeyRow(Rect row, string label, string value, float scale)
+    {
+        var labelSize = Typography.Measure(label, TextStyles.Subheadline);
+        Typography.Draw(new Vector2(row.Min.X, row.Center.Y - labelSize.Y * 0.5f), label, Pal.MutedInk,
+            TextStyles.Subheadline);
+        var valueSize = Typography.Measure(value, TextStyles.Headline);
+        Typography.Draw(new Vector2(row.Max.X - valueSize.X, row.Center.Y - valueSize.Y * 0.5f), value, Pal.TitleInk,
+            TextStyles.Headline);
+    }
+
+    private void StepLabel(string text, float scale)
+    {
+        ui.SectionLabel($"Step {setupStep + 1} of {SetupSteps}  ·  {text}", TextStyles.FootnoteEmphasized, 8f);
+    }
+
+    private bool RadioRow(string title, string subtitle, bool selected, float scale)
+    {
+        var width = ImGui.GetContentRegionAvail().X;
+        var origin = ImGui.GetCursorScreenPos();
+        var height = 48f * scale;
+        var min = origin;
+        var max = origin + new Vector2(width, height);
+        var drawList = ImGui.GetWindowDrawList();
+        var hovered = ImGui.IsMouseHoveringRect(min, max);
+        var fill = selected ? Pal.Accent with { W = 0.18f } : Pal.FieldSurface with { W = Pal.FieldSurface.W * (hovered ? 1.4f : 1f) };
+        drawList.AddRectFilled(min, max, ImGui.GetColorU32(fill), 12f * scale);
+        if (selected)
+        {
+            drawList.AddRect(min, max, ImGui.GetColorU32(Pal.Accent), 12f * scale, ImDrawFlags.RoundCornersAll, 1.5f * scale);
+        }
+
+        var cy = origin.Y + height * 0.5f;
+        var cx = origin.X + 20f * scale;
+        var ring = 8f * scale;
+        drawList.AddCircle(new Vector2(cx, cy), ring, ImGui.GetColorU32(selected ? Pal.Accent : Pal.MutedInk), 24,
+            2f * scale);
+        if (selected)
+        {
+            drawList.AddCircleFilled(new Vector2(cx, cy), ring * 0.5f, ImGui.GetColorU32(Pal.Accent), 16);
+        }
+
+        var textLeft = cx + 18f * scale;
+        if (subtitle.Length > 0)
+        {
+            Typography.Draw(new Vector2(textLeft, cy - 15f * scale), title, Pal.TitleInk, TextStyles.Headline);
+            Typography.Draw(new Vector2(textLeft, cy + 3f * scale), subtitle, Pal.MutedInk, TextStyles.Footnote);
+        }
+        else
+        {
+            var size = Typography.Measure(title, TextStyles.Headline);
+            Typography.Draw(new Vector2(textLeft, cy - size.Y * 0.5f), title, Pal.TitleInk, TextStyles.Headline);
+        }
+
+        ImGui.SetCursorScreenPos(origin);
+        ImGui.Dummy(new Vector2(width, height + 8f * scale));
+        return hovered && ImGui.IsMouseClicked(ImGuiMouseButton.Left);
+    }
+
+    // ---- Hydration ----------------------------------------------------------
+
+    private void DrawHydration(float scale)
+    {
+        var day = Profile.LatestDay ?? new HealthDay();
+        var origin = ImGui.GetCursorScreenPos();
+        var width = ImGui.GetContentRegionAvail().X;
+        Typography.DrawCentered(new Vector2(origin.X + width * 0.5f, origin.Y + 14f * scale),
+            $"{day.DrinkCount} / {Profile.DailyHydrationGoal} drinks today", Pal.TitleInk, TextStyles.Title3);
+        ImGui.SetCursorScreenPos(origin);
+        ImGui.Dummy(new Vector2(width, 34f * scale));
+
+        if (WideButton("Drink Water", true, scale, 46f))
+        {
+            tracker.LogDrink("Water", 250);
+        }
+
+        // Quick drink
+        var chipOrigin = ImGui.GetCursorScreenPos();
+        var centerY = chipOrigin.Y + 16f * scale;
+        var cursorX = chipOrigin.X;
+        for (var index = 0; index < DrinkKinds.Length; index++)
+        {
+            if (ui.FlowChip(ref cursorX, centerY, 8f * scale, DrinkKinds[index], false))
+            {
+                tracker.LogDrink(DrinkKinds[index], 250);
+            }
+        }
+
+        ImGui.SetCursorScreenPos(chipOrigin);
+        ImGui.Dummy(new Vector2(width, 40f * scale));
+
+        ui.SectionLabel("Custom drink", TextStyles.FootnoteEmphasized, 6f);
+        ui.Field("Name", "##health.customName", ref customDrinkName, 24, false);
+        var serving = IntField("Serving (ml)", "##hp.water.serving", customDrinkMl, 50, 50, 2000, scale);
+        if (serving != customDrinkMl)
+        {
+            customDrinkMl = serving;
+        }
+
+        if (WideButton("Log custom drink", false, scale))
+        {
+            tracker.LogDrink(customDrinkName.Length > 0 ? customDrinkName : "Drink", customDrinkMl);
+        }
+
+        if (WideButton("Undo last drink", false, scale))
+        {
+            tracker.UndoLastDrink();
+        }
+
+        var goalDrinks = IntField("Daily goal (drinks)", "##hp.water.goal", Profile.DailyHydrationGoal, 1, 1, 20, scale);
+        if (goalDrinks != Profile.DailyHydrationGoal)
+        {
+            Profile.DailyHydrationGoal = goalDrinks;
+            tracker.SaveNow();
+        }
+
+        ui.SectionLabel("Today", TextStyles.FootnoteEmphasized, 6f);
+        if (day.Drinks.Count == 0)
+        {
+            ui.HelpText("No drinks logged yet today.");
+        }
+        else
+        {
+            for (var index = day.Drinks.Count - 1; index >= 0; index--)
+            {
+                var entry = day.Drinks[index];
+                var time = DateTimeOffset.FromUnixTimeSeconds(entry.Unix).LocalDateTime.ToString("HH:mm",
+                    CultureInfo.InvariantCulture);
+                ui.LabelValue($"{time}  {entry.Kind}", HealthFormat.Volume(entry.Millilitres, U));
+            }
+        }
+
+        DrawReminderSettings(scale);
+    }
+
+    private void DrawReminderSettings(float scale)
+    {
+        ui.SectionLabel("Reminders", TextStyles.FootnoteEmphasized, 8f);
+        var enabled = Profile.HydrationRemindersEnabled;
+        ui.ToggleRow("Hydration reminders", ref enabled);
+        if (enabled != Profile.HydrationRemindersEnabled)
+        {
+            Profile.HydrationRemindersEnabled = enabled;
+            tracker.SaveNow();
+        }
+
+        if (!Profile.HydrationRemindersEnabled)
+        {
+            return;
+        }
+
+        var every = IntField("Every (min)", "##hp.remind.every", Profile.ReminderIntervalMinutes, 5, 1, 720, scale);
+        if (every != Profile.ReminderIntervalMinutes)
+        {
+            Profile.ReminderIntervalMinutes = every;
+            tracker.SaveNow();
+        }
+
+        var (fromHour, fromMinute) = TimeField("Quiet from", "##hp.remind.from", Profile.QuietStartHour,
+            Profile.QuietStartMinute, scale);
+        if (fromHour != Profile.QuietStartHour || fromMinute != Profile.QuietStartMinute)
+        {
+            Profile.QuietStartHour = fromHour;
+            Profile.QuietStartMinute = fromMinute;
+            tracker.SaveNow();
+        }
+
+        var (untilHour, untilMinute) = TimeField("Quiet until", "##hp.remind.until", Profile.QuietEndHour,
+            Profile.QuietEndMinute, scale);
+        if (untilHour != Profile.QuietEndHour || untilMinute != Profile.QuietEndMinute)
+        {
+            Profile.QuietEndHour = untilHour;
+            Profile.QuietEndMinute = untilMinute;
+            tracker.SaveNow();
+        }
+
+        var pause = Profile.ReminderPauseInDuties;
+        ui.ToggleRow("Pause during combat / duties", ref pause);
+        if (pause != Profile.ReminderPauseInDuties)
+        {
+            Profile.ReminderPauseInDuties = pause;
+            tracker.SaveNow();
+        }
+    }
+
+    // ---- Goals --------------------------------------------------------------
+
+    private void DrawGoals(float scale)
+    {
+        for (var index = 0; index < Profile.Goals.Count; index++)
+        {
+            var goal = Profile.Goals[index];
+            GoalBar(goal, scale);
+            if (editingGoalId == goal.Id)
+            {
+                DrawGoalEditor(goal, scale);
+            }
+            else if (WideButton(goal.Enabled ? "Edit" : "Edit (disabled)", false, scale, 30f))
+            {
+                editingGoalId = goal.Id;
+                goalNameBuffer = goal.Name;
+            }
+
+            ImGui.Dummy(new Vector2(0f, 6f * scale));
+        }
+
+        if (WideButton("Add goal", true, scale))
+        {
+            var goal = new HealthGoal { Name = "New goal", Type = HealthGoalType.Steps, Target = 1000 };
+            Profile.Goals.Add(goal);
+            editingGoalId = goal.Id;
+            goalNameBuffer = goal.Name;
+            tracker.SaveNow();
+        }
+
+        if (WideButton("Reset to default goals", false, scale))
+        {
+            confirm.Ask(new ConfirmRequest
+            {
+                Title = "Reset goals",
+                Message = "Replace your goals with the defaults?",
+                ConfirmLabel = "Reset",
+                CancelLabel = "Cancel",
+                Confirm = () =>
+                {
+                    Profile.Goals = HealthTracker.DefaultGoals();
+                    editingGoalId = null;
+                    tracker.SaveNow();
+                },
+            });
+        }
+    }
+
+    private void DrawGoalEditor(HealthGoal goal, float scale)
+    {
+        ui.Field("Name", "##health.goalName", ref goalNameBuffer, 40, false);
+
+        var typeDelta = StepperRow("Type", GoalTypeLabel(goal.Type), scale);
+        if (typeDelta != 0)
+        {
+            goal.Type = Cycle(goal.Type, typeDelta);
+            tracker.SaveNow();
+        }
+
+        var scopeDelta = StepperRow("Scope", ScopeLabels[(int)goal.Scope], scale);
+        if (scopeDelta != 0)
+        {
+            goal.Scope = (HealthGoalScope)(((int)goal.Scope + scopeDelta + 4) % 4);
+            tracker.SaveNow();
+        }
+
+        var target = FloatField("Target", "##hp.goalTarget", goal.Target, GoalStep(goal.Type), 1, 10_000_000,
+            "%.0f", scale);
+        if (Math.Abs(target - goal.Target) > 0.001)
+        {
+            goal.Target = target;
+            goal.CompletedKey = string.Empty;
+            tracker.SaveNow();
+        }
+
+        var enabled = goal.Enabled;
+        ui.ToggleRow("Enabled", ref enabled);
+        if (enabled != goal.Enabled)
+        {
+            goal.Enabled = enabled;
+            tracker.SaveNow();
+        }
+
+        if (WideButton("Delete goal", false, scale, 30f))
+        {
+            Profile.Goals.Remove(goal);
+            editingGoalId = null;
+            tracker.SaveNow();
+            return;
+        }
+
+        if (WideButton("Done", true, scale, 30f))
+        {
+            goal.Name = goalNameBuffer.Length > 0 ? goalNameBuffer : "Goal";
+            editingGoalId = null;
+            tracker.SaveNow();
+        }
+    }
+
+    private static string GoalTypeLabel(HealthGoalType type) => type switch
+    {
+        HealthGoalType.Steps => "Steps",
+        HealthGoalType.OnFootDistance => "On-foot distance",
+        HealthGoalType.WalkDistance => "Walking distance",
+        HealthGoalType.RunDistance => "Running distance",
+        HealthGoalType.SwimDistance => "Swimming distance",
+        HealthGoalType.ActiveTime => "Active time",
+        HealthGoalType.HydrationCount => "Drinks logged",
+        HealthGoalType.HydrationVolume => "Drink volume",
+        HealthGoalType.Teleports => "Teleports",
+        HealthGoalType.TeleportDistance => "Teleport distance",
+        _ => "Est. energy",
+    };
+
+    private static double GoalStep(HealthGoalType type) => type switch
+    {
+        HealthGoalType.Steps => 500,
+        HealthGoalType.ActiveTime => 300,
+        HealthGoalType.HydrationCount or HealthGoalType.Teleports => 1,
+        HealthGoalType.HydrationVolume => 250,
+        HealthGoalType.Calories => 50,
+        _ => 100,
+    };
+
+    private static HealthGoalType Cycle(HealthGoalType type, int delta)
+    {
+        var count = Enum.GetValues<HealthGoalType>().Length;
+        return (HealthGoalType)(((int)type + delta + count) % count);
+    }
+
+    // ---- History ------------------------------------------------------------
+
+    private void DrawHistory(float scale)
+    {
+        var days = Profile.Days;
+        if (days.Count == 0)
+        {
+            ui.HelpText("No activity recorded yet.");
+            return;
+        }
+
+        var shown = 0;
+        for (var index = days.Count - 1; index >= 0 && shown < 7; index--, shown++)
+        {
+            var day = days[index];
+            var steps = HealthFormat.Steps(day.OnFootYalms, Profile.StrideYalms);
+            ui.SectionLabel($"{FormatDate(day.Date)}  ·  {day.GoalsCompleted} goals · {day.Teleports} tp",
+                TextStyles.FootnoteEmphasized, 6f);
+            var card = BeginCard(4, CompactRowHeight, scale);
+            StatRow(CardRow(card, 0, CompactRowHeight, scale), Accent1, FontAwesomeIcon.Walking,
+                $"{HealthFormat.Number(steps)} steps", Dist(day.OnFootYalms), scale);
+            StatRow(CardRow(card, 1, CompactRowHeight, scale), Accent2, FontAwesomeIcon.Clock,
+                "Active", HealthFormat.Duration(day.ActiveSeconds), scale);
+            StatRow(CardRow(card, 2, CompactRowHeight, scale), Accent4, FontAwesomeIcon.Tint,
+                "Hydration", $"{day.DrinkCount} drinks", scale);
+            var kcal = Profile.CaloriesEnabled ? $"{day.Calories:0} kcal" : "—";
+            StatRow(CardRow(card, 3, CompactRowHeight, scale), Accent3, FontAwesomeIcon.Fire, "Energy", kcal, scale);
+            EndCard(card, scale);
+        }
+    }
+
+    private static string FormatDate(string key)
+    {
+        return DateTime.TryParseExact(key, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None,
+            out var parsed)
+            ? parsed.ToString("ddd, MMM d", CultureInfo.InvariantCulture)
+            : key;
+    }
+
+    // ---- Profile / Settings -------------------------------------------------
+
+    private void DrawProfile(float scale)
+    {
+        DrawSummaryCard(scale);
+
+        BeginPanel("Height", scale);
+        InfoRow("Reading", $"{HealthFormat.Height(tracker.HeightCm, U)}  ·  {tracker.HeightSource}", scale);
+        if (WideButton("Refresh height", false, scale, 30f))
+        {
+            tracker.RefreshHeight();
+        }
+
+        var autoHeight = PanelToggle("Auto-refresh on change", Profile.AutoRefreshHeight, scale);
+        if (autoHeight != Profile.AutoRefreshHeight)
+        {
+            Profile.AutoRefreshHeight = autoHeight;
+            tracker.SaveNow();
+        }
+
+        var manualDelta = StepperRow("Manual override (cm)",
+            Profile.ManualHeightCm is { } m ? $"{m:0.0}" : "off", scale);
+        if (manualDelta != 0)
+        {
+            var baseCm = Profile.ManualHeightCm ?? (tracker.HeightCm > 0 ? tracker.HeightCm : 170);
+            Profile.ManualHeightCm = Math.Clamp(baseCm + manualDelta * 0.5, 50, 260);
+            tracker.RefreshHeight();
+            tracker.SaveNow();
+        }
+
+        if (Profile.ManualHeightCm is not null && WideButton("Clear override", false, scale, 30f))
+        {
+            Profile.ManualHeightCm = null;
+            tracker.RefreshHeight();
+            tracker.SaveNow();
+        }
+
+        EndPanel(scale);
+
+        BeginPanel("Fictional weight", scale);
+        InfoRow("Current", Profile.WeightKg is { } kg ? HealthFormat.Weight(kg, U) : "not set", scale);
+        PanelField($"Enter weight ({WeightUnitLabel()})", "##health.weight", ref weightBuffer, 8, scale);
+        if (WideButton("Set weight", false, scale, 30f) &&
+            double.TryParse(weightBuffer, NumberStyles.Any, CultureInfo.CurrentCulture, out var value) && value > 0)
+        {
+            Profile.WeightKg = HealthFormat.WeightToKg(value, U);
+            tracker.SaveNow();
+        }
+
+        if (Profile.WeightKg is not null && WideButton("Clear weight", false, scale, 30f))
+        {
+            Profile.WeightKg = null;
+            weightBuffer = string.Empty;
+            tracker.SaveNow();
+        }
+
+        DrawWeightSuggestions(scale);
+
+        var calories = PanelToggle("Estimate activity energy", Profile.CaloriesEnabled, scale);
+        if (calories != Profile.CaloriesEnabled)
+        {
+            Profile.CaloriesEnabled = calories;
+            tracker.SaveNow();
+        }
+
+        PanelHint("Character weight is optional and used only for fictional activity-energy estimates.", scale);
+        EndPanel(scale);
+
+        BeginPanel("Units", scale);
+        var units = Segmented("health.units", UnitLabels, (int)U, scale);
+        if (units != (int)U)
+        {
+            Profile.Units = (HealthUnits)units;
+            weightBuffer = string.Empty;
+            tracker.SaveNow();
+        }
+
+        EndPanel(scale);
+
+        BeginPanel("Stride length", scale);
+        var strideDelta = StepperRow("Yalms per step",
+            Profile.StrideYalms.ToString("0.00", CultureInfo.CurrentCulture), scale);
+        if (strideDelta != 0)
+        {
+            Profile.StrideYalms = Math.Clamp(Profile.StrideYalms + strideDelta * 0.05, 0.30, 1.50);
+            tracker.SaveNow();
+        }
+
+        if (WideButton("Suggest from height", false, scale, 30f))
+        {
+            Profile.StrideYalms = HealthFormat.SuggestStride(tracker.HeightCm);
+            tracker.SaveNow();
+        }
+
+        PanelHint("Only walking and running produce steps. Raw distance is stored, so changing stride never loses progress.", scale);
+        EndPanel(scale);
+
+        BeginPanel("Tracking status", scale);
+        InfoRow("Status", tracker.TrackingStatus, scale);
+        EndPanel(scale);
+
+        BeginPanel("Reset", scale);
+        if (WideButton("Reset session", false, scale, 30f))
+        {
+            tracker.ResetSession();
+        }
+
+        if (WideButton("Reset today", false, scale, 30f))
+        {
+            AskReset("Reset today's activity?", tracker.ResetToday);
+        }
+
+        if (WideButton("Reset today's hydration", false, scale, 30f))
+        {
+            AskReset("Clear today's hydration entries?", tracker.ResetTodayHydration);
+        }
+
+        if (WideButton("Reset history", false, scale, 30f))
+        {
+            AskReset("Delete recent activity history?", tracker.ResetHistory);
+        }
+
+        if (WideButton("Reset personal records", false, scale, 30f))
+        {
+            AskReset("Reset personal records?", tracker.ResetRecords);
+        }
+
+        if (WideButton("Reset all Health data", false, scale, 30f))
+        {
+            AskReset("Erase ALL Health data for this character? This cannot be undone.", tracker.ResetAll);
+        }
+
+        EndPanel(scale);
+
+        PanelHint("Health tracks fictional activity performed by your FFXIV character. Its steps, calories, hydration, and wellness values are estimates intended for roleplay and statistics.", scale);
+    }
+
+    private void AskReset(string message, Action confirmed)
+    {
+        confirm.Ask(new ConfirmRequest
+        {
+            Title = "Confirm",
+            Message = message,
+            ConfirmLabel = "Reset",
+            CancelLabel = "Cancel",
+            Confirm = confirmed,
+        });
+    }
+
+    private string WeightUnitLabel() => U switch
+    {
+        HealthUnits.Metric => "kg",
+        HealthUnits.Imperial => "lb",
+        _ => "ponz",
+    };
+
+    // Fictional "normal" weight suggestions derived from the character's height and racial build.
+    // These are only tappable hints; weight is never auto-assigned.
+    private void DrawWeightSuggestions(float scale)
+    {
+        var cm = tracker.HeightCm;
+        if (cm <= 0)
+        {
+            return;
+        }
+
+        PanelLabel("Suggested (tap to use)", scale);
+        foreach (var (label, kg) in WeightSuggestions(cm))
+        {
+            if (WideButton($"{label}  ·  {HealthFormat.Weight(kg, U)}", false, scale, 30f))
+            {
+                Profile.WeightKg = kg;
+                weightBuffer = string.Empty;
+                tracker.SaveNow();
+            }
+        }
+
+        PanelHint("Fictional estimates from your character's height and build.", scale);
+    }
+
+    private void PanelLabel(string text, float scale)
+    {
+        var full = ImGui.GetContentRegionAvail().X;
+        var basePos = ImGui.GetCursorScreenPos();
+        Typography.Draw(new Vector2(basePos.X + groupPad, basePos.Y), text, Pal.MutedInk, TextStyles.Caption1);
+        ImGui.SetCursorScreenPos(basePos);
+        ImGui.Dummy(new Vector2(full, 18f * scale));
+    }
+
+    private (string Label, double Kg)[] WeightSuggestions(double cm)
+    {
+        var metres = cm / 100d;
+        var build = RaceBuildFactor();
+        return new (string, double)[]
+        {
+            ("Lean", Math.Round(19.5 * metres * metres * build)),
+            ("Average", Math.Round(23.0 * metres * metres * build)),
+            ("Sturdy", Math.Round(26.5 * metres * metres * build)),
+        };
+    }
+
+    private double RaceBuildFactor()
+    {
+        var player = gameData.LocalPlayer;
+        if (player is null)
+        {
+            return 1.0;
+        }
+
+        try
+        {
+            var customize = player.Customize;
+            if (customize.Length >= 1)
+            {
+                return customize[0] switch
+                {
+                    3 => 1.12,  // Lalafell — small but stocky
+                    5 => 1.18,  // Roegadyn — heavy, muscular
+                    7 => 1.20,  // Hrothgar — huge, muscular
+                    2 => 0.95,  // Elezen — slender
+                    8 => 0.93,  // Viera — slender
+                    _ => 1.0,   // Hyur, Miqo'te, Au Ra
+                };
+            }
+        }
+        catch
+        {
+            // Appearance unreadable; use a neutral build.
+        }
+
+        return 1.0;
+    }
+
+    private void ReadIdentity(out string race, out string clan)
+    {
+        race = string.Empty;
+        clan = string.Empty;
+        var player = gameData.LocalPlayer;
+        if (player is null)
+        {
+            return;
+        }
+
+        try
+        {
+            var customize = player.Customize;
+            if (customize.Length >= 5)
+            {
+                var female = customize[1] == 1;
+                race = gameData.RaceName(customize[0], female);
+                clan = gameData.ClanName(customize[4], female);
+            }
+        }
+        catch
+        {
+            // Appearance not readable right now; identity stays blank.
+        }
+    }
+
+    // ---- Small controls -----------------------------------------------------
+
+    private int StepperRow(string label, string value, float scale, float rowHeight = 40f)
+    {
+        var full = ImGui.GetContentRegionAvail().X;
+        var basePos = ImGui.GetCursorScreenPos();
+        var origin = new Vector2(basePos.X + groupPad, basePos.Y);
+        var width = full - groupPad * 2f;
+        var row = new Rect(origin, origin + new Vector2(width, rowHeight * scale));
+        Typography.Draw(new Vector2(row.Min.X, row.Center.Y - 8f * scale), label, Pal.BodyInk, TextStyles.Subheadline);
+        var radius = 13f * scale;
+        var plus = new Vector2(row.Max.X - radius, row.Center.Y);
+        var minus = new Vector2(row.Max.X - radius - 96f * scale, row.Center.Y);
+        var valueCenter = new Vector2((plus.X + minus.X) * 0.5f, row.Center.Y);
+        Typography.DrawCentered(valueCenter, value, Pal.TitleInk, 0.95f, FontWeight.SemiBold);
+        var delta = 0;
+        if (ui.IconButton(minus, radius, FontAwesomeIcon.Minus.ToIconString(), Pal.TitleInk, Pal.FieldSurface, 0.5f))
+        {
+            delta--;
+        }
+
+        if (ui.IconButton(plus, radius, FontAwesomeIcon.Plus.ToIconString(), Pal.TitleInk, Pal.FieldSurface, 0.5f))
+        {
+            delta++;
+        }
+
+        ImGui.SetCursorScreenPos(basePos);
+        ImGui.Dummy(new Vector2(full, (rowHeight + 6f) * scale));
+        return delta;
+    }
+
+    private string? activeNumberId;
+
+    private int IntField(string label, string id, int value, int step, int min, int max, float scale)
+    {
+        NumberField(label, scale, out var inputPos, out var inputWidth, out var boxCenter, out var dec, out var inc,
+            out var basePos, out var full, out var rowHeight);
+        var v = Math.Clamp(value + (dec ? -step : 0) + (inc ? step : 0), min, max);
+        var active = activeNumberId == id;
+        ImGui.SetCursorScreenPos(inputPos);
+        using (Plugin.Fonts.Push(TextStyles.Body.Scale, TextStyles.Body.Weight))
+        using (ImRaii.PushColor(ImGuiCol.FrameBg, AppSkin.Transparent))
+        using (ImRaii.PushColor(ImGuiCol.Text, active ? Pal.TitleInk : AppSkin.Transparent))
+        {
+            ImGui.SetNextItemWidth(inputWidth);
+            ImGui.InputInt(id, ref v, 0, 0);
+        }
+
+        UpdateActiveNumber(id);
+        if (activeNumberId != id)
+        {
+            Typography.DrawCentered(boxCenter, v.ToString(CultureInfo.CurrentCulture), Pal.TitleInk,
+                TextStyles.Headline);
+        }
+
+        ImGui.SetCursorScreenPos(basePos);
+        ImGui.Dummy(new Vector2(full, rowHeight));
+        return Math.Clamp(v, min, max);
+    }
+
+    private double FloatField(string label, string id, double value, double step, double min, double max,
+        string format, float scale)
+    {
+        NumberField(label, scale, out var inputPos, out var inputWidth, out var boxCenter, out var dec, out var inc,
+            out var basePos, out var full, out var rowHeight);
+        var v = (float)Math.Clamp(value + (dec ? -step : 0) + (inc ? step : 0), min, max);
+        var active = activeNumberId == id;
+        ImGui.SetCursorScreenPos(inputPos);
+        using (Plugin.Fonts.Push(TextStyles.Body.Scale, TextStyles.Body.Weight))
+        using (ImRaii.PushColor(ImGuiCol.FrameBg, AppSkin.Transparent))
+        using (ImRaii.PushColor(ImGuiCol.Text, active ? Pal.TitleInk : AppSkin.Transparent))
+        {
+            ImGui.SetNextItemWidth(inputWidth);
+            ImGui.InputFloat(id, ref v, 0f, 0f, format);
+        }
+
+        UpdateActiveNumber(id);
+        if (activeNumberId != id)
+        {
+            var decimals = format.Contains(".2") ? "0.00" : format.Contains(".1") ? "0.0" : "0";
+            Typography.DrawCentered(boxCenter, v.ToString(decimals, CultureInfo.CurrentCulture), Pal.TitleInk,
+                TextStyles.Headline);
+        }
+
+        ImGui.SetCursorScreenPos(basePos);
+        ImGui.Dummy(new Vector2(full, rowHeight));
+        return Math.Clamp(v, min, max);
+    }
+
+    private void UpdateActiveNumber(string id)
+    {
+        if (ImGui.IsItemActive())
+        {
+            activeNumberId = id;
+        }
+        else if (activeNumberId == id)
+        {
+            activeNumberId = null;
+        }
+    }
+
+    private void NumberField(string label, float scale, out Vector2 inputPos, out float inputWidth,
+        out Vector2 boxCenter, out bool dec, out bool inc, out Vector2 basePos, out float full, out float rowHeight)
+    {
+        full = ImGui.GetContentRegionAvail().X;
+        basePos = ImGui.GetCursorScreenPos();
+        var origin = new Vector2(basePos.X + groupPad, basePos.Y);
+        var width = full - groupPad * 2f;
+        var frameHeight = ImGui.GetFrameHeight();
+        rowHeight = frameHeight + 10f * scale;
+        var centerY = basePos.Y + rowHeight * 0.5f;
+        var labelSize = Typography.Measure(label, TextStyles.Subheadline);
+        Typography.Draw(new Vector2(origin.X, centerY - labelSize.Y * 0.5f), label, Pal.BodyInk,
+            TextStyles.Subheadline);
+
+        var radius = 13f * scale;
+        var gap = 8f * scale;
+        inputWidth = 88f * scale;
+        var rightEdge = origin.X + width;
+        var plusCenter = new Vector2(rightEdge - radius, centerY);
+        var inputRight = plusCenter.X - radius - gap;
+        var inputLeft = inputRight - inputWidth;
+        var minusCenter = new Vector2(inputLeft - gap - radius, centerY);
+        dec = ui.IconButton(minusCenter, radius, FontAwesomeIcon.Minus.ToIconString(), Pal.TitleInk,
+            Pal.FieldSurface, 0.5f);
+        inc = ui.IconButton(plusCenter, radius, FontAwesomeIcon.Plus.ToIconString(), Pal.TitleInk,
+            Pal.FieldSurface, 0.5f);
+
+        var boxMin = new Vector2(inputLeft, centerY - frameHeight * 0.5f);
+        var boxMax = new Vector2(inputRight, centerY + frameHeight * 0.5f);
+        ImGui.GetWindowDrawList().AddRectFilled(boxMin, boxMax, ImGui.GetColorU32(Pal.FieldSurface), 8f * scale);
+        boxCenter = new Vector2((inputLeft + inputRight) * 0.5f, centerY);
+        inputPos = boxMin;
+    }
+
+    // A single centered numeric box (no label, no steppers); used to compose fields like TimeField.
+    private int IntBox(string id, float inputLeft, float centerY, float inputWidth, float frameHeight, int value,
+        int min, int max, string overlayFormat, float scale)
+    {
+        var boxMin = new Vector2(inputLeft, centerY - frameHeight * 0.5f);
+        var boxMax = new Vector2(inputLeft + inputWidth, centerY + frameHeight * 0.5f);
+        ImGui.GetWindowDrawList().AddRectFilled(boxMin, boxMax, ImGui.GetColorU32(Pal.FieldSurface), 8f * scale);
+        var v = Math.Clamp(value, min, max);
+        var active = activeNumberId == id;
+        ImGui.SetCursorScreenPos(boxMin);
+        using (Plugin.Fonts.Push(TextStyles.Body.Scale, TextStyles.Body.Weight))
+        using (ImRaii.PushColor(ImGuiCol.FrameBg, AppSkin.Transparent))
+        using (ImRaii.PushColor(ImGuiCol.Text, active ? Pal.TitleInk : AppSkin.Transparent))
+        {
+            ImGui.SetNextItemWidth(inputWidth);
+            ImGui.InputInt(id, ref v, 0, 0);
+        }
+
+        UpdateActiveNumber(id);
+        if (activeNumberId != id)
+        {
+            Typography.DrawCentered(new Vector2((boxMin.X + boxMax.X) * 0.5f, centerY),
+                v.ToString(overlayFormat, CultureInfo.CurrentCulture), Pal.TitleInk, TextStyles.Headline);
+        }
+
+        return Math.Clamp(v, min, max);
+    }
+
+    // Label on the left; two centered HH / MM boxes separated by a colon on the right.
+    private (int Hour, int Minute) TimeField(string label, string id, int hour, int minute, float scale)
+    {
+        var full = ImGui.GetContentRegionAvail().X;
+        var basePos = ImGui.GetCursorScreenPos();
+        var origin = new Vector2(basePos.X + groupPad, basePos.Y);
+        var width = full - groupPad * 2f;
+        var frameHeight = ImGui.GetFrameHeight();
+        var rowHeight = frameHeight + 10f * scale;
+        var centerY = basePos.Y + rowHeight * 0.5f;
+        var labelSize = Typography.Measure(label, TextStyles.Subheadline);
+        Typography.Draw(new Vector2(origin.X, centerY - labelSize.Y * 0.5f), label, Pal.BodyInk,
+            TextStyles.Subheadline);
+
+        var boxWidth = 54f * scale;
+        var colonGap = 16f * scale;
+        var rightEdge = origin.X + width;
+        var minuteLeft = rightEdge - boxWidth;
+        var colonX = minuteLeft - colonGap * 0.5f;
+        var hourLeft = minuteLeft - colonGap - boxWidth;
+        var h = IntBox(id + ".h", hourLeft, centerY, boxWidth, frameHeight, hour, 0, 23, "00", scale);
+        Typography.DrawCentered(new Vector2(colonX, centerY), ":", Pal.TitleInk, TextStyles.Headline);
+        var m = IntBox(id + ".m", minuteLeft, centerY, boxWidth, frameHeight, minute, 0, 59, "00", scale);
+
+        ImGui.SetCursorScreenPos(basePos);
+        ImGui.Dummy(new Vector2(full, rowHeight));
+        return (h, m);
+    }
+
+    private int Segmented(string id, string[] options, int selected, float scale, float rowHeight = 32f)
+    {
+        var full = ImGui.GetContentRegionAvail().X;
+        var basePos = ImGui.GetCursorScreenPos();
+        var origin = new Vector2(basePos.X + groupPad, basePos.Y);
+        var width = full - groupPad * 2f;
+        var rect = new Rect(origin, origin + new Vector2(width, rowHeight * scale));
+        var result = SegmentStrip.Draw(id, rect, options, selected, Pal);
+        ImGui.SetCursorScreenPos(basePos);
+        ImGui.Dummy(new Vector2(full, (rowHeight + 6f) * scale));
+        return result;
+    }
+
+    // ---- Card panels ------
+
+    private Vector2 panelStart;
+    private float panelWidth;
+
+    private void BeginPanel(string title, float scale)
+    {
+        var drawList = ImGui.GetWindowDrawList();
+        drawList.ChannelsSplit(2);
+        drawList.ChannelsSetCurrent(1);
+        panelStart = ImGui.GetCursorScreenPos();
+        panelWidth = ImGui.GetContentRegionAvail().X;
+        ImGui.Dummy(new Vector2(panelWidth, 10f * scale));
+        groupPad = 14f * scale;
+        var origin = ImGui.GetCursorScreenPos();
+        Typography.Draw(new Vector2(origin.X + groupPad, origin.Y),
+            CultureInfo.CurrentCulture.TextInfo.ToUpper(title), Pal.HeaderInk, TextStyles.Caption1);
+        ImGui.SetCursorScreenPos(origin);
+        ImGui.Dummy(new Vector2(panelWidth, 22f * scale));
+    }
+
+    private void EndPanel(float scale)
+    {
+        ImGui.Dummy(new Vector2(panelWidth, 10f * scale));
+        var end = ImGui.GetCursorScreenPos();
+        groupPad = 0f;
+        var drawList = ImGui.GetWindowDrawList();
+        drawList.ChannelsSetCurrent(0);
+        ui.Card(drawList, panelStart, new Vector2(panelStart.X + panelWidth, end.Y), 18f * scale, elevated: true);
+        drawList.ChannelsMerge();
+        ImGui.Dummy(new Vector2(panelWidth, 12f * scale));
+    }
+
+    private void InfoRow(string label, string value, float scale, float rowHeight = 34f)
+    {
+        var full = ImGui.GetContentRegionAvail().X;
+        var basePos = ImGui.GetCursorScreenPos();
+        var origin = new Vector2(basePos.X + groupPad, basePos.Y);
+        KeyRow(new Rect(origin, origin + new Vector2(full - groupPad * 2f, rowHeight * scale)), label, value, scale);
+        ImGui.SetCursorScreenPos(basePos);
+        ImGui.Dummy(new Vector2(full, rowHeight * scale));
+    }
+
+    private bool PanelToggle(string label, bool value, float scale)
+    {
+        var full = ImGui.GetContentRegionAvail().X;
+        var basePos = ImGui.GetCursorScreenPos();
+        var origin = new Vector2(basePos.X + groupPad, basePos.Y);
+        var width = full - groupPad * 2f;
+        var height = 34f * scale;
+        var row = new Rect(origin, origin + new Vector2(width, height));
+        Typography.Draw(new Vector2(row.Min.X, row.Center.Y - 8f * scale), label, Pal.BodyInk,
+            TextStyles.Subheadline);
+        var trackWidth = 44f * scale;
+        var trackHeight = 24f * scale;
+        var trackMin = new Vector2(row.Max.X - trackWidth, row.Center.Y - trackHeight * 0.5f);
+        var trackMax = new Vector2(row.Max.X, row.Center.Y + trackHeight * 0.5f);
+        var drawList = ImGui.GetWindowDrawList();
+        drawList.AddRectFilled(trackMin, trackMax, ImGui.GetColorU32(value ? Pal.Accent : Pal.FieldSurface),
+            trackHeight * 0.5f);
+        var knobRadius = trackHeight * 0.5f - 3f * scale;
+        var knobX = value ? trackMax.X - knobRadius - 3f * scale : trackMin.X + knobRadius + 3f * scale;
+        drawList.AddCircleFilled(new Vector2(knobX, row.Center.Y), knobRadius,
+            ImGui.GetColorU32(new Vector4(1f, 1f, 1f, 1f)), 20);
+        var clicked = ImGui.IsMouseHoveringRect(row.Min, row.Max) && ImGui.IsMouseClicked(ImGuiMouseButton.Left);
+        ImGui.SetCursorScreenPos(basePos);
+        ImGui.Dummy(new Vector2(full, height + 6f * scale));
+        return clicked ? !value : value;
+    }
+
+    private void PanelField(string label, string id, ref string value, int maxLength, float scale)
+    {
+        var full = ImGui.GetContentRegionAvail().X;
+        var basePos = ImGui.GetCursorScreenPos();
+        var origin = new Vector2(basePos.X + groupPad, basePos.Y);
+        var width = full - groupPad * 2f;
+        Typography.Draw(origin, label, Pal.MutedInk, TextStyles.Footnote);
+        var boxTop = origin.Y + 18f * scale;
+        var boxHeight = 32f * scale;
+        var min = new Vector2(origin.X, boxTop);
+        var max = new Vector2(origin.X + width, boxTop + boxHeight);
+        ImGui.GetWindowDrawList().AddRectFilled(min, max, ImGui.GetColorU32(Pal.FieldSurface), 8f * scale);
+        ImGui.SetCursorScreenPos(new Vector2(min.X + 10f * scale, boxTop + boxHeight * 0.5f - ImGui.GetFrameHeight() * 0.5f));
+        ImGui.SetNextItemWidth(width - 20f * scale);
+        using (ImRaii.PushColor(ImGuiCol.FrameBg, AppSkin.Transparent))
+        using (ImRaii.PushColor(ImGuiCol.Text, Pal.TitleInk))
+        {
+            ImGui.InputText(id, ref value, maxLength, ImGuiInputTextFlags.None);
+        }
+
+        ImGui.SetCursorScreenPos(basePos);
+        ImGui.Dummy(new Vector2(full, (18f + 32f + 8f) * scale));
+    }
+
+    private void PanelHint(string text, float scale)
+    {
+        if (groupPad > 0f)
+        {
+            ImGui.Indent(groupPad);
+        }
+
+        ImGui.PushTextWrapPos(0f);
+        using (ImRaii.PushColor(ImGuiCol.Text, Pal.MutedInk))
+        {
+            Typography.Wrapped(text);
+        }
+
+        ImGui.PopTextWrapPos();
+        if (groupPad > 0f)
+        {
+            ImGui.Unindent(groupPad);
+        }
+
+        ImGui.Dummy(new Vector2(0f, 4f * scale));
+    }
+}

--- a/src/Aetherphone/Apps/Health/HealthApp.cs
+++ b/src/Aetherphone/Apps/Health/HealthApp.cs
@@ -1,0 +1,328 @@
+using Aetherphone.Core;
+using Aetherphone.Core.Apps;
+using Aetherphone.Core.Confirm;
+using Aetherphone.Core.Game;
+using Aetherphone.Core.Health;
+using Aetherphone.Windows.Components;
+using Dalamud.Bindings.ImGui;
+using Dalamud.Interface;
+using Dalamud.Interface.Utility;
+
+namespace Aetherphone.Apps.Health;
+
+internal sealed partial class HealthApp : IPhoneApp
+{
+    private const float RowHeight = 56f;
+    private const float CompactRowHeight = 44f;
+    private const float CardPadding = 8f;
+    private const float CardRounding = 18f;
+    private const float CardGap = 12f;
+    private const float TileSize = 30f;
+
+    private static readonly string[] Tabs =
+        { "Overview", "Activity", "Water", "Goals", "History", "Profile" };
+
+    public string Id => "health";
+    public string DisplayName => "Health";
+    public string Glyph => "He";
+    public int BadgeCount => 0;
+
+    private readonly HealthTracker tracker;
+    private readonly GameData gameData;
+    private readonly ConfirmService confirm;
+    private readonly AppSkin ui = new(AppPalettes.Health);
+
+    private int screenIndex;
+    private float groupPad;
+
+    // Editable UI buffers
+    private string weightBuffer = string.Empty;
+    private string customDrinkName = "Cordial";
+    private int customDrinkMl = 250;
+    private string? editingGoalId;
+    private string goalNameBuffer = string.Empty;
+
+    public HealthApp(HealthTracker tracker, GameData gameData, ConfirmService confirm)
+    {
+        this.tracker = tracker;
+        this.gameData = gameData;
+        this.confirm = confirm;
+    }
+
+    private HealthProfile Profile => tracker.Profile;
+    private HealthUnits U => tracker.Profile.Units;
+    private AppPalette Pal => AppPalettes.Health;
+
+    public void OnOpened() => tracker.RefreshHeight();
+
+    public void OnClosed() => tracker.SaveNow();
+
+    public void Dispose()
+    {
+    }
+
+    public void Draw(in PhoneContext context)
+    {
+        var scale = ImGuiHelpers.GlobalScale;
+        var theme = context.Theme;
+        var content = context.Content;
+        ui.Theme = theme;
+        var screen = SceneChrome.ScreenFrom(content, theme, scale);
+        ui.Backdrop(screen);
+
+        var title = tracker.IsTracking && !Profile.SetupCompleted ? "Welcome" : "Health";
+        var rowCenterY = content.Min.Y + AppHeader.Height * scale * 0.5f;
+        Typography.DrawCentered(new Vector2(content.Center.X, rowCenterY), title, Pal.TitleInk, 1.15f,
+            FontWeight.SemiBold);
+
+        var body = new Rect(new Vector2(content.Min.X, content.Min.Y + AppHeader.Height * scale), content.Max);
+        if (!tracker.IsTracking)
+        {
+            Typography.DrawCentered(body.Center, "Log in to view your adventurer's Health.", Pal.MutedInk);
+            return;
+        }
+
+        if (!Profile.SetupCompleted)
+        {
+            using (AppSurface.Begin(body))
+            {
+                DrawSetup(scale);
+            }
+
+            return;
+        }
+
+        DrawTabs(body, scale);
+        var tabbed = new Rect(new Vector2(body.Min.X, body.Min.Y + 40f * scale), body.Max);
+        using (AppSurface.Begin(tabbed))
+        {
+            switch (screenIndex)
+            {
+                case 0: DrawOverview(scale); break;
+                case 1: DrawActivity(scale); break;
+                case 2: DrawHydration(scale); break;
+                case 3: DrawGoals(scale); break;
+                case 4: DrawHistory(scale); break;
+                default: DrawProfile(scale); break;
+            }
+
+            ImGui.Dummy(new Vector2(0f, 16f * scale));
+        }
+    }
+
+    private void DrawTabs(Rect body, float scale)
+    {
+        var rect = new Rect(new Vector2(body.Min.X + 10f * scale, body.Min.Y + 4f * scale),
+            new Vector2(body.Max.X - 10f * scale, body.Min.Y + 36f * scale));
+        screenIndex = SegmentStrip.Draw("health.tabs", rect, Tabs, screenIndex, Pal);
+    }
+
+    // ---- Overview -----------------------------------------------------------
+
+    private void DrawOverview(float scale)
+    {
+        var day = tracker.Profile.LatestDay ?? new HealthDay();
+        var steps = HealthFormat.Steps(day.OnFootYalms, Profile.StrideYalms);
+
+        var origin = ImGui.GetCursorScreenPos();
+        var width = ImGui.GetContentRegionAvail().X;
+        Typography.DrawCentered(new Vector2(origin.X + width * 0.5f, origin.Y + 26f * scale),
+            HealthFormat.Number(steps), Pal.TitleInk, TextStyles.LargeTitle);
+        Typography.DrawCentered(new Vector2(origin.X + width * 0.5f, origin.Y + 54f * scale),
+            $"estimated steps today · goal {HealthFormat.Number(Profile.DailyStepGoal)}", Pal.MutedInk,
+            TextStyles.Footnote);
+        ImGui.SetCursorScreenPos(origin);
+        ImGui.Dummy(new Vector2(width, 74f * scale));
+
+        var card = BeginCard(4, RowHeight, scale);
+        StatRow(CardRow(card, 0, RowHeight, scale), Accent1, FontAwesomeIcon.Walking, "On foot",
+            Dist(day.OnFootYalms), scale);
+        StatRow(CardRow(card, 1, RowHeight, scale), Accent2, FontAwesomeIcon.Clock, "Active time",
+            HealthFormat.Duration(day.ActiveSeconds), scale);
+        var kcal = Profile.CaloriesEnabled && Profile.WeightKg is not null
+            ? $"{day.Calories:0} kcal"
+            : "—";
+        StatRow(CardRow(card, 2, RowHeight, scale), Accent3, FontAwesomeIcon.Fire, "Est. energy", kcal, scale);
+        StatRow(CardRow(card, 3, RowHeight, scale), Accent4, FontAwesomeIcon.Tint, "Hydration",
+            $"{day.DrinkCount} / {Profile.DailyHydrationGoal}", scale);
+        EndCard(card, scale);
+
+        ui.SectionLabel("Goals", TextStyles.FootnoteEmphasized, 6f);
+        var shown = 0;
+        for (var index = 0; index < Profile.Goals.Count && shown < 3; index++)
+        {
+            if (!Profile.Goals[index].Enabled)
+            {
+                continue;
+            }
+
+            GoalBar(Profile.Goals[index], scale);
+            shown++;
+        }
+
+        if (shown == 0)
+        {
+            ui.HelpText("No active goals. Add some on the Goals tab.");
+        }
+
+        ui.SectionLabel("Streak", TextStyles.FootnoteEmphasized, 6f);
+        var streakCard = BeginCard(1, RowHeight, scale);
+        StatRow(CardRow(streakCard, 0, RowHeight, scale), Accent1, FontAwesomeIcon.Fire, "Current streak",
+            Profile.StreakDays == 1 ? "1 day" : $"{Profile.StreakDays} days", scale);
+        EndCard(streakCard, scale);
+    }
+
+    // ---- Activity -----------------------------------------------------------
+
+    private void DrawActivity(float scale)
+    {
+        var day = Profile.LatestDay ?? new HealthDay();
+        ui.SectionLabel("Today", TextStyles.FootnoteEmphasized, 6f);
+        var card = BeginCard(4, CompactRowHeight, scale);
+        StatRow(CardRow(card, 0, CompactRowHeight, scale), Accent1, FontAwesomeIcon.Walking, "On foot",
+            Dist(day.OnFootYalms), scale);
+        StatRow(CardRow(card, 1, CompactRowHeight, scale), Accent2, FontAwesomeIcon.Swimmer, "Swimming",
+            Dist(day.SwimYalms), scale);
+        StatRow(CardRow(card, 2, CompactRowHeight, scale), Accent3, FontAwesomeIcon.Water, "Diving",
+            Dist(day.DiveYalms), scale);
+        StatRow(CardRow(card, 3, CompactRowHeight, scale), Accent4, FontAwesomeIcon.Clock, "Active time",
+            HealthFormat.Duration(day.ActiveSeconds), scale);
+        EndCard(card, scale);
+
+        ui.SectionLabel("Session", TextStyles.FootnoteEmphasized, 6f);
+        var session = BeginCard(4, CompactRowHeight, scale);
+        StatRow(CardRow(session, 0, CompactRowHeight, scale), Accent1, FontAwesomeIcon.Walking, "On foot",
+            Dist(tracker.SessionOnFootYalms), scale);
+        StatRow(CardRow(session, 1, CompactRowHeight, scale), Accent2, FontAwesomeIcon.Swimmer, "Swimming",
+            Dist(tracker.SessionSwimmingYalms), scale);
+        StatRow(CardRow(session, 2, CompactRowHeight, scale), Accent3, FontAwesomeIcon.Water, "Diving",
+            Dist(tracker.SessionDivingYalms), scale);
+        StatRow(CardRow(session, 3, CompactRowHeight, scale), Accent4, FontAwesomeIcon.Clock, "Active time",
+            HealthFormat.Duration(tracker.SessionActiveSeconds), scale);
+        EndCard(session, scale);
+
+        ui.SectionLabel("All-time", TextStyles.FootnoteEmphasized, 6f);
+        var all = BeginCard(4, CompactRowHeight, scale);
+        StatRow(CardRow(all, 0, CompactRowHeight, scale), Accent1, FontAwesomeIcon.Walking, "On foot",
+            Dist(Profile.AllWalkYalms + Profile.AllRunYalms), scale);
+        StatRow(CardRow(all, 1, CompactRowHeight, scale), Accent2, FontAwesomeIcon.Swimmer, "Swimming",
+            Dist(Profile.AllSwimYalms), scale);
+        StatRow(CardRow(all, 2, CompactRowHeight, scale), Accent3, FontAwesomeIcon.Water, "Diving",
+            Dist(Profile.AllDiveYalms), scale);
+        StatRow(CardRow(all, 3, CompactRowHeight, scale), Accent4, FontAwesomeIcon.LocationArrow, "Teleports",
+            HealthFormat.Number(Profile.AllTeleports), scale);
+        EndCard(all, scale);
+
+        ui.SectionLabel("Teleports", TextStyles.FootnoteEmphasized, 6f);
+        var tp = BeginCard(2, CompactRowHeight, scale);
+        StatRow(CardRow(tp, 0, CompactRowHeight, scale), Accent3, FontAwesomeIcon.LocationArrow, "Today",
+            HealthFormat.Number((Profile.LatestDay?.Teleports ?? 0)), scale);
+        StatRow(CardRow(tp, 1, CompactRowHeight, scale), Accent3, FontAwesomeIcon.Route, "Distance skipped",
+            Dist(Profile.AllTeleportYalms), scale);
+        EndCard(tp, scale);
+        ui.HelpText("Teleport distance skipped is a same-map straight-line estimate only; cross-zone teleports are counted without distance.");
+
+        ui.SectionLabel("Records", TextStyles.FootnoteEmphasized, 6f);
+        var rec = BeginCard(3, CompactRowHeight, scale);
+        StatRow(CardRow(rec, 0, CompactRowHeight, scale), Accent1, FontAwesomeIcon.Trophy, "Most steps in a day",
+            HealthFormat.Number(Profile.RecordStepsInDay), scale);
+        StatRow(CardRow(rec, 1, CompactRowHeight, scale), Accent2, FontAwesomeIcon.Trophy, "Longest on-foot session",
+            HealthFormat.Duration(Profile.LongestOnFootSessionSeconds), scale);
+        StatRow(CardRow(rec, 2, CompactRowHeight, scale), Accent2, FontAwesomeIcon.Trophy, "Longest swim session",
+            HealthFormat.Duration(Profile.LongestSwimSessionSeconds), scale);
+        EndCard(rec, scale);
+    }
+
+    // ---- Shared drawing helpers --------------------------------------------
+
+    private Vector4 Accent1 => Pal.Accent;
+    private static readonly Vector4 Accent2 = new(0.28f, 0.68f, 0.92f, 1f);
+    private static readonly Vector4 Accent3 = new(0.62f, 0.52f, 0.96f, 1f);
+    private static readonly Vector4 Accent4 = new(0.30f, 0.78f, 0.52f, 1f);
+
+    private string Dist(double yalms) => HealthFormat.Distance(yalms, U);
+
+    private Rect BeginCard(int rowCount, float rowHeight, float scale)
+    {
+        var width = ImGui.GetContentRegionAvail().X;
+        var origin = ImGui.GetCursorScreenPos();
+        var height = (rowCount * rowHeight + 2f * CardPadding) * scale;
+        var rect = new Rect(origin, origin + new Vector2(width, height));
+        ui.Card(ImGui.GetWindowDrawList(), rect.Min, rect.Max, CardRounding * scale, elevated: true);
+        return rect;
+    }
+
+    private static Rect CardRow(Rect card, int rowIndex, float rowHeight, float scale)
+    {
+        var padding = 14f * scale;
+        var top = card.Min.Y + CardPadding * scale + rowIndex * rowHeight * scale;
+        return new Rect(new Vector2(card.Min.X + padding, top),
+            new Vector2(card.Max.X - padding, top + rowHeight * scale));
+    }
+
+    private static void EndCard(Rect card, float scale)
+    {
+        ImGui.SetCursorScreenPos(card.Min);
+        ImGui.Dummy(card.Size);
+        ImGui.Dummy(new Vector2(0f, CardGap * scale));
+    }
+
+    private void StatRow(Rect row, Vector4 tint, FontAwesomeIcon icon, string label, string value, float scale)
+    {
+        var tile = TileSize * scale;
+        IconTile.Draw(new Vector2(row.Min.X + tile * 0.5f, row.Center.Y), tile, tint, icon);
+        var textLeft = row.Min.X + tile + 12f * scale;
+        var labelSize = Typography.Measure(label, TextStyles.Headline);
+        Typography.Draw(new Vector2(textLeft, row.Center.Y - labelSize.Y * 0.5f), label, Pal.TitleInk,
+            TextStyles.Headline);
+        var valueSize = Typography.Measure(value, 1.02f, FontWeight.SemiBold);
+        Typography.Draw(new Vector2(row.Max.X - valueSize.X, row.Center.Y - valueSize.Y * 0.5f), value, Pal.TitleInk,
+            1.02f, FontWeight.SemiBold);
+    }
+
+    private void GoalBar(HealthGoal goal, float scale)
+    {
+        var (current, target) = tracker.GoalProgress(goal);
+        var fraction = target > 0 ? (float)Math.Clamp(current / target, 0d, 1d) : 0f;
+        var complete = current + 0.0001 >= target;
+        var width = ImGui.GetContentRegionAvail().X;
+        var origin = ImGui.GetCursorScreenPos();
+        var height = 46f * scale;
+        var drawList = ImGui.GetWindowDrawList();
+        var label = goal.Name;
+        Typography.Draw(new Vector2(origin.X, origin.Y + 2f * scale), label,
+            complete ? Accent4 : Pal.TitleInk, TextStyles.Subheadline);
+        var pct = $"{(int)MathF.Round(fraction * 100f)}%";
+        var pctSize = Typography.Measure(pct, TextStyles.Footnote);
+        Typography.Draw(new Vector2(origin.X + width - pctSize.X, origin.Y + 2f * scale), pct, Pal.MutedInk,
+            TextStyles.Footnote);
+
+        var barTop = origin.Y + 26f * scale;
+        var barMin = new Vector2(origin.X, barTop);
+        var barMax = new Vector2(origin.X + width, barTop + 6f * scale);
+        var rounding = (barMax.Y - barMin.Y) * 0.5f;
+        drawList.AddRectFilled(barMin, barMax, ImGui.GetColorU32(Pal.FieldSurface), rounding);
+        if (fraction > 0.001f)
+        {
+            drawList.AddRectFilled(barMin, new Vector2(barMin.X + width * fraction, barMax.Y),
+                ImGui.GetColorU32(complete ? Accent4 : Pal.Accent), rounding);
+        }
+
+        ImGui.SetCursorScreenPos(origin);
+        ImGui.Dummy(new Vector2(width, height));
+    }
+
+    // Full-width pill button; returns true when clicked.
+    private bool WideButton(string label, bool filled, float scale, float heightUnscaled = 40f)
+    {
+        var full = ImGui.GetContentRegionAvail().X;
+        var basePos = ImGui.GetCursorScreenPos();
+        var origin = new Vector2(basePos.X + groupPad, basePos.Y);
+        var width = full - groupPad * 2f;
+        var rect = new Rect(origin, origin + new Vector2(width, heightUnscaled * scale));
+        var clicked = AppSkin.PillButton(rect, label, filled, true, ui.Theme);
+        ImGui.SetCursorScreenPos(basePos);
+        ImGui.Dummy(new Vector2(full, (heightUnscaled + 8f) * scale));
+        return clicked;
+    }
+}

--- a/src/Aetherphone/Core/Apps/AppAccents.cs
+++ b/src/Aetherphone/Core/Apps/AppAccents.cs
@@ -17,6 +17,7 @@ internal static class AppAccents
         ["aethergram"] = new(0.92f, 0.30f, 0.38f, 1f),
         ["velvet"] = new(0.898f, 0.102f, 0.357f, 1f),
         ["character"] = new(0.98f, 0.22f, 0.36f, 1f),
+        ["health"] = new(0.93f, 0.30f, 0.42f, 1f),
         ["camera"] = new(0.70f, 0.72f, 0.78f, 1f),
         ["photos"] = new(0.95f, 0.62f, 0.25f, 1f),
         ["collections"] = new(0.36f, 0.62f, 0.96f, 1f),

--- a/src/Aetherphone/Core/Apps/AppRegistry.cs
+++ b/src/Aetherphone/Core/Apps/AppRegistry.cs
@@ -8,6 +8,7 @@ using Aetherphone.Apps.Collections;
 using Aetherphone.Apps.Dailies;
 using Aetherphone.Apps.Fishing;
 using Aetherphone.Apps.Games;
+using Aetherphone.Apps.Health;
 using Aetherphone.Apps.Inventory;
 using Aetherphone.Apps.Jobs;
 using Aetherphone.Apps.Calculator;
@@ -46,6 +47,7 @@ internal static class AppRegistry
         {
             new LinkpearlApp(services.Messages, services.Linkshells, services.LinkshellMutes, services.LinkpearlNotificationGate, services.ChatBridge, services.LinkshellBridge, services.LinkpearlLauncher, services.Lodestone, services.Notifications, services.GameData, services.Lookup, services.Confirm),
             new ActivityApp(services.GameData, services.Activity, services.Configuration),
+            new HealthApp(services.Health, services.GameData, services.Confirm),
         };
 
         var photoLibrary = new PhotoLibrary(Plugin.PluginInterface.ConfigDirectory);

--- a/src/Aetherphone/Core/Health/HealthFormat.cs
+++ b/src/Aetherphone/Core/Health/HealthFormat.cs
@@ -1,0 +1,191 @@
+using System.Globalization;
+using Aetherphone.Core.Localization;
+
+namespace Aetherphone.Core.Health;
+
+internal static class HealthFormat
+{
+    public const double YalmsPerMalm = 1760d;
+
+    // A yalm is treated as roughly one metre for real-world unit display.
+    private const double MetresPerYalm = 1d;
+    private const double FeetPerMetre = 3.28084d;
+    private const double MetresPerMile = 1609.34d;
+    private const double CmPerInch = 2.54d;
+    private const double InchPerFulm = 12d;
+    private const double LbPerKg = 2.2046226d;
+    private const double MlPerFlOz = 29.5735d;
+
+    private static CultureInfo Culture => Loc.Culture;
+
+    // ---- Distance -----------------------------------------------------------
+
+    public static string Distance(double yalms, HealthUnits units)
+    {
+        yalms = Sane(yalms);
+        switch (units)
+        {
+            case HealthUnits.Metric:
+                var metres = yalms * MetresPerYalm;
+                return metres >= 1000d
+                    ? (metres / 1000d).ToString("0.00", Culture) + " km"
+                    : metres.ToString("0", Culture) + " m";
+            case HealthUnits.Imperial:
+                var miMetres = yalms * MetresPerYalm;
+                if (miMetres >= MetresPerMile)
+                {
+                    return (miMetres / MetresPerMile).ToString("0.00", Culture) + " mi";
+                }
+
+                return (miMetres * FeetPerMetre).ToString("0", Culture) + " ft";
+            default:
+                return yalms >= YalmsPerMalm
+                    ? (yalms / YalmsPerMalm).ToString("0.00", Culture) + " malms"
+                    : yalms.ToString("0", Culture) + " yalms";
+        }
+    }
+
+    // ---- Height -------------------------------------------------------------
+
+    public static string Height(double cm, HealthUnits units)
+    {
+        cm = Sane(cm);
+        if (cm <= 0)
+        {
+            return "—";
+        }
+
+        switch (units)
+        {
+            case HealthUnits.Metric:
+                return cm.ToString("0.0", Culture) + " cm";
+            case HealthUnits.Imperial:
+                return FeetInches(cm, "'", "\"");
+            default:
+                return FeetInches(cm, " fulm", " ilm");
+        }
+    }
+
+    private static string FeetInches(double cm, string bigUnit, string smallUnit)
+    {
+        var totalInches = cm / CmPerInch;
+        var big = (int)(totalInches / InchPerFulm);
+        var small = (int)Math.Round(totalInches - big * InchPerFulm);
+        if (small >= 12)
+        {
+            big++;
+            small = 0;
+        }
+
+        return $"{big}{bigUnit} {small}{smallUnit}";
+    }
+
+    // ---- Weight -------------------------------------------------------------
+
+    public static string Weight(double kg, HealthUnits units)
+    {
+        kg = Sane(kg);
+        return units switch
+        {
+            HealthUnits.Metric => kg.ToString("0.0", Culture) + " kg",
+            _ => (kg * LbPerKg).ToString("0", Culture) + (units == HealthUnits.Eorzean ? " ponz" : " lb"),
+        };
+    }
+
+    public static double WeightToKg(double value, HealthUnits units) =>
+        units == HealthUnits.Metric ? value : value / LbPerKg;
+
+    public static double WeightFromKg(double kg, HealthUnits units) =>
+        units == HealthUnits.Metric ? kg : kg * LbPerKg;
+
+    // ---- Volume -------------------------------------------------------------
+
+    public static string Volume(double ml, HealthUnits units)
+    {
+        ml = Sane(ml);
+        if (units == HealthUnits.Imperial)
+        {
+            return (ml / MlPerFlOz).ToString("0", Culture) + " fl oz";
+        }
+
+        return ml >= 1000d ? (ml / 1000d).ToString("0.0", Culture) + " L" : ml.ToString("0", Culture) + " ml";
+    }
+
+    // ---- Steps --------------------------------------------------------------
+
+    public static long Steps(double onFootYalms, double strideYalms)
+    {
+        var stride = strideYalms is > 0.05 and < 10 ? strideYalms : 0.75;
+        return (long)Math.Floor(Sane(onFootYalms) / stride);
+    }
+
+    public static string Number(long value) => value.ToString("N0", Culture);
+
+    public static string Duration(double seconds)
+    {
+        var total = (int)Math.Max(0, seconds);
+        var minutes = total / 60;
+        var hours = minutes / 60;
+        return hours > 0 ? $"{hours}h {minutes % 60}m" : $"{minutes}m";
+    }
+
+    // ---- Calories (fictional, activity-only MET estimate) -------------------
+
+    public static double MetFor(MovementKind kind) => kind switch
+    {
+        MovementKind.Walking => 3.5,
+        MovementKind.Running => 8.0,
+        MovementKind.Swimming => 6.0,
+        MovementKind.Diving => 7.0,
+        _ => 0d,
+    };
+
+    // kcal for a burst of activity: MET * 3.5 * kg / 200 per minute.
+    public static double Calories(MovementKind kind, double seconds, double weightKg)
+    {
+        var met = MetFor(kind);
+        if (met <= 0 || weightKg <= 0 || seconds <= 0)
+        {
+            return 0d;
+        }
+
+        return met * 3.5 * weightKg / 200d * (seconds / 60d);
+    }
+
+    // ---- Height model -------------------------------------------------------
+
+    // FFXIV racial-scaling (RSP) height model, per PlayerSync/Mare's HeightConversion + RspData:
+    // heightCm = factorCm * rsp,  where rsp = lerp(min, max, slider/100).
+    // Keyed by tribe (subrace) + body; tribe ids match FFXIV's Tribe sheet (1..16). The factor is
+    // the height in cm at rsp = 1.0; min/max are the racial slider bounds.
+    private static (double FactorCm, double Min, double Max)? Rsp(uint tribe, bool female) => tribe switch
+    {
+        1 => (female ? 163.8788462 : 174.8692308, 0.960, 1.040),                        // Midlander
+        2 => (female ? 163.8566434 : 174.9580420, 1.056, 1.144),                        // Highlander
+        3 or 4 => (female ? 190.9278152 : 201.9287777, 0.961, 1.039),                   // Elezen (Wildwood/Duskwight)
+        5 or 6 => (91.96966825, 0.945, 1.055),                                          // Lalafell (Plainsfolk/Dunesfolk)
+        7 or 8 => female ? (155.8192308, 0.960, 1.040) : (174.9777778, 0.910, 0.990),   // Miqo'te
+        9 or 10 => female ? (192.0327586, 1.000, 1.160) : (221.9441233, 0.962, 1.038),  // Roegadyn
+        11 or 12 => female ? (156.9267327, 0.930, 1.010) : (174.9322581, 1.160, 1.240), // Au Ra
+        13 or 14 => female ? (187.0450281, 0.986, 1.066) : (219.8884298, 0.892, 0.968), // Hrothgar
+        15 or 16 => female ? (160.8595458, 1.111, 1.189) : (174.8930582, 0.984, 1.066), // Viera
+        _ => null,
+    };
+
+    public static double HeightCm(uint tribeId, bool female, byte heightSlider)
+    {
+        if (Rsp(tribeId, female) is not { } r)
+        {
+            return 0d;
+        }
+
+        var t = Math.Clamp(heightSlider / 100d, 0d, 1d);
+        return r.FactorCm * (r.Min + (r.Max - r.Min) * t);
+    }
+
+    // Rough biomechanical stride: ~0.415 of height. Kept within sensible plugin limits.
+    public static double SuggestStride(double heightCm) =>
+        heightCm > 0 ? Math.Clamp(heightCm * 0.00415d, 0.30d, 1.50d) : 0.75d;
+
+    private static double Sane(double value) => double.IsFinite(value) && value > 0 ? value : 0d;
+}

--- a/src/Aetherphone/Core/Health/HealthModels.cs
+++ b/src/Aetherphone/Core/Health/HealthModels.cs
@@ -1,0 +1,177 @@
+using Newtonsoft.Json;
+
+namespace Aetherphone.Core.Health;
+
+internal enum HealthUnits
+{
+    Eorzean,
+    Metric,
+    Imperial,
+}
+
+internal enum HeightSource
+{
+    Unavailable,
+    Game,
+    Manual,
+}
+
+internal enum HealthGoalType
+{
+    Steps,
+    OnFootDistance,
+    WalkDistance,
+    RunDistance,
+    SwimDistance,
+    ActiveTime,
+    HydrationCount,
+    HydrationVolume,
+    Teleports,
+    TeleportDistance,
+    Calories,
+}
+
+internal enum HealthGoalScope
+{
+    Daily,
+    Weekly,
+    Session,
+    AllTime,
+}
+
+internal sealed class HydrationEntry
+{
+    [JsonProperty("t")] public long Unix { get; set; }
+
+    [JsonProperty("k")] public string Kind { get; set; } = "Water";
+
+    [JsonProperty("ml")] public double Millilitres { get; set; }
+}
+
+internal sealed class HealthGoal
+{
+    [JsonProperty("id")] public string Id { get; set; } = Guid.NewGuid().ToString("N");
+
+    [JsonProperty("name")] public string Name { get; set; } = string.Empty;
+
+    [JsonProperty("type")] public HealthGoalType Type { get; set; }
+
+    [JsonProperty("scope")] public HealthGoalScope Scope { get; set; } = HealthGoalScope.Daily;
+
+    [JsonProperty("target")] public double Target { get; set; } = 1;
+
+    [JsonProperty("enabled")] public bool Enabled { get; set; } = true;
+
+    // Scope key (e.g. the date) this goal was last completed for; prevents duplicate notifications.
+    [JsonProperty("done")] public string CompletedKey { get; set; } = string.Empty;
+}
+
+internal sealed class HealthDay
+{
+    [JsonProperty("date")] public string Date { get; set; } = string.Empty;
+
+    [JsonProperty("walk")] public double WalkYalms { get; set; }
+
+    [JsonProperty("run")] public double RunYalms { get; set; }
+
+    [JsonProperty("swim")] public double SwimYalms { get; set; }
+
+    [JsonProperty("dive")] public double DiveYalms { get; set; }
+
+    [JsonProperty("mount")] public double MountYalms { get; set; }
+
+    [JsonProperty("fly")] public double FlyYalms { get; set; }
+
+    [JsonProperty("active")] public double ActiveSeconds { get; set; }
+
+    [JsonProperty("kcal")] public double Calories { get; set; }
+
+    [JsonProperty("tp")] public int Teleports { get; set; }
+
+    [JsonProperty("tpy")] public double TeleportYalms { get; set; }
+
+    [JsonProperty("goals")] public int GoalsCompleted { get; set; }
+
+    [JsonProperty("drinks")] public List<HydrationEntry> Drinks { get; set; } = new();
+
+    [JsonIgnore] public double OnFootYalms => WalkYalms + RunYalms;
+
+    [JsonIgnore] public double SwimTotalYalms => SwimYalms + DiveYalms;
+
+    [JsonIgnore] public int DrinkCount => Drinks.Count;
+
+    [JsonIgnore] public double DrinkMillilitres
+    {
+        get
+        {
+            var sum = 0d;
+            for (var index = 0; index < Drinks.Count; index++)
+            {
+                sum += Drinks[index].Millilitres;
+            }
+
+            return sum;
+        }
+    }
+}
+
+internal sealed class HealthProfile
+{
+    [JsonProperty("version")] public int Version { get; set; } = 1;
+
+    // Profile / setup
+    [JsonProperty("setup")] public bool SetupCompleted { get; set; }
+    [JsonProperty("units")] public HealthUnits Units { get; set; } = HealthUnits.Eorzean;
+    [JsonProperty("manualHeightCm")] public double? ManualHeightCm { get; set; }
+    [JsonProperty("weightKg")] public double? WeightKg { get; set; }
+    [JsonProperty("calories")] public bool CaloriesEnabled { get; set; } = true;
+    [JsonProperty("stride")] public double StrideYalms { get; set; } = 0.75;
+    [JsonProperty("autoHeight")] public bool AutoRefreshHeight { get; set; } = true;
+
+    // Daily targets used by the Overview rings and the default goals
+    [JsonProperty("goalSteps")] public int DailyStepGoal { get; set; } = 10000;
+    [JsonProperty("goalSwim")] public double DailySwimGoalYalms { get; set; } = 500;
+    [JsonProperty("goalDrinks")] public int DailyHydrationGoal { get; set; } = 4;
+
+    [JsonProperty("goalList")] public List<HealthGoal> Goals { get; set; } = new();
+
+    // History (most recent last). Trimmed to a bounded window by the tracker.
+    [JsonProperty("days")] public List<HealthDay> Days { get; set; } = new();
+
+    // All-time totals (yalms / seconds / count)
+    [JsonProperty("allWalk")] public double AllWalkYalms { get; set; }
+    [JsonProperty("allRun")] public double AllRunYalms { get; set; }
+    [JsonProperty("allSwim")] public double AllSwimYalms { get; set; }
+    [JsonProperty("allDive")] public double AllDiveYalms { get; set; }
+    [JsonProperty("allMount")] public double AllMountYalms { get; set; }
+    [JsonProperty("allFly")] public double AllFlyYalms { get; set; }
+    [JsonProperty("allActive")] public double AllActiveSeconds { get; set; }
+    [JsonProperty("allKcal")] public double AllCalories { get; set; }
+    [JsonProperty("allTp")] public int AllTeleports { get; set; }
+    [JsonProperty("allTpY")] public double AllTeleportYalms { get; set; }
+    [JsonProperty("allDrinks")] public int AllDrinks { get; set; }
+
+    // Personal records
+    [JsonProperty("recSteps")] public long RecordStepsInDay { get; set; }
+    [JsonProperty("recOnFoot")] public double RecordOnFootYalmsInDay { get; set; }
+    [JsonProperty("recSwim")] public double RecordSwimYalmsInDay { get; set; }
+    [JsonProperty("recActive")] public double RecordActiveSecondsInDay { get; set; }
+    [JsonProperty("recFootSession")] public double LongestOnFootSessionSeconds { get; set; }
+    [JsonProperty("recSwimSession")] public double LongestSwimSessionSeconds { get; set; }
+    [JsonProperty("recTeleport")] public double LongestTeleportYalms { get; set; }
+
+    // Streak of consecutive days that met the daily step goal
+    [JsonProperty("streak")] public int StreakDays { get; set; }
+    [JsonProperty("streakDate")] public string StreakLastDate { get; set; } = string.Empty;
+
+    // Hydration reminders
+    [JsonProperty("remind")] public bool HydrationRemindersEnabled { get; set; }
+    [JsonProperty("remindMins")] public int ReminderIntervalMinutes { get; set; } = 120;
+    [JsonProperty("quietStart")] public int QuietStartHour { get; set; } = 22;
+    [JsonProperty("quietStartMin")] public int QuietStartMinute { get; set; }
+    [JsonProperty("quietEnd")] public int QuietEndHour { get; set; } = 8;
+    [JsonProperty("quietEndMin")] public int QuietEndMinute { get; set; }
+    [JsonProperty("remindPause")] public bool ReminderPauseInDuties { get; set; } = true;
+
+    [JsonIgnore] public HealthDay? LatestDay => Days.Count > 0 ? Days[Days.Count - 1] : null;
+}

--- a/src/Aetherphone/Core/Health/HealthStore.cs
+++ b/src/Aetherphone/Core/Health/HealthStore.cs
@@ -1,0 +1,94 @@
+using Newtonsoft.Json;
+
+namespace Aetherphone.Core.Health;
+
+internal sealed class HealthStore
+{
+    private readonly DirectoryInfo root;
+
+    public HealthStore(DirectoryInfo root)
+    {
+        this.root = root;
+        if (!root.Exists)
+        {
+            root.Create();
+        }
+    }
+
+    public HealthProfile Load(ulong contentId)
+    {
+        var path = PathFor(contentId);
+        if (!File.Exists(path))
+        {
+            return new HealthProfile();
+        }
+
+        try
+        {
+            var loaded = JsonConvert.DeserializeObject<HealthProfile>(File.ReadAllText(path));
+            return loaded is null ? new HealthProfile() : Sanitize(loaded);
+        }
+        catch (Exception exception)
+        {
+            AepLog.Warning($"HealthStore load failed for {contentId:X16}: {exception.Message}");
+            return new HealthProfile();
+        }
+    }
+
+    public void Save(ulong contentId, HealthProfile profile)
+    {
+        if (contentId == 0)
+        {
+            return;
+        }
+
+        try
+        {
+            var path = PathFor(contentId);
+            var temp = path + ".tmp";
+            File.WriteAllText(temp, JsonConvert.SerializeObject(profile));
+            File.Move(temp, path, true);
+        }
+        catch (Exception exception)
+        {
+            AepLog.Warning($"HealthStore write failed for {contentId:X16}: {exception.Message}");
+        }
+    }
+
+    // Guard against corrupt, missing, NaN, infinite, or negative saved values.
+    private static HealthProfile Sanitize(HealthProfile profile)
+    {
+        profile.StrideYalms = profile.StrideYalms is > 0.05 and < 10 ? profile.StrideYalms : 0.75;
+        if (profile.WeightKg is { } weight && (!double.IsFinite(weight) || weight <= 0))
+        {
+            profile.WeightKg = null;
+        }
+
+        if (profile.ManualHeightCm is { } height && (!double.IsFinite(height) || height <= 0))
+        {
+            profile.ManualHeightCm = null;
+        }
+
+        profile.DailyStepGoal = Math.Clamp(profile.DailyStepGoal, 1, 1_000_000);
+        profile.DailyHydrationGoal = Math.Clamp(profile.DailyHydrationGoal, 1, 100);
+        profile.ReminderIntervalMinutes = Math.Clamp(profile.ReminderIntervalMinutes, 1, 720);
+        profile.QuietStartHour = Math.Clamp(profile.QuietStartHour, 0, 23);
+        profile.QuietEndHour = Math.Clamp(profile.QuietEndHour, 0, 23);
+        profile.QuietStartMinute = Math.Clamp(profile.QuietStartMinute, 0, 59);
+        profile.QuietEndMinute = Math.Clamp(profile.QuietEndMinute, 0, 59);
+        profile.Goals ??= new List<HealthGoal>();
+        profile.Days ??= new List<HealthDay>();
+        profile.Goals.RemoveAll(goal => goal is null || goal.Target <= 0);
+        for (var index = 0; index < profile.Goals.Count; index++)
+        {
+            if (string.IsNullOrWhiteSpace(profile.Goals[index].Id))
+            {
+                profile.Goals[index].Id = Guid.NewGuid().ToString("N");
+            }
+        }
+
+        return profile;
+    }
+
+    private string PathFor(ulong contentId) => Path.Combine(root.FullName, contentId.ToString("X16") + ".json");
+}

--- a/src/Aetherphone/Core/Health/HealthTracker.cs
+++ b/src/Aetherphone/Core/Health/HealthTracker.cs
@@ -1,0 +1,869 @@
+using System.Globalization;
+using Aetherphone.Core.Apps;
+using Aetherphone.Core.Game;
+using Aetherphone.Core.Notifications;
+using Dalamud.Game.ClientState.Conditions;
+using Dalamud.Plugin.Services;
+
+namespace Aetherphone.Core.Health;
+
+internal enum MovementKind
+{
+    None,
+    Walking,
+    Running,
+    Swimming,
+    Diving,
+    Mounted,
+    Flying,
+}
+
+internal sealed class HealthTracker : IDisposable
+{
+    private const long SampleIntervalMs = 100;      // ~10 samples/second
+    private const long SaveIntervalMs = 60_000;     // flush at most once per minute of movement
+    private const int MaxStoredDays = 60;
+    private const double Epsilon = 0.05;            // ignore jitter / standing still (yalms)
+    private const double WalkSpeedMax = 4.0;        // yalms/sec below which on-foot counts as walking
+    private const double MaxFootPerSec = 25.0;      // above sprint, rejects teleport jumps
+    private const double MaxMountPerSec = 60.0;
+    private const double MaxSwimPerSec = 20.0;
+
+    private static readonly Vector4 Accent = AppAccents.For("health");
+
+    private readonly CharacterWatch watch;
+    private readonly NotificationService notifications;
+    private readonly HealthStore store;
+    private readonly FrameworkTicker ticker;
+
+    private HealthProfile profile = new();
+    private ulong contentId;
+    private long lastTickMs;
+    private long lastSaveMs = Environment.TickCount64;
+    private bool dirty;
+    private bool loggedError;
+
+    // Baseline / discontinuity state
+    private Vector3 lastPos;
+    private uint lastTerritory, lastMap;
+    private bool hasBaseline;
+    private bool wasLoggedIn;
+
+    // Session (memory only; reset on reload / character switch)
+    private double sWalk, sRun, sSwim, sDive, sMount, sFly, sActive, sKcal, sDrinkMl;
+    private int sTeleports, sDrinks;
+    private double sTeleY;
+    private double onFootSessionSeconds, swimSessionSeconds;
+
+    // Pending teleport captured at a loading transition
+    private Vector3 tpOrigin;
+    private uint tpOriginTerritory, tpOriginMap;
+    private bool pendingTeleport;
+
+    // Height + reminders
+    private long lastDrinkUnix;
+    private long lastReminderMs;
+    private string pausedReason = "Paused";
+
+    public HealthTracker(IFramework framework, CharacterWatch watch, NotificationService notifications,
+        DirectoryInfo configDirectory)
+    {
+        this.watch = watch;
+        this.notifications = notifications;
+        store = new HealthStore(new DirectoryInfo(Path.Combine(configDirectory.FullName, "Health")));
+        SessionStartedUnix = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        ticker = new FrameworkTicker(framework, SampleIntervalMs, OnTick);
+        Plugin.ClientState.Logout += OnLogout;
+    }
+
+    public HealthProfile Profile => profile;
+    public bool IsTracking => contentId != 0;
+    public long SessionStartedUnix { get; private set; }
+    public MovementKind CurrentKind { get; private set; }
+    public bool IsMoving { get; private set; }
+    public HeightSource HeightSource { get; private set; } = HeightSource.Unavailable;
+    public double HeightCm { get; private set; }
+
+    public string TrackingStatus
+    {
+        get
+        {
+            if (!IsTracking)
+            {
+                return "Paused: not logged in";
+            }
+
+            return CurrentKind switch
+            {
+                MovementKind.Swimming or MovementKind.Diving => "Tracking swimming",
+                MovementKind.Walking or MovementKind.Running => "Tracking on-foot movement",
+                _ => pausedReason,
+            };
+        }
+    }
+
+    // Session read-outs used by the UI
+    public double SessionOnFootYalms => sWalk + sRun;
+    public double SessionSwimYalms => sSwim + sDive;
+    public double SessionSwimmingYalms => sSwim;
+    public double SessionDivingYalms => sDive;
+    public double SessionActiveSeconds => sActive;
+    public double SessionCalories => sKcal;
+    public int SessionTeleports => sTeleports;
+
+    public void Dispose()
+    {
+        Plugin.ClientState.Logout -= OnLogout;
+        ticker.Dispose();
+        SaveNow();
+    }
+
+    // ---- Public mutations ---------------------------------------------------
+
+    public void SaveNow()
+    {
+        if (contentId == 0)
+        {
+            return;
+        }
+
+        store.Save(contentId, profile);
+        dirty = false;
+        lastSaveMs = Environment.TickCount64;
+    }
+
+    public void MarkDirty() => dirty = true;
+
+    public void LogDrink(string kind, double millilitres)
+    {
+        if (!IsTracking || millilitres <= 0)
+        {
+            return;
+        }
+
+        var day = Today();
+        day.Drinks.Add(new HydrationEntry
+        {
+            Unix = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            Kind = kind,
+            Millilitres = millilitres,
+        });
+        profile.AllDrinks++;
+        sDrinks++;
+        sDrinkMl += millilitres;
+        lastDrinkUnix = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        EvaluateGoals(day);
+        SaveNow();
+    }
+
+    public void UndoLastDrink()
+    {
+        if (!IsTracking)
+        {
+            return;
+        }
+
+        var day = Today();
+        if (day.Drinks.Count == 0)
+        {
+            return;
+        }
+
+        day.Drinks.RemoveAt(day.Drinks.Count - 1);
+        if (profile.AllDrinks > 0)
+        {
+            profile.AllDrinks--;
+        }
+
+        if (sDrinks > 0)
+        {
+            sDrinks--;
+        }
+
+        SaveNow();
+    }
+
+    public void RefreshHeight() => ResolveHeight();
+
+    public void ResetSession()
+    {
+        sWalk = sRun = sSwim = sDive = sMount = sFly = sActive = sKcal = sDrinkMl = sTeleY = 0;
+        sTeleports = sDrinks = 0;
+        onFootSessionSeconds = swimSessionSeconds = 0;
+        SessionStartedUnix = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+    }
+
+    public void ResetToday()
+    {
+        var day = Today();
+        day.WalkYalms = day.RunYalms = day.SwimYalms = day.DiveYalms = day.MountYalms = day.FlyYalms = 0;
+        day.ActiveSeconds = day.Calories = day.TeleportYalms = 0;
+        day.Teleports = day.GoalsCompleted = 0;
+        day.Drinks.Clear();
+        SaveNow();
+    }
+
+    public void ResetTodayHydration()
+    {
+        Today().Drinks.Clear();
+        SaveNow();
+    }
+
+    public void ResetHistory()
+    {
+        var keep = Today();
+        profile.Days.Clear();
+        profile.Days.Add(keep);
+        SaveNow();
+    }
+
+    public void ResetRecords()
+    {
+        profile.RecordStepsInDay = 0;
+        profile.RecordOnFootYalmsInDay = 0;
+        profile.RecordSwimYalmsInDay = 0;
+        profile.RecordActiveSecondsInDay = 0;
+        profile.LongestOnFootSessionSeconds = 0;
+        profile.LongestSwimSessionSeconds = 0;
+        profile.LongestTeleportYalms = 0;
+        SaveNow();
+    }
+
+    public void ResetAll()
+    {
+        profile = new HealthProfile { SetupCompleted = profile.SetupCompleted, Units = profile.Units };
+        profile.Goals = DefaultGoals();
+        ResetSession();
+        hasBaseline = false;
+        SaveNow();
+    }
+
+    public static List<HealthGoal> DefaultGoals() => new()
+    {
+        new HealthGoal { Name = "Walk 1,000 steps", Type = HealthGoalType.Steps, Target = 1000 },
+        new HealthGoal { Name = "Walk 5,000 steps", Type = HealthGoalType.Steps, Target = 5000 },
+        new HealthGoal { Name = "Walk 10,000 steps", Type = HealthGoalType.Steps, Target = 10000 },
+        new HealthGoal { Name = "Walk 1 malm", Type = HealthGoalType.OnFootDistance, Target = HealthFormat.YalmsPerMalm },
+        new HealthGoal { Name = "Swim 500 yalms", Type = HealthGoalType.SwimDistance, Target = 500 },
+        new HealthGoal { Name = "Log 4 drinks", Type = HealthGoalType.HydrationCount, Target = 4 },
+        new HealthGoal { Name = "Remain active for 30 minutes", Type = HealthGoalType.ActiveTime, Target = 1800 },
+    };
+
+    // ---- Tracking loop ------------------------------------------------------
+
+    private void OnTick()
+    {
+        var now = Environment.TickCount64;
+        var delta = lastTickMs == 0 ? 0 : now - lastTickMs;
+        lastTickMs = now;
+        var dt = Math.Min(delta / 1000.0, 1.0);
+
+        try
+        {
+            Sample(dt, now);
+        }
+        catch (Exception exception)
+        {
+            hasBaseline = false;
+            if (!loggedError)
+            {
+                loggedError = true;
+                AepLog.Warning($"Health tracking error: {exception.Message}");
+            }
+        }
+    }
+
+    private void Sample(double dt, long now)
+    {
+        var id = watch.CurrentContentId;
+        if (id != contentId)
+        {
+            SaveNow();
+            contentId = id;
+            if (contentId != 0)
+            {
+                profile = store.Load(contentId);
+                if (profile.Goals.Count == 0 && !profile.SetupCompleted)
+                {
+                    profile.Goals = DefaultGoals();
+                }
+            }
+            else
+            {
+                profile = new HealthProfile();
+            }
+
+            ResetSession();
+            hasBaseline = false;
+            pendingTeleport = false;
+            ResolveHeight();
+        }
+
+        var loggedIn = Plugin.ClientState.IsLoggedIn && contentId != 0;
+        if (wasLoggedIn && !loggedIn)
+        {
+            hasBaseline = false;
+            pendingTeleport = false;
+            SaveNow();
+        }
+
+        wasLoggedIn = loggedIn;
+        if (!loggedIn)
+        {
+            CurrentKind = MovementKind.None;
+            IsMoving = false;
+            pausedReason = "Paused: not logged in";
+            return;
+        }
+
+        RollDayIfNeeded();
+        HydrationReminderCheck(now);
+
+        var player = Plugin.ObjectTable.LocalPlayer;
+        var loading = Plugin.Condition[ConditionFlag.BetweenAreas] || Plugin.Condition[ConditionFlag.BetweenAreas51];
+        if (player is null || loading)
+        {
+            if (loading && hasBaseline && !pendingTeleport)
+            {
+                tpOrigin = lastPos;
+                tpOriginTerritory = lastTerritory;
+                tpOriginMap = lastMap;
+                pendingTeleport = true;
+            }
+
+            hasBaseline = false;
+            IsMoving = false;
+            CurrentKind = MovementKind.None;
+            pausedReason = player is null ? "Paused: player unavailable" : "Paused: loading";
+            return;
+        }
+
+        var cur = player.Position;
+        var curT = Plugin.ClientState.TerritoryType;
+        var curM = Plugin.ClientState.MapId;
+
+        if (pendingTeleport)
+        {
+            RegisterTeleport(cur, curT, curM);
+            SetBaseline(cur, curT, curM);
+            SaveNow();
+            return;
+        }
+
+        if (!hasBaseline)
+        {
+            SetBaseline(cur, curT, curM);
+            return;
+        }
+
+        if (curT != lastTerritory || curM != lastMap)
+        {
+            RegisterTeleport(cur, curT, curM, crossOnly: true);
+            SetBaseline(cur, curT, curM);
+            SaveNow();
+            return;
+        }
+
+        var kind = Classify();
+        var horiz = Horizontal(lastPos, cur);
+        var maxStep = MaxSpeed(kind) * dt;
+        if (double.IsFinite(horiz) && horiz > Epsilon && horiz <= maxStep && kind != MovementKind.None)
+        {
+            Accumulate(kind, horiz, dt);
+            IsMoving = true;
+        }
+        else
+        {
+            IsMoving = false;
+            onFootSessionSeconds = 0;
+            swimSessionSeconds = 0;
+        }
+
+        CurrentKind = IsMoving ? kind : MovementKind.None;
+        if (!IsMoving)
+        {
+            pausedReason = kind switch
+            {
+                MovementKind.Mounted => "Paused: mounted",
+                MovementKind.Flying => "Paused: flying",
+                _ => "Idle",
+            };
+        }
+
+        SetBaseline(cur, curT, curM);
+
+        if (dirty && now - lastSaveMs > SaveIntervalMs)
+        {
+            SaveNow();
+        }
+    }
+
+    private MovementKind Classify()
+    {
+        var c = Plugin.Condition;
+        if (c[ConditionFlag.Diving])
+        {
+            return MovementKind.Diving;
+        }
+
+        if (c[ConditionFlag.Swimming])
+        {
+            return MovementKind.Swimming;
+        }
+
+        if (c[ConditionFlag.InFlight])
+        {
+            return MovementKind.Flying;
+        }
+
+        if (c[ConditionFlag.Mounted] || c[ConditionFlag.RidingPillion])
+        {
+            // Auto-transport (chocobo porters, ferries) reports BeingMoved and is excluded.
+            return c[ConditionFlag.BeingMoved] ? MovementKind.None : MovementKind.Mounted;
+        }
+
+        if (c[ConditionFlag.BeingMoved] || c[ConditionFlag.Occupied38] || c[ConditionFlag.WatchingCutscene] ||
+            c[ConditionFlag.WatchingCutscene78] || c[ConditionFlag.OccupiedInCutSceneEvent] ||
+            c[ConditionFlag.Unconscious])
+        {
+            return MovementKind.None;
+        }
+
+        return MovementKind.Walking; // refined to Running by speed in Accumulate
+    }
+
+    private static double MaxSpeed(MovementKind kind) => kind switch
+    {
+        MovementKind.Mounted => MaxMountPerSec,
+        MovementKind.Flying => MaxMountPerSec,
+        MovementKind.Swimming or MovementKind.Diving => MaxSwimPerSec,
+        _ => MaxFootPerSec,
+    };
+
+    private void Accumulate(MovementKind kind, double horiz, double dt)
+    {
+        var day = Today();
+        var speed = dt > 0 ? horiz / dt : 0;
+        switch (kind)
+        {
+            case MovementKind.Walking:
+            case MovementKind.Running:
+                var running = speed > WalkSpeedMax;
+                if (running)
+                {
+                    day.RunYalms += horiz;
+                    sRun += horiz;
+                    profile.AllRunYalms += horiz;
+                }
+                else
+                {
+                    day.WalkYalms += horiz;
+                    sWalk += horiz;
+                    profile.AllWalkYalms += horiz;
+                }
+
+                AddActive(day, dt, running ? MovementKind.Running : MovementKind.Walking);
+                onFootSessionSeconds += dt;
+                swimSessionSeconds = 0;
+                if (onFootSessionSeconds > profile.LongestOnFootSessionSeconds)
+                {
+                    profile.LongestOnFootSessionSeconds = onFootSessionSeconds;
+                }
+
+                break;
+            case MovementKind.Swimming:
+                day.SwimYalms += horiz;
+                sSwim += horiz;
+                profile.AllSwimYalms += horiz;
+                AddActive(day, dt, MovementKind.Swimming);
+                swimSessionSeconds += dt;
+                onFootSessionSeconds = 0;
+                if (swimSessionSeconds > profile.LongestSwimSessionSeconds)
+                {
+                    profile.LongestSwimSessionSeconds = swimSessionSeconds;
+                }
+
+                break;
+            case MovementKind.Diving:
+                day.DiveYalms += horiz;
+                sDive += horiz;
+                profile.AllDiveYalms += horiz;
+                AddActive(day, dt, MovementKind.Diving);
+                swimSessionSeconds += dt;
+                onFootSessionSeconds = 0;
+                break;
+            case MovementKind.Mounted:
+                day.MountYalms += horiz;
+                sMount += horiz;
+                profile.AllMountYalms += horiz;
+                break;
+            case MovementKind.Flying:
+                day.FlyYalms += horiz;
+                sFly += horiz;
+                profile.AllFlyYalms += horiz;
+                break;
+        }
+
+        UpdateRecords(day);
+        EvaluateGoals(day);
+        dirty = true;
+    }
+
+    private void AddActive(HealthDay day, double dt, MovementKind kind)
+    {
+        day.ActiveSeconds += dt;
+        sActive += dt;
+        profile.AllActiveSeconds += dt;
+        if (profile.CaloriesEnabled && profile.WeightKg is { } weight)
+        {
+            var kcal = HealthFormat.Calories(kind, dt, weight);
+            day.Calories += kcal;
+            sKcal += kcal;
+            profile.AllCalories += kcal;
+        }
+    }
+
+    private void UpdateRecords(HealthDay day)
+    {
+        var steps = HealthFormat.Steps(day.OnFootYalms, profile.StrideYalms);
+        if (steps > profile.RecordStepsInDay)
+        {
+            profile.RecordStepsInDay = steps;
+        }
+
+        if (day.OnFootYalms > profile.RecordOnFootYalmsInDay)
+        {
+            profile.RecordOnFootYalmsInDay = day.OnFootYalms;
+        }
+
+        if (day.SwimTotalYalms > profile.RecordSwimYalmsInDay)
+        {
+            profile.RecordSwimYalmsInDay = day.SwimTotalYalms;
+        }
+
+        if (day.ActiveSeconds > profile.RecordActiveSecondsInDay)
+        {
+            profile.RecordActiveSecondsInDay = day.ActiveSeconds;
+        }
+    }
+
+    private void RegisterTeleport(Vector3 cur, uint curT, uint curM, bool crossOnly = false)
+    {
+        var day = Today();
+        day.Teleports++;
+        profile.AllTeleports++;
+        sTeleports++;
+        pendingTeleport = false;
+        if (crossOnly)
+        {
+            return;
+        }
+
+        // Same coordinate space only: straight-line horizontal estimate, never exact path.
+        if (tpOriginTerritory == curT && tpOriginMap == curM)
+        {
+            var d = Horizontal(tpOrigin, cur);
+            if (double.IsFinite(d) && d > 0)
+            {
+                day.TeleportYalms += d;
+                profile.AllTeleportYalms += d;
+                sTeleY += d;
+                if (d > profile.LongestTeleportYalms)
+                {
+                    profile.LongestTeleportYalms = d;
+                }
+            }
+        }
+    }
+
+    private void SetBaseline(Vector3 pos, uint territory, uint map)
+    {
+        lastPos = pos;
+        lastTerritory = territory;
+        lastMap = map;
+        hasBaseline = true;
+    }
+
+    // ---- Day rollover / streak ---------------------------------------------
+
+    private static string DateKey() => DateTime.Now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+    private HealthDay Today()
+    {
+        var key = DateKey();
+        var days = profile.Days;
+        if (days.Count > 0 && days[days.Count - 1].Date == key)
+        {
+            return days[days.Count - 1];
+        }
+
+        var day = new HealthDay { Date = key };
+        days.Add(day);
+        while (days.Count > MaxStoredDays)
+        {
+            days.RemoveAt(0);
+        }
+
+        dirty = true;
+        return day;
+    }
+
+    private void RollDayIfNeeded()
+    {
+        var key = DateKey();
+        var latest = profile.LatestDay;
+        if (latest is null || latest.Date == key)
+        {
+            return;
+        }
+
+        // A new day began: fold the previous day into the streak before opening today.
+        var steps = HealthFormat.Steps(latest.OnFootYalms, profile.StrideYalms);
+        if (steps >= profile.DailyStepGoal)
+        {
+            profile.StreakDays = profile.StreakLastDate == PreviousDateKey(key)
+                ? profile.StreakDays + 1
+                : 1;
+            profile.StreakLastDate = latest.Date;
+        }
+        else if (profile.StreakLastDate != latest.Date)
+        {
+            profile.StreakDays = 0;
+        }
+
+        _ = Today();
+        SaveNow();
+    }
+
+    private static string PreviousDateKey(string todayKey)
+    {
+        return DateTime.TryParseExact(todayKey, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None,
+            out var parsed)
+            ? parsed.AddDays(-1).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)
+            : string.Empty;
+    }
+
+    // ---- Height -------------------------------------------------------------
+
+    private void ResolveHeight()
+    {
+        if (profile.ManualHeightCm is { } manual && manual > 0)
+        {
+            HeightCm = manual;
+            HeightSource = HeightSource.Manual;
+            return;
+        }
+
+        var player = Plugin.ObjectTable.LocalPlayer;
+        if (player is not null)
+        {
+            try
+            {
+                var customize = player.Customize;
+                if (customize.Length >= 5)
+                {
+                    var female = customize[1] == 1;
+                    var slider = customize[3];
+                    var tribe = customize[4];
+                    var cm = HealthFormat.HeightCm(tribe, female, slider);
+                    if (cm > 0)
+                    {
+                        HeightCm = cm;
+                        HeightSource = HeightSource.Game;
+                        return;
+                    }
+                }
+            }
+            catch (Exception exception)
+            {
+                if (!loggedError)
+                {
+                    loggedError = true;
+                    AepLog.Warning($"Health height read failed: {exception.Message}");
+                }
+            }
+        }
+
+        HeightCm = 0;
+        HeightSource = HeightSource.Unavailable;
+    }
+
+    // ---- Hydration reminders ------------------------------------------------
+
+    private void HydrationReminderCheck(long now)
+    {
+        if (!profile.HydrationRemindersEnabled)
+        {
+            return;
+        }
+
+        var intervalMs = profile.ReminderIntervalMinutes * 60_000L;
+        if (now - lastReminderMs < intervalMs)
+        {
+            return;
+        }
+
+        var lastDrink = lastDrinkUnix;
+        var latest = profile.LatestDay;
+        if (latest is { Drinks.Count: > 0 })
+        {
+            lastDrink = Math.Max(lastDrink, latest.Drinks[latest.Drinks.Count - 1].Unix);
+        }
+
+        var sinceDrinkSeconds = DateTimeOffset.UtcNow.ToUnixTimeSeconds() - lastDrink;
+        if (lastDrink != 0 && sinceDrinkSeconds < profile.ReminderIntervalMinutes * 60L)
+        {
+            return;
+        }
+
+        if (InQuietHours(DateTime.Now) || RemindersSuppressed())
+        {
+            return;
+        }
+
+        lastReminderMs = now;
+        notifications.Notify(new PhoneNotification("health", "Hydration",
+            "Your adventurer has not logged a drink recently.", DateTime.Now, Accent, "health.hydration"));
+    }
+
+    private bool InQuietHours(DateTime now)
+    {
+        var start = profile.QuietStartHour * 60 + profile.QuietStartMinute;
+        var end = profile.QuietEndHour * 60 + profile.QuietEndMinute;
+        if (start == end)
+        {
+            return false;
+        }
+
+        var current = now.Hour * 60 + now.Minute;
+        return start < end ? current >= start && current < end : current >= start || current < end;
+    }
+
+    private bool RemindersSuppressed()
+    {
+        if (!profile.ReminderPauseInDuties)
+        {
+            return false;
+        }
+
+        var c = Plugin.Condition;
+        return c[ConditionFlag.InCombat] || c[ConditionFlag.BoundByDuty] || c[ConditionFlag.BoundByDuty56] ||
+               c[ConditionFlag.WatchingCutscene] || c[ConditionFlag.OccupiedInCutSceneEvent] ||
+               c[ConditionFlag.BetweenAreas];
+    }
+
+    // ---- Goals --------------------------------------------------------------
+
+    public (double Current, double Target) GoalProgress(HealthGoal goal)
+    {
+        return (GoalValue(goal.Type, goal.Scope), goal.Target);
+    }
+
+    private void EvaluateGoals(HealthDay day)
+    {
+        for (var index = 0; index < profile.Goals.Count; index++)
+        {
+            var goal = profile.Goals[index];
+            if (!goal.Enabled || goal.Target <= 0)
+            {
+                continue;
+            }
+
+            var current = GoalValue(goal.Type, goal.Scope);
+            var key = ScopeKey(goal.Scope);
+            if (current + 0.0001 < goal.Target)
+            {
+                continue;
+            }
+
+            if (goal.CompletedKey == key)
+            {
+                continue;
+            }
+
+            goal.CompletedKey = key;
+            day.GoalsCompleted++;
+            dirty = true;
+            notifications.Notify(new PhoneNotification("health", "Goal complete",
+                $"{goal.Name} — done!", DateTime.Now, Accent, "health.goal." + goal.Id));
+        }
+    }
+
+    private string ScopeKey(HealthGoalScope scope) => scope switch
+    {
+        HealthGoalScope.Daily => DateKey(),
+        HealthGoalScope.Weekly => WeekStartKey(),
+        HealthGoalScope.Session => SessionStartedUnix.ToString(CultureInfo.InvariantCulture),
+        _ => "all",
+    };
+
+    private static string WeekStartKey()
+    {
+        var today = DateTime.Now.Date;
+        var offset = (int)today.DayOfWeek;
+        return today.AddDays(-offset).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+    }
+
+    private double GoalValue(HealthGoalType type, HealthGoalScope scope) => type switch
+    {
+        HealthGoalType.Steps => HealthFormat.Steps(Scoped(scope, d => d.OnFootYalms, SessionOnFootYalms,
+            profile.AllWalkYalms + profile.AllRunYalms), profile.StrideYalms),
+        HealthGoalType.OnFootDistance => Scoped(scope, d => d.OnFootYalms, SessionOnFootYalms,
+            profile.AllWalkYalms + profile.AllRunYalms),
+        HealthGoalType.WalkDistance => Scoped(scope, d => d.WalkYalms, sWalk, profile.AllWalkYalms),
+        HealthGoalType.RunDistance => Scoped(scope, d => d.RunYalms, sRun, profile.AllRunYalms),
+        HealthGoalType.SwimDistance => Scoped(scope, d => d.SwimTotalYalms, SessionSwimYalms,
+            profile.AllSwimYalms + profile.AllDiveYalms),
+        HealthGoalType.ActiveTime => Scoped(scope, d => d.ActiveSeconds, sActive, profile.AllActiveSeconds),
+        HealthGoalType.HydrationCount => Scoped(scope, d => d.DrinkCount, sDrinks, profile.AllDrinks),
+        HealthGoalType.HydrationVolume => Scoped(scope, d => d.DrinkMillilitres, sDrinkMl, WeekSum(d => d.DrinkMillilitres)),
+        HealthGoalType.Teleports => Scoped(scope, d => d.Teleports, sTeleports, profile.AllTeleports),
+        HealthGoalType.TeleportDistance => Scoped(scope, d => d.TeleportYalms, sTeleY, profile.AllTeleportYalms),
+        HealthGoalType.Calories => Scoped(scope, d => d.Calories, sKcal, profile.AllCalories),
+        _ => 0d,
+    };
+
+    private double Scoped(HealthGoalScope scope, Func<HealthDay, double> perDay, double session, double allTime)
+    {
+        return scope switch
+        {
+            HealthGoalScope.Session => session,
+            HealthGoalScope.AllTime => allTime,
+            HealthGoalScope.Weekly => WeekSum(perDay),
+            _ => profile.LatestDay is { } day ? perDay(day) : 0d,
+        };
+    }
+
+    private double WeekSum(Func<HealthDay, double> perDay)
+    {
+        var cutoff = DateTime.Now.Date.AddDays(-6).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        var sum = 0d;
+        for (var index = profile.Days.Count - 1; index >= 0; index--)
+        {
+            var day = profile.Days[index];
+            if (string.CompareOrdinal(day.Date, cutoff) < 0)
+            {
+                break;
+            }
+
+            sum += perDay(day);
+        }
+
+        return sum;
+    }
+
+    // ---- Helpers ------------------------------------------------------------
+
+    private void OnLogout(int type, int code)
+    {
+        SaveNow();
+        hasBaseline = false;
+        pendingTeleport = false;
+    }
+
+    private static double Horizontal(Vector3 a, Vector3 b)
+    {
+        double dx = a.X - b.X, dz = a.Z - b.Z;
+        return Math.Sqrt(dx * dx + dz * dz);
+    }
+}

--- a/src/Aetherphone/Core/Home/HomeLayoutService.cs
+++ b/src/Aetherphone/Core/Home/HomeLayoutService.cs
@@ -26,6 +26,7 @@ internal sealed class HomeLayoutService
         "clock", "notes", "calculator", "timers",
         "wallet", "dailies", "calendar", "news",
         "character", "notifications", "jobs",
+        "health",
     };
 
     private static readonly string[] DefaultTrailingApps = { "dev" };

--- a/src/Aetherphone/Core/Localization/L.cs
+++ b/src/Aetherphone/Core/Localization/L.cs
@@ -281,6 +281,9 @@ internal static class L
         public static readonly LocString CharacterSub = new("storeCopy.characterSub", "Your day, tracked");
         public static readonly LocString CharacterBody = new("storeCopy.characterBody",
             "Rings, streaks and history for the things you do every day.");
+        public static readonly LocString HealthSub = new("storeCopy.healthSub", "Your adventurer's activity");
+        public static readonly LocString HealthBody = new("storeCopy.healthBody",
+            "Estimated steps, distance, swimming, hydration and personal goals for your character. A fictional activity tracker for roleplay and statistics.");
         public static readonly LocString WalletSub = new("storeCopy.walletSub", "Gil and currencies");
         public static readonly LocString WalletBody = new("storeCopy.walletBody",
             "Every currency you carry, with caps and totals you can actually read.");

--- a/src/Aetherphone/Core/PhoneServices.cs
+++ b/src/Aetherphone/Core/PhoneServices.cs
@@ -6,6 +6,7 @@ using Aetherphone.Core.Confirm;
 using Aetherphone.Core.Crypto;
 using Aetherphone.Core.Game;
 using Aetherphone.Core.Games;
+using Aetherphone.Core.Health;
 using Aetherphone.Core.Inventory;
 using Aetherphone.Core.Lodestone;
 using Aetherphone.Core.Maps;
@@ -85,6 +86,7 @@ internal sealed class PhoneServices : IDisposable
     public required InventoryCaptureService InventoryCapture { get; init; }
     public required ActivityTracker Activity { get; init; }
     public required ActivityRingNotifier RingNotifier { get; init; }
+    public required HealthTracker Health { get; init; }
     public required CallHub Calls { get; init; }
     public required PhoneVisibility Visibility { get; init; }
     public required RealtimeSignalBus RealtimeSignals { get; init; }
@@ -170,6 +172,7 @@ internal sealed class PhoneServices : IDisposable
         var inventoryCapture = new InventoryCaptureService(framework, inventoryStore);
         var activity = new ActivityTracker(framework, clientState, dutyState, gameData, configDirectory);
         var ringNotifier = new ActivityRingNotifier(framework, activity, configuration, notifications);
+        var health = new HealthTracker(framework, characterWatch, notifications, configDirectory);
         var realtimeSignals = new RealtimeSignalBus();
         var visibility = new PhoneVisibility();
         var confirm = new ConfirmService();
@@ -230,6 +233,7 @@ internal sealed class PhoneServices : IDisposable
             InventoryCapture = inventoryCapture,
             Activity = activity,
             RingNotifier = ringNotifier,
+            Health = health,
             Calls = calls,
             Visibility = visibility,
             RealtimeSignals = realtimeSignals,
@@ -253,6 +257,7 @@ internal sealed class PhoneServices : IDisposable
         Collections.Dispose();
         InventoryCapture.Dispose();
         RingNotifier.Dispose();
+        Health.Dispose();
         Activity.Dispose();
         Venues.Dispose();
         SongPlayer.Dispose();

--- a/src/Aetherphone/Windows/Components/AppIconArt.cs
+++ b/src/Aetherphone/Windows/Components/AppIconArt.cs
@@ -67,6 +67,9 @@ internal static class AppIconArt
             case "tetris":
                 DrawTetris(dl, center, extent, inkColor);
                 return true;
+            case "health":
+                DrawHealth(dl, center, extent, inkColor, holeColor);
+                return true;
             default:
                 return false;
         }
@@ -365,6 +368,33 @@ internal static class AppIconArt
             var blockMin = new Vector2(blockCenter.X - blockExtent, blockCenter.Y - blockExtent);
             var blockMax = new Vector2(blockCenter.X + blockExtent, blockCenter.Y + blockExtent);
             dl.AddRectFilled(blockMin, blockMax, ink, rounding);
+        }
+    }
+
+    private static void DrawHealth(ImDrawListPtr dl, Vector2 center, float extent, uint ink, uint hole)
+    {
+        var lobe = extent * 0.36f;
+        var leftLobe = At(center, extent, -0.34f, -0.24f);
+        var rightLobe = At(center, extent, 0.34f, -0.24f);
+        dl.AddCircleFilled(leftLobe, lobe, ink, 24);
+        dl.AddCircleFilled(rightLobe, lobe, ink, 24);
+        Span<Vector2> heart = stackalloc Vector2[3]
+        {
+            At(center, extent, -0.72f, -0.08f), At(center, extent, 0.72f, -0.08f), At(center, extent, 0f, 0.88f),
+        };
+        FillConvex(dl, ink, heart);
+
+        var y = center.Y + extent * 0.02f;
+        var thickness = extent * 0.13f;
+        Span<Vector2> pulse = stackalloc Vector2[6]
+        {
+            new(center.X - lobe * 1.7f, y), new(center.X - lobe * 0.7f, y),
+            new(center.X - lobe * 0.3f, y - extent * 0.36f), new(center.X + lobe * 0.15f, y + extent * 0.32f),
+            new(center.X + lobe * 0.6f, y), new(center.X + lobe * 1.7f, y),
+        };
+        for (var index = 0; index < pulse.Length - 1; index++)
+        {
+            dl.AddLine(pulse[index], pulse[index + 1], hole, thickness);
         }
     }
 

--- a/src/Aetherphone/Windows/Components/AppPalettes.cs
+++ b/src/Aetherphone/Windows/Components/AppPalettes.cs
@@ -10,6 +10,24 @@ internal static class AppPalettes
     private static readonly Vector4 GlassField = new(1f, 1f, 1f, 0.10f);
     private static readonly Vector4 DefaultHover = new(1f, 1f, 1f, 0.06f);
 
+    public static readonly AppPalette Health = new()
+    {
+        Accent = AppAccents.For("health"),
+        TitleInk = new(0.99f, 0.95f, 0.96f, 1f),
+        BodyInk = new(0.94f, 0.86f, 0.88f, 0.96f),
+        MutedInk = new(0.80f, 0.68f, 0.72f, 0.85f),
+        HeaderInk = new(0.99f, 0.72f, 0.76f, 0.95f),
+        HeadingInk = new(0.99f, 0.94f, 0.95f, 1f),
+        BackdropTop = new(0.24f, 0.06f, 0.11f, 1f),
+        BackdropBottom = new(0.05f, 0.02f, 0.03f, 1f),
+        BloomTop = new(0.92f, 0.30f, 0.42f, 0.24f),
+        BloomBottom = new(0.50f, 0.12f, 0.20f, 0f),
+        CardFill = GlassFill,
+        CardStroke = GlassStroke,
+        FieldSurface = GlassField,
+        HoverTint = DefaultHover,
+    };
+
     public static readonly AppPalette Chirper = new()
     {
         Accent = AppAccents.For("chirper"),


### PR DESCRIPTION
## What

Adds **Health**, a native phone app (id `health`) that tracks your character's fictional activity: estimated steps and on-foot distance, swimming/diving, active time, optional activity energy, hydration logging with reminders, daily/custom goals, history, streaks, personal records, and best-effort teleport stats.

## Why

There's no step tracker among the built-in apps, and it's a natural fit for the phone: it's passive, glanceable, and per-character. Everything is presented in-universe as estimates for roleplay and statistics — no real-world or medical framing, and no gender/sex/pronoun or identity fields anywhere.

Implementation notes for review:

- `HealthTracker` samples the local player's position ~10x/s via the shared `FrameworkTicker`, uses horizontal X/Z displacement only, and pauses on loading, cutscenes, mounts, flying and auto-transport (`BeingMoved`), so teleports and zone changes never add fake walking distance.
- Per-character JSON under the config dir, following the existing `ActivityStore` pattern. Session totals reset on reload; daily totals roll over at local midnight; 60 days of history retained; loaded values are sanitized (NaN/negative/corrupt goals).
- Height is derived from the in-game customize array using FFXIV's racial-scaling (RSP) model; weight is an optional fictional value used only for energy estimates. Units switch between Eorzean / Metric / Imperial.
- Reuses existing infrastructure throughout: `IPhoneApp` + `AppRegistry`, `PhoneServices` lifecycle, `NotificationService` for goal/hydration notifications, `ConfirmService` for destructive resets, `AppSkin`/`Typography`/`SegmentStrip`/`IconTile` for UI, vector app icon in `AppIconArt`, and an App Store entry under Adventure. No new NuGet packages, no IPC, no network, no hooks or memory reads.

## How to test

1. `/phone` → Health appears on the home screen (and in App Store -> Adventure).
2. **Setup:** first open runs a 5-step wizard (units, daily goals, weight, movement, review). Confirm detected name/world/race/clan and that no gender/identity field appears.
3. **Tracking:** walk/sprint -> steps and on-foot distance rise; stand still -> no change; mount or fly -> no steps; swim -> tracked separately with no steps; teleport or change zone -> teleport counter increments with no false walking distance.
4. **Hydration:** "Drink Water" and the quick chips log entries; "Undo last drink" removes the newest; reminder settings expose interval + `HH:MM` quiet hours.
5. **Goals:** add / edit (type, scope, numeric target) / disable / delete / reset to defaults; completing a goal fires one notification, not repeats.
6. **Profile:** Height, Weight (+ suggestions), Units, Stride, Tracking status and Reset cards all function; resets ask for confirmation.
7. **Persistence:** reload the plugin — daily and all-time survive, session resets to zero. Switch characters — stats stay separate.

## Checklist

- [x] `dotnet build -c Release` passes
- [x] Verified in-game: opened the phone and exercised the affected app/screen
- [ ] If this changes user-visible behavior, README is updated
- [x] Matches existing style: uses the shared `Windows/Components/` widgets, no `what` comments
