### PR TITLE
fix(controlcenter): removed modules no longer reappear after a restart

### DIFF
--- a/src/Aetherphone.Tests/Aetherphone.Tests.csproj
+++ b/src/Aetherphone.Tests/Aetherphone.Tests.csproj
@@ -9,6 +9,26 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+    <DalamudLibPath>$(appdata)\XIVLauncher\addon\Hooks\dev\</DalamudLibPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
+    <DalamudLibPath>$(HOME)/.xlcore/dalamud/Hooks/dev/</DalamudLibPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
+    <DalamudLibPath>$(HOME)/Library/Application Support/XIV on Mac/dalamud/Hooks/dev/</DalamudLibPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(DALAMUD_HOME)' != ''">
+    <DalamudLibPath>$(DALAMUD_HOME)/</DalamudLibPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblySearchPaths>$(AssemblySearchPaths);$(DalamudLibPath)</AssemblySearchPaths>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="Dalamud" Private="true" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.9.2" />

--- a/src/Aetherphone.Tests/ControlLayoutServiceInstallTests.cs
+++ b/src/Aetherphone.Tests/ControlLayoutServiceInstallTests.cs
@@ -1,0 +1,130 @@
+using Aetherphone.Core.ControlCenter;
+using Dalamud.Interface;
+using Xunit;
+
+namespace Aetherphone.Tests;
+
+public sealed class ControlLayoutServiceInstallTests
+{
+    [Fact]
+    public void FreshInstall_EnablesEveryAvailableModule()
+    {
+        var modules = MakeModules();
+        var service = BuildService(modules, new FakeControlConfiguration());
+
+        for (var index = 0; index < modules.Count; index++)
+        {
+            Assert.True(SlotIndexOf(service, modules[index].Id) >= 0,
+                $"Module '{modules[index].Id}' should ship on the grid");
+        }
+    }
+
+    [Fact]
+    public void ModuleShippedAfterTheSaveWasWritten_IsNotEnabled()
+    {
+        var modules = MakeModules();
+        var configuration = SavedWith("a", "b");
+
+        var service = BuildService(modules, configuration);
+
+        Assert.Equal(-1, SlotIndexOf(service, "c"));
+    }
+
+    [Fact]
+    public void Add_PutsTheModuleOnTheGridAndSurvivesAReload()
+    {
+        var modules = MakeModules();
+        var configuration = SavedWith("a", "b");
+
+        var first = BuildService(modules, configuration);
+        first.Add(modules[2]);
+        Assert.True(SlotIndexOf(first, "c") >= 0);
+
+        var reloaded = BuildService(modules, configuration);
+
+        Assert.True(SlotIndexOf(reloaded, "c") >= 0, "A module the user added should still be on the grid after a reload");
+    }
+
+    [Fact]
+    public void Remove_TakesTheModuleOffTheGridAndSurvivesAReload()
+    {
+        var modules = MakeModules();
+        var configuration = SavedWith("a", "b", "c");
+
+        var first = BuildService(modules, configuration);
+        var slot = first.Slots[SlotIndexOf(first, "c")];
+        first.Remove(slot);
+        Assert.Equal(-1, SlotIndexOf(first, "c"));
+
+        var reloaded = BuildService(modules, configuration);
+
+        Assert.True(SlotIndexOf(reloaded, "c") < 0, "A module the user removed must stay removed across a restart");
+    }
+
+    private static int SlotIndexOf(ControlLayoutService service, string moduleId)
+    {
+        for (var index = 0; index < service.Slots.Count; index++)
+        {
+            if (service.Slots[index].Id == moduleId)
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    private static ControlLayoutService BuildService(List<IControlModule> modules, FakeControlConfiguration configuration) =>
+        new(new FakeControlRegistry(modules), configuration);
+
+    private static FakeControlConfiguration SavedWith(params string[] moduleIds)
+    {
+        var layout = new ControlLayout();
+        for (var index = 0; index < moduleIds.Length; index++)
+        {
+            layout.Items.Add(new ControlItem { ModuleId = moduleIds[index], Span = "small" });
+        }
+
+        layout.Enabled.AddRange(moduleIds);
+        return new FakeControlConfiguration { ControlPanel = layout };
+    }
+
+    private static List<IControlModule> MakeModules() =>
+        new()
+        {
+            new FakeControlModule("a"),
+            new FakeControlModule("b"),
+            new FakeControlModule("c"),
+        };
+
+    private sealed class FakeControlModule : IControlModule
+    {
+        public FakeControlModule(string id) => Id = id;
+        public string Id { get; }
+        public string GalleryLabel => Id;
+        public FontAwesomeIcon GalleryIcon => FontAwesomeIcon.Circle;
+        public IReadOnlyList<ControlSpan> Sizes { get; } = new[] { ControlSpan.Small };
+        public ControlSpan DefaultSpan => ControlSpan.Small;
+        public void Draw(in ControlModuleContext context) { }
+    }
+
+    private sealed class FakeControlRegistry : IControlRegistry
+    {
+        private readonly Dictionary<string, IControlModule> byId;
+
+        public FakeControlRegistry(List<IControlModule> modules)
+        {
+            Modules = modules;
+            byId = modules.ToDictionary(module => module.Id);
+        }
+
+        public IReadOnlyList<IControlModule> Modules { get; }
+        public bool TryGet(string id, out IControlModule module) => byId.TryGetValue(id, out module!);
+    }
+
+    private sealed class FakeControlConfiguration : IControlConfiguration
+    {
+        public ControlLayout? ControlPanel { get; set; }
+        public void Save() { }
+    }
+}

--- a/src/Aetherphone/Configuration.cs
+++ b/src/Aetherphone/Configuration.cs
@@ -22,7 +22,7 @@ using Dalamud.Configuration;
 namespace Aetherphone;
 
 [Serializable]
-internal sealed class Configuration : IPluginConfiguration, IHomeConfiguration
+internal sealed class Configuration : IPluginConfiguration, IHomeConfiguration, IControlConfiguration
 {
     public int Version { get; set; } = 1;
     public bool OpenOnStartup { get; set; } = true;

--- a/src/Aetherphone/Core/ControlCenter/ControlLayout.cs
+++ b/src/Aetherphone/Core/ControlCenter/ControlLayout.cs
@@ -4,6 +4,7 @@ namespace Aetherphone.Core.ControlCenter;
 internal sealed class ControlLayout
 {
     public List<ControlItem> Items { get; set; } = new();
+    public List<string> Enabled { get; set; } = new();
 }
 
 [Serializable]

--- a/src/Aetherphone/Core/ControlCenter/ControlLayoutService.cs
+++ b/src/Aetherphone/Core/ControlCenter/ControlLayoutService.cs
@@ -7,15 +7,15 @@ internal sealed class ControlLayoutService
     public const int Columns = 4;
     private const int SolverRows = 16;
 
-    private readonly ControlRegistry registry;
-    private readonly Configuration configuration;
+    private readonly IControlRegistry registry;
+    private readonly IControlConfiguration configuration;
     private readonly List<ControlSlot> slots = new();
     private readonly List<GridCell> placements = new();
     private readonly HashSet<string> enabled = new();
     private bool placementsDirty = true;
     private int rowsUsed;
 
-    public ControlLayoutService(ControlRegistry registry, Configuration configuration)
+    public ControlLayoutService(IControlRegistry registry, IControlConfiguration configuration)
     {
         this.registry = registry;
         this.configuration = configuration;
@@ -203,6 +203,8 @@ internal sealed class ControlLayoutService
         {
             SeedEnabled(saved);
         }
+
+        enabled.UnionWith(placed);
 
         var all = registry.Modules;
         for (var index = 0; index < all.Count; index++)

--- a/src/Aetherphone/Core/ControlCenter/ControlLayoutService.cs
+++ b/src/Aetherphone/Core/ControlCenter/ControlLayoutService.cs
@@ -11,6 +11,7 @@ internal sealed class ControlLayoutService
     private readonly Configuration configuration;
     private readonly List<ControlSlot> slots = new();
     private readonly List<GridCell> placements = new();
+    private readonly HashSet<string> enabled = new();
     private bool placementsDirty = true;
     private int rowsUsed;
 
@@ -117,6 +118,7 @@ internal sealed class ControlLayoutService
     {
         if (slots.Remove(slot))
         {
+            enabled.Remove(slot.Id);
             Commit();
         }
     }
@@ -128,6 +130,7 @@ internal sealed class ControlLayoutService
             return;
         }
 
+        enabled.Add(module.Id);
         slots.Add(ControlSlot.For(module, module.DefaultSpan));
         Commit();
     }
@@ -177,19 +180,56 @@ internal sealed class ControlLayoutService
             }
         }
 
-        var all = registry.Modules;
-        for (var index = 0; index < all.Count; index++)
-        {
-            if (placed.Add(all[index].Id))
-            {
-                slots.Add(ControlSlot.For(all[index], all[index].DefaultSpan));
-            }
-        }
+        LoadEnabled(saved, placed);
 
         placementsDirty = true;
         if (saved is null)
         {
             Save();
+        }
+    }
+
+    private void LoadEnabled(ControlLayout? saved, HashSet<string> placed)
+    {
+        enabled.Clear();
+        if (saved?.Enabled is { Count: > 0 } stored)
+        {
+            for (var index = 0; index < stored.Count; index++)
+            {
+                enabled.Add(stored[index]);
+            }
+        }
+        else
+        {
+            SeedEnabled(saved);
+        }
+
+        var all = registry.Modules;
+        for (var index = 0; index < all.Count; index++)
+        {
+            if (enabled.Contains(all[index].Id) && placed.Add(all[index].Id))
+            {
+                slots.Add(ControlSlot.For(all[index], all[index].DefaultSpan));
+            }
+        }
+    }
+
+    private void SeedEnabled(ControlLayout? saved)
+    {
+        if (saved is null)
+        {
+            var all = registry.Modules;
+            for (var index = 0; index < all.Count; index++)
+            {
+                enabled.Add(all[index].Id);
+            }
+
+            return;
+        }
+
+        for (var index = 0; index < saved.Items.Count; index++)
+        {
+            enabled.Add(saved.Items[index].ModuleId);
         }
     }
 
@@ -224,6 +264,7 @@ internal sealed class ControlLayoutService
             });
         }
 
+        layout.Enabled.AddRange(enabled);
         configuration.ControlPanel = layout;
         configuration.Save();
     }

--- a/src/Aetherphone/Core/ControlCenter/ControlRegistry.cs
+++ b/src/Aetherphone/Core/ControlCenter/ControlRegistry.cs
@@ -8,7 +8,7 @@ using Dalamud.Interface;
 
 namespace Aetherphone.Core.ControlCenter;
 
-internal sealed class ControlRegistry
+internal sealed class ControlRegistry : IControlRegistry
 {
     private readonly List<IControlModule> modules = new();
     private readonly Dictionary<string, IControlModule> byId = new();

--- a/src/Aetherphone/Core/ControlCenter/IControlConfiguration.cs
+++ b/src/Aetherphone/Core/ControlCenter/IControlConfiguration.cs
@@ -1,0 +1,7 @@
+namespace Aetherphone.Core.ControlCenter;
+
+internal interface IControlConfiguration
+{
+    ControlLayout? ControlPanel { get; set; }
+    void Save();
+}

--- a/src/Aetherphone/Core/ControlCenter/IControlRegistry.cs
+++ b/src/Aetherphone/Core/ControlCenter/IControlRegistry.cs
@@ -1,0 +1,7 @@
+namespace Aetherphone.Core.ControlCenter;
+
+internal interface IControlRegistry
+{
+    IReadOnlyList<IControlModule> Modules { get; }
+    bool TryGet(string id, out IControlModule module);
+}


### PR DESCRIPTION
## Summary

Removed Control Center modules reappeared on every plugin restart, forcing a manual re-removal each time.

`ControlLayoutService.Load()` derived which modules belong on the grid from what's currently placed, with no record of what the user explicitly removed. A module absent from a saved layout looked identical to a module that had never been added, so the auto-add fallback (meant for modules newly registered since the last save) silently re-added anything the user had removed, every time the plugin loaded. Tile position and span for kept modules were never affected - that path only touches `Items`.

## Root cause

```csharp
private void Load()
{
    // ...loads saved Items into slots...

    var all = registry.Modules;
    for (var index = 0; index < all.Count; index++)
    {
        if (placed.Add(all[index].Id))
        {
            slots.Add(ControlSlot.For(all[index], all[index].DefaultSpan));
        }
    }
    // ...
}
```

That fallback can't distinguish "genuinely new module" from "module the user removed." Both are simply absent from `placed`.

## Fix

`ControlLayout` gains a persisted `Enabled` list, and `ControlLayoutService` mirrors `HomeLayoutService`'s existing `Installed`/`LoadInstalled` pattern, which already solves this exact problem correctly for the home screen's app install/uninstall system:

- Trust the saved `Enabled` set directly when present - no re-deriving from `Items`.
- Seed it only once: every module, on a genuinely first run (`saved is null`); from the current `Items`, on a save that predates this field (existing users keep their current layout as the new baseline instead of losing it).
- `Add`/`Remove` update `Enabled` alongside `Items`.
- `Reset()` already nulls the whole `ControlPanel`, so it clears `Enabled` too - a full reset still restores everything.
- `LoadEnabled` unions `placed` into `enabled` right after the trust/seed branch, so `Items` stays a subset of `Enabled` even if the two ever drift (a hand-edited config, a future migration).

No new mechanism invented - same shape, same load order as the code already uses one directory over.

## Behavior change worth flagging

Dropping the auto-add fallback removes a capability, not just a bug: a Control Center module shipped in a future version no longer appears on the grid automatically. It lands in the "Add Controls" gallery instead, same as a first-run module does today, matching `HomeLayoutService`'s already-tested contract.

Control Center has no `MandatoryApps`-equivalent to force a module visible by default - Home does. If a future module needs to ship visible without user action, that's the first time this gap needs closing.

## Unit tests

Added `ControlLayoutServiceInstallTests.cs`, mirroring `HomeLayoutServiceInstallTests.cs`'s first four cases for this same persistence contract:

- `FreshInstall_EnablesEveryAvailableModule`
- `ModuleShippedAfterTheSaveWasWritten_IsNotEnabled`
- `Add_PutsTheModuleOnTheGridAndSurvivesAReload`
- `Remove_TakesTheModuleOffTheGridAndSurvivesAReload` - the actual restart-regression case pinned down deterministically

Needed two small seams to make `ControlLayoutService` fakeable, both additive, no behavior change:

- `IControlConfiguration` (new): `ControlPanel` + `Save()`, the two members the service actually calls on `Configuration`. `Configuration` picks it up alongside its existing `IHomeConfiguration`.
- `IControlRegistry` (new): `Modules` + `TryGet`, the two members the service actually calls on `ControlRegistry`. `ControlRegistry` now implements it; its constructor and module wiring are untouched.
- `ControlLayoutService`'s constructor takes the two interfaces instead of the concrete types. Every call site already passes a `ControlRegistry`/`Configuration`, so this is source-compatible everywhere it's constructed.

One more wrinkle worth flagging: `IControlModule.GalleryIcon` is typed as `FontAwesomeIcon` (Dalamud), unlike every other fakeable interface in this suite (`IPhoneApp.Glyph` is a plain `string` specifically to keep Dalamud out of the test project). Faking `IControlModule` needed `Aetherphone.Tests.csproj` to gain its own reference to the Dalamud assembly, resolved the same way `Aetherphone.csproj` resolves it, without pulling in `Dalamud.NET.Sdk`'s plugin-packaging targets (those don't apply to a test project and demand a plugin manifest if imported). Test-project build config only; no production code or packaging path touched.

## Test plan

- [x] `dotnet build -c Release`: 0 errors, no new warnings (pre-existing AngleSharp NU1902 advisory only)
- [x] `dotnet test`: 107/107 passing (103 existing + 4 new)
- [x] In-game: removed a module, reloaded the plugin (simulates a restart - `ControlLayoutService` only loads once per instantiation), confirmed the module stayed removed
- [x] In-game: confirmed a kept module's position/span survived the reload unaffected
- [x] In-game: re-added the removed module from the gallery, reloaded again, confirmed it now stays present
- [x] Full FFXIV/XIVLauncher restart: removed tiles confirmed still gone after a real restart, not just a plugin reload

No comments added.
