### PR TITLE
AppStore: support per-app developer names in the detail card

### DIFF
--- a/src/Aetherphone/Apps/AppStore/AppStoreApp.Detail.cs
+++ b/src/Aetherphone/Apps/AppStore/AppStoreApp.Detail.cs
@@ -154,14 +154,20 @@ internal sealed partial class AppStoreApp
         var cardMin = new Vector2(origin.X, top);
         var cardMax = new Vector2(origin.X + width, top + rowCount * rowHeight);
         ui.Card(drawList, cardMin, cardMax, Metrics.Radius.Card * scale, true);
-        DrawInfoRow(drawList, cardMin, cardMax, 0, rowHeight, Loc.T(L.Store.Developer), Loc.T(L.Store.DeveloperName),
-            scale);
+        DrawInfoRow(drawList, cardMin, cardMax, 0, rowHeight, Loc.T(L.Store.Developer), DeveloperName(app), scale);
         DrawInfoRow(drawList, cardMin, cardMax, 1, rowHeight, Loc.T(L.Store.Category),
             Loc.T(AppStoreCatalog.Name(entry.Category)), scale);
         DrawInfoRow(drawList, cardMin, cardMax, 2, rowHeight, Loc.T(L.Store.Languages),
             Loc.T(L.Store.LanguageCount, LanguageCount), scale);
         return cardMax.Y + Metrics.Space.Xl * scale;
     }
+
+    private static string DeveloperName(IPhoneApp app) => app.Id switch
+    {
+        "health" => "Yozora",
+        "jobs" => "K.I.R.O",
+        _ => Loc.T(L.Store.DeveloperName), // default "Aetherphone"
+    };
 
     private void DrawInfoRow(ImDrawListPtr drawList, Vector2 cardMin, Vector2 cardMax, int index, float rowHeight,
         string label, string value, float scale)


### PR DESCRIPTION
## What

Replaces the hardcoded global developer string in the App Store detail's Information card with a small `DeveloperName(IPhoneApp app)` helper keyed on `app.Id`, so individual apps can be attributed to their own author while everything else falls back to the localized default.

## Why

The Information card previously showed the same developer ("Aetherphone") for every app, so there was no way to credit an app contributed by someone else. This makes attribution a one-line addition per app — a `switch` arm in a single file — with the existing localized name as the default for anything not listed. No behavior changes for existing apps.

## How to test

1. `/phone` -> App Store -> open any existing app (e.g. Polls) -> Information card still shows the default developer, unchanged.
2. Add a temporary arm to `DeveloperName` (e.g. `"polls" => "Test Name",`), rebuild, reopen that app's store page -> Developer now reads "Test Name" while every other app is unaffected.

## Checklist

- [x] `dotnet build -c Release` passes
- [x] Verified in-game: opened the phone and exercised the affected app/screen
- [ ] If this changes user-visible behavior, README is updated
- [x] Matches existing style: uses the shared `Windows/Components/` widgets, no `what` comments
