### PR TITLE
fix(velvet): treat an unknown race as unavailable instead of allowed

### DIFF
--- a/src/Aetherphone.Tests/RaceWatchTests.cs
+++ b/src/Aetherphone.Tests/RaceWatchTests.cs
@@ -1,0 +1,137 @@
+using Aetherphone.Core.Game;
+using Xunit;
+
+namespace Aetherphone.Tests;
+
+public sealed class RaceWatchTests
+{
+    private const byte HyurRace = 1;
+    private const byte Unpopulated = 0;
+    private const int CustomizeLength = 26;
+
+    [Fact]
+    public void StartsUnknown_SoNothingIsReportedBeforeACharacterLoads()
+    {
+        var watch = new RaceWatch();
+
+        Assert.Null(watch.Race);
+        Assert.Null(watch.IsLalafell);
+    }
+
+    [Fact]
+    public void Observe_RecordsTheRaceItRead()
+    {
+        var watch = new RaceWatch();
+
+        watch.Observe(Customize(HyurRace));
+
+        Assert.Equal(HyurRace, watch.Race);
+    }
+
+    [Fact]
+    public void Observe_RecordsALalafell()
+    {
+        var watch = new RaceWatch();
+
+        watch.Observe(Customize(RaceWatch.LalafellRaceId));
+
+        Assert.Equal(RaceWatch.LalafellRaceId, watch.Race);
+        Assert.True(watch.IsLalafell);
+    }
+
+    [Fact]
+    public void Observe_RecordsANonLalafell()
+    {
+        var watch = new RaceWatch();
+
+        watch.Observe(Customize(HyurRace));
+
+        Assert.False(watch.IsLalafell);
+    }
+
+    [Fact]
+    public void Observe_LeavesTheAnswerUnknownWhenThereIsNoCustomizeData()
+    {
+        var watch = new RaceWatch();
+
+        watch.Observe([]);
+
+        Assert.Null(watch.Race);
+        Assert.Null(watch.IsLalafell);
+    }
+
+    [Fact]
+    public void Observe_TreatsAnUnpopulatedRaceByteAsNoAnswer()
+    {
+        var watch = new RaceWatch();
+
+        watch.Observe(Customize(Unpopulated));
+
+        Assert.Null(watch.Race);
+        Assert.Null(watch.IsLalafell);
+    }
+
+    [Fact]
+    public void AnUnpopulatedReadDoesNotOverwriteAKnownAnswer()
+    {
+        var watch = new RaceWatch();
+        watch.Observe(Customize(RaceWatch.LalafellRaceId));
+
+        watch.Observe(Customize(Unpopulated));
+
+        Assert.True(watch.IsLalafell);
+    }
+
+    [Fact]
+    public void AFailedReadDoesNotEraseAnAnswerWeAlreadyHave()
+    {
+        var watch = new RaceWatch();
+        watch.Observe(Customize(RaceWatch.LalafellRaceId));
+
+        watch.Observe([]);
+
+        Assert.True(watch.IsLalafell);
+    }
+
+    [Fact]
+    public void Observe_TracksARaceChangeRatherThanLatchingTheFirstRead()
+    {
+        var watch = new RaceWatch();
+        watch.Observe(Customize(HyurRace));
+
+        watch.Observe(Customize(RaceWatch.LalafellRaceId));
+
+        Assert.True(watch.IsLalafell);
+    }
+
+    [Fact]
+    public void Forget_ReturnsToUnknownWhenTheCharacterGoesAway()
+    {
+        var watch = new RaceWatch();
+        watch.Observe(Customize(RaceWatch.LalafellRaceId));
+
+        watch.Forget();
+
+        Assert.Null(watch.Race);
+        Assert.Null(watch.IsLalafell);
+    }
+
+    [Fact]
+    public void ObserveAfterForget_DoesNotKeepThePreviousCharactersAnswer()
+    {
+        var watch = new RaceWatch();
+        watch.Observe(Customize(RaceWatch.LalafellRaceId));
+        watch.Forget();
+
+        watch.Observe(Customize(HyurRace));
+
+        Assert.False(watch.IsLalafell);
+    }
+
+    private static byte[] Customize(byte race)
+    {
+        var customize = new byte[CustomizeLength];
+        customize[RaceWatch.RaceIndex] = race;
+        return customize;
+    }
+}

--- a/src/Aetherphone/Apps/Velvet/VelvetShell.cs
+++ b/src/Aetherphone/Apps/Velvet/VelvetShell.cs
@@ -22,7 +22,6 @@ using Aetherphone.Core.Theme;
 using Aetherphone.Core.Wallpapers;
 using Aetherphone.Windows.Components;
 using Dalamud.Bindings.ImGui;
-using Dalamud.Game.ClientState.Objects.Enums;
 using Dalamud.Interface;
 using Dalamud.Interface.Utility;
 
@@ -31,6 +30,7 @@ namespace Aetherphone.Apps.Velvet;
 internal sealed partial class VelvetShell : IPhoneApp
 {
     private const float HeartbeatSeconds = 45f;
+    private const long RaceProbeIntervalMilliseconds = 1000;
 
     private readonly VelvetStore store;
     private readonly StoryPresenter stories;
@@ -66,11 +66,13 @@ internal sealed partial class VelvetShell : IPhoneApp
     private readonly RouterDraw<VelvetView> drawView;
     private readonly Action back;
 
+    private readonly RaceWatch race = new();
+    private readonly FrameworkTicker raceTicker;
+
     private PhoneTheme theme = PhoneTheme.Default;
     private INavigator navigation = null!;
     private VelvetPage activeTab = VelvetPage.Discover;
     private float sinceHeartbeat = HeartbeatSeconds;
-    private bool cachedLalafell;
 
     public VelvetShell(AethernetSession session, AethernetApi net, LodestoneService lodestone,
         Configuration configuration, PhotoLibrary library, HttpService http, RemoteImageCache images,
@@ -109,6 +111,8 @@ internal sealed partial class VelvetShell : IPhoneApp
         drawView = DrawView;
         back = () => router.Pop();
         threadView = new ThreadView(this);
+        raceTicker = new FrameworkTicker(Plugin.Framework, RaceProbeIntervalMilliseconds, ProbeRace,
+            installer.Gate(Id));
     }
 
     public string Id => "velvet";
@@ -206,7 +210,7 @@ internal sealed partial class VelvetShell : IPhoneApp
             return;
         }
 
-        if (IsLalafellCharacter() || store.AccessBlocked)
+        if (Unavailable)
         {
             TourHolds.Hold(Id);
             store.EnsureMe();
@@ -263,6 +267,7 @@ internal sealed partial class VelvetShell : IPhoneApp
 
     public void Dispose()
     {
+        raceTicker.Dispose();
         threadView.Dispose();
         stories.Dispose();
         store.Dispose();
@@ -272,34 +277,38 @@ internal sealed partial class VelvetShell : IPhoneApp
         configuration.VelvetAcknowledgedGate &&
         configuration.VelvetAcknowledgedGateVersion >= Configuration.VelvetGateVersion;
 
+    private bool Unavailable => race.IsLalafell is not false || store.AccessBlocked;
+
     private void TickHeartbeat()
     {
         sinceHeartbeat += ImGui.GetIO().DeltaTime;
-        if (sinceHeartbeat >= HeartbeatSeconds)
+        if (sinceHeartbeat < HeartbeatSeconds)
         {
-            sinceHeartbeat = 0f;
-            store.Heartbeat(SocialRegion.EffectiveCode(configuration, gameData), IsLalafellCharacter());
+            return;
         }
+
+        if (race.IsLalafell is not { } isLalafell)
+        {
+            return;
+        }
+
+        sinceHeartbeat = 0f;
+        store.Heartbeat(SocialRegion.EffectiveCode(configuration, gameData), isLalafell);
     }
 
-    private bool IsLalafellCharacter()
+    private void ProbeRace()
     {
-        const byte lalafellRaceId = 3;
-        if (!Plugin.Framework.IsInFrameworkUpdateThread)
+        if (!Plugin.ClientState.IsLoggedIn)
         {
-            return cachedLalafell;
+            race.Forget();
+            return;
         }
 
         var local = gameData.LocalPlayer;
-        if (local is null)
+        if (local is not null)
         {
-            return cachedLalafell;
+            race.Observe(local.Customize);
         }
-
-        var customize = local.Customize;
-        var raceIndex = (int)CustomizeIndex.Race;
-        cachedLalafell = customize.Length > raceIndex && customize[raceIndex] == lalafellRaceId;
-        return cachedLalafell;
     }
 
     private void DrawView(VelvetView view, Rect area, int depth)

--- a/src/Aetherphone/Core/Game/RaceWatch.cs
+++ b/src/Aetherphone/Core/Game/RaceWatch.cs
@@ -1,0 +1,35 @@
+using Dalamud.Game.ClientState.Objects.Enums;
+
+namespace Aetherphone.Core.Game;
+
+internal sealed class RaceWatch
+{
+    internal const int RaceIndex = (int)CustomizeIndex.Race;
+    internal const byte LalafellRaceId = 3;
+
+    private const byte UnknownRaceId = 0;
+
+    private volatile byte race = UnknownRaceId;
+
+    public byte? Race => race == UnknownRaceId ? null : race;
+
+    public bool? IsLalafell => Race is { } known ? known == LalafellRaceId : null;
+
+    public void Forget() => race = UnknownRaceId;
+
+    public void Observe(ReadOnlySpan<byte> customize)
+    {
+        if (customize.Length <= RaceIndex)
+        {
+            return;
+        }
+
+        var observed = customize[RaceIndex];
+        if (observed == UnknownRaceId)
+        {
+            return;
+        }
+
+        race = observed;
+    }
+}


### PR DESCRIPTION
## What

Velvet is meant to be unavailable on Lalafell characters. The check behind that can't tell your race until a character is loaded, and when it can't tell it answers "not a Lalafell". So at the login screen a Lalafell gets in. This gives the check a third answer, "don't know yet", and treats that as unavailable.

## Why

Came out of this report: https://discord.com/channels/1527213298087493732/1530436723899633855

`cachedLalafell` is a plain bool defaulting to false and both early returns in `IsLalafellCharacter()` hand it back, so "couldn't read the race" and "confirmed not a Lalafell" were the same value. With no character loaded it is always false.

Two things consume it:

- the unavailable screen from 048db794, so the app opens at the title screen
- the heartbeat, which sends `&lalafell=false`. `sinceHeartbeat` starts already expired, so the first drawn frame sends it before any read could have succeeded.

The 403 doesn't cover this on its own. `EnsureMe` returns early once `me is not null`, and `me` and `accessBlocked` only reset on an account change, so the 403 can only land on the first profile load after signing in. After one 200 the client side check is the only thing left. The gate at the top of `Draw` also runs before the profile load it depends on has finished.

## How to test

1. Sign in, then sit at the title screen with Velvet open (reloading the plugin there is quickest). On master the app opens normally. With this it shows the Unavailable screen.
2. Log in on a Lalafell with Velvet open. Unavailable, same as master.
3. Log in on anything else. Velvet works as before, though it can take up to a second after the character loads.

Step 1 is the one that matters.

## Extra

`RaceWatch` (new, `Core/Game/`) holds the race id it read, or null if it doesn't have one yet, and `IsLalafell` comes off that. Race id 0 is ignored since it isn't a real race, and a failed read never overwrites an answer it already has. It's a volatile byte because `bool?` is two fields and can be caught half written from the draw thread.

`VelvetShell` reads it on a `FrameworkTicker` (1s, gated on the app being installed) rather than during `Draw`, so it no longer depends on whether `Draw` counts as the framework thread. It forgets the answer only on a real logout, so a loading screen or a zone change keeps the last known race.

The two call sites want opposite defaults, which is the reason for the tri-state: the gate blocks on unknown, the heartbeat sends nothing on unknown instead of a guess.

11 tests in `RaceWatchTests`.

Couple of open questions:

- Does the 403 depend on the `lalafell` flag we send? If it does, some stored tags are probably wrong, since master can send false for a character it never read.
- Skipping the beat also skips region and last seen, so presence stops refreshing at the title screen. Beating without the flag would avoid that, but `&lalafell=` is always appended, so it needs a server side change.

## Checklist

- [ ] `dotnet build -c Release` passes
- [ ] Verified in-game: opened the phone and exercised the affected app/screen
- [ ] If this changes user-visible behavior, README is updated
- [ ] Matches existing style: uses the shared `Windows/Components/` widgets, no `what` comments
