### PR TITLE
feat(security): implement recipient guard and related tests for conversation key management

### DIFF
--- a/src/Aetherphone.Tests/ConversationKeyStoreSecurityTests.cs
+++ b/src/Aetherphone.Tests/ConversationKeyStoreSecurityTests.cs
@@ -1,0 +1,134 @@
+using System.Security.Cryptography;
+using Aetherphone.Core.Aethernet.Clients;
+using Aetherphone.Core.Aethernet.Contracts;
+using Aetherphone.Core.Crypto;
+using Xunit;
+
+namespace Aetherphone.Tests;
+
+public sealed class ConversationKeyStoreSecurityTests
+{
+    [Fact]
+    public async Task DmMemberRestrictionDropsInjectedThirdParty()
+    {
+        using var victim = CryptoBox.TryGenerateIdentity()!;
+        using var bob = CryptoBox.TryGenerateIdentity()!;
+        using var attacker = CryptoBox.TryGenerateIdentity()!;
+        var cek = CryptoBox.GenerateCek();
+
+        var response = new ConversationKeysDto(
+            "velvet-thread",
+            1,
+            new[] { new KeyWrapDto(1, CryptoBox.WrapCek(cek, CryptoBox.ExportPublicKey(victim))!, "victim", 1, 0) },
+            new[]
+            {
+                new UserPublicKeyDto("victim", CryptoBox.ExportPublicKey(victim), 1),
+                new UserPublicKeyDto("bob", CryptoBox.ExportPublicKey(bob), 1),
+                new UserPublicKeyDto("evil", CryptoBox.ExportPublicKey(attacker), 1),
+            },
+            Array.Empty<string>(),
+            Array.Empty<string>(),
+            new[] { "evil" },
+            false);
+
+        var client = new FakeKeysClient { VelvetResponse = response };
+        var store = new ConversationKeyStore(client, new FakeVault(victim));
+        await store.EnsureVelvetKeysAsync("bob", "victim", CancellationToken.None);
+
+        Assert.DoesNotContain(client.VelvetWraps, wrap => wrap.RecipientUserId == "evil");
+    }
+
+    [Fact]
+    public async Task GuardRosterRejectsInjectedRecipientInGroupChat()
+    {
+        using var victim = CryptoBox.TryGenerateIdentity()!;
+        using var attacker = CryptoBox.TryGenerateIdentity()!;
+        var cek = CryptoBox.GenerateCek();
+
+        var response = new ConversationKeysDto(
+            "42",
+            1,
+            new[] { new KeyWrapDto(1, CryptoBox.WrapCek(cek, CryptoBox.ExportPublicKey(victim))!, "victim", 1, 0) },
+            new[] { new UserPublicKeyDto("evil", CryptoBox.ExportPublicKey(attacker), 1) },
+            Array.Empty<string>(),
+            Array.Empty<string>(),
+            new[] { "evil" },
+            false);
+
+        var guard = new PinnedRecipientGuard();
+        guard.SetAuthorizedMembers("victim");
+        var client = new FakeKeysClient { ChatResponse = response };
+        var store = new ConversationKeyStore(client, new FakeVault(victim), guard);
+        await store.EnsureChatKeysAsync("42", CancellationToken.None);
+
+        Assert.Empty(client.ChatWraps);
+    }
+}
+
+internal sealed class FakeVault : IKeyVault
+{
+    private readonly ECDiffieHellman privateKey;
+
+    public FakeVault(ECDiffieHellman privateKey) => this.privateKey = privateKey;
+
+    public event Action? Changed
+    {
+        add { }
+        remove { }
+    }
+
+    public KeyVaultState State => KeyVaultState.Unlocked;
+
+    public byte[]? UnwrapCek(string wrappedKey) => CryptoBox.UnwrapCek(wrappedKey, privateKey);
+}
+
+internal sealed class FakeKeysClient : IKeysClient
+{
+    public ConversationKeysDto? ChatResponse { get; set; }
+
+    public ConversationKeysDto? VelvetResponse { get; set; }
+
+    public List<NewWrapDto> ChatWraps { get; } = new();
+
+    public List<NewWrapDto> VelvetWraps { get; } = new();
+
+    public Task<ConversationKeysDto?> ConversationKeysAsync(string conversationId, CancellationToken token)
+        => Task.FromResult(ChatResponse);
+
+    public Task<bool> AddConversationWrapsAsync(string conversationId, AddWrapsRequest request, CancellationToken token)
+    {
+        ChatWraps.AddRange(request.Wraps);
+        return Task.FromResult(true);
+    }
+
+    public Task<ConversationKeysDto?> VelvetThreadKeysAsync(string otherId, CancellationToken token)
+        => Task.FromResult(VelvetResponse);
+
+    public Task<bool> AddVelvetWrapsAsync(string otherId, AddWrapsRequest request, CancellationToken token)
+    {
+        VelvetWraps.AddRange(request.Wraps);
+        return Task.FromResult(true);
+    }
+
+    public Task<MyKeysDto?> PutMyKeysAsync(PutMyKeysRequest request, CancellationToken token) => Task.FromResult<MyKeysDto?>(null);
+
+    public Task<(MyKeysDto? Keys, int Status)> MyKeysAsync(CancellationToken token) => Task.FromResult<(MyKeysDto?, int)>((null, 0));
+
+    public Task<PublicKeysDto?> PublicKeysAsync(string[] userIds, CancellationToken token) => Task.FromResult<PublicKeysDto?>(null);
+
+    public Task<MyConversationKeysDto?> MyConversationKeysAsync(CancellationToken token) => Task.FromResult<MyConversationKeysDto?>(null);
+
+    public Task<(bool Ok, int Status)> CreateConversationGenerationAsync(string conversationId, CreateGenerationRequest request, CancellationToken token) => Task.FromResult((false, 0));
+
+    public Task<MyConversationKeysDto?> VelvetKeysAsync(CancellationToken token) => Task.FromResult<MyConversationKeysDto?>(null);
+
+    public Task<(bool Ok, int Status)> CreateVelvetGenerationAsync(string otherId, CreateGenerationRequest request, CancellationToken token) => Task.FromResult((false, 0));
+
+    public Task<MyConversationKeysDto?> GramKeysAsync(CancellationToken token) => Task.FromResult<MyConversationKeysDto?>(null);
+
+    public Task<ConversationKeysDto?> GramThreadKeysAsync(string otherId, CancellationToken token) => Task.FromResult<ConversationKeysDto?>(null);
+
+    public Task<(bool Ok, int Status)> CreateGramGenerationAsync(string otherId, CreateGenerationRequest request, CancellationToken token) => Task.FromResult((false, 0));
+
+    public Task<bool> AddGramWrapsAsync(string otherId, AddWrapsRequest request, CancellationToken token) => Task.FromResult(true);
+}

--- a/src/Aetherphone.Tests/PinnedRecipientGuardTests.cs
+++ b/src/Aetherphone.Tests/PinnedRecipientGuardTests.cs
@@ -1,0 +1,48 @@
+using Aetherphone.Core.Aethernet.Contracts;
+using Aetherphone.Core.Crypto;
+using Xunit;
+
+namespace Aetherphone.Tests;
+
+public sealed class PinnedRecipientGuardTests
+{
+    [Fact]
+    public void AllowsUnknownRecipientWhenNoRosterConfigured()
+    {
+        var guard = new PinnedRecipientGuard();
+        Assert.True(guard.IsAuthorized(new UserPublicKeyDto("bob", "key-a", 1)));
+    }
+
+    [Fact]
+    public void RejectsRecipientNotOnConfiguredRoster()
+    {
+        var guard = new PinnedRecipientGuard();
+        guard.SetAuthorizedMembers("alice");
+        Assert.False(guard.IsAuthorized(new UserPublicKeyDto("bob", "key-a", 1)));
+    }
+
+    [Fact]
+    public void RejectsSameVersionKeySubstitution()
+    {
+        var guard = new PinnedRecipientGuard();
+        guard.Pin("bob", 1, "honest-key");
+        Assert.False(guard.IsAuthorized(new UserPublicKeyDto("bob", "attacker-key", 1)));
+    }
+
+    [Fact]
+    public void AllowsHigherVersionKeyRotation()
+    {
+        var guard = new PinnedRecipientGuard();
+        guard.Pin("bob", 1, "honest-key");
+        Assert.True(guard.IsAuthorized(new UserPublicKeyDto("bob", "rotated-key", 2)));
+    }
+
+    [Fact]
+    public void AcceptsMatchingPinnedKey()
+    {
+        var guard = new PinnedRecipientGuard();
+        var recipient = new UserPublicKeyDto("bob", "key-a", 1);
+        Assert.True(guard.IsAuthorized(recipient));
+        Assert.True(guard.IsAuthorized(recipient));
+    }
+}

--- a/src/Aetherphone/Core/Aethernet/Clients/IKeysClient.cs
+++ b/src/Aetherphone/Core/Aethernet/Clients/IKeysClient.cs
@@ -1,0 +1,36 @@
+using Aetherphone.Core.Aethernet.Contracts;
+
+namespace Aetherphone.Core.Aethernet.Clients;
+
+internal interface IKeysClient
+{
+    Task<MyKeysDto?> PutMyKeysAsync(PutMyKeysRequest request, CancellationToken token);
+
+    Task<(MyKeysDto? Keys, int Status)> MyKeysAsync(CancellationToken token);
+
+    Task<PublicKeysDto?> PublicKeysAsync(string[] userIds, CancellationToken token);
+
+    Task<MyConversationKeysDto?> MyConversationKeysAsync(CancellationToken token);
+
+    Task<ConversationKeysDto?> ConversationKeysAsync(string conversationId, CancellationToken token);
+
+    Task<(bool Ok, int Status)> CreateConversationGenerationAsync(string conversationId, CreateGenerationRequest request, CancellationToken token);
+
+    Task<bool> AddConversationWrapsAsync(string conversationId, AddWrapsRequest request, CancellationToken token);
+
+    Task<MyConversationKeysDto?> VelvetKeysAsync(CancellationToken token);
+
+    Task<ConversationKeysDto?> VelvetThreadKeysAsync(string otherId, CancellationToken token);
+
+    Task<(bool Ok, int Status)> CreateVelvetGenerationAsync(string otherId, CreateGenerationRequest request, CancellationToken token);
+
+    Task<bool> AddVelvetWrapsAsync(string otherId, AddWrapsRequest request, CancellationToken token);
+
+    Task<MyConversationKeysDto?> GramKeysAsync(CancellationToken token);
+
+    Task<ConversationKeysDto?> GramThreadKeysAsync(string otherId, CancellationToken token);
+
+    Task<(bool Ok, int Status)> CreateGramGenerationAsync(string otherId, CreateGenerationRequest request, CancellationToken token);
+
+    Task<bool> AddGramWrapsAsync(string otherId, AddWrapsRequest request, CancellationToken token);
+}

--- a/src/Aetherphone/Core/Aethernet/Clients/KeysClient.cs
+++ b/src/Aetherphone/Core/Aethernet/Clients/KeysClient.cs
@@ -2,7 +2,7 @@ using Aetherphone.Core.Aethernet.Contracts;
 
 namespace Aetherphone.Core.Aethernet.Clients;
 
-internal sealed class KeysClient
+internal sealed class KeysClient : IKeysClient
 {
     private readonly AethernetTransport net;
 

--- a/src/Aetherphone/Core/Crypto/ConversationKeyStore.cs
+++ b/src/Aetherphone/Core/Crypto/ConversationKeyStore.cs
@@ -15,15 +15,17 @@ internal sealed record ChatKeyStatus(
 
 internal sealed class ConversationKeyStore
 {
-    private readonly KeysClient client;
-    private readonly KeyVault vault;
+    private readonly IKeysClient client;
+    private readonly IKeyVault vault;
+    private readonly IWrapRecipientGuard? guard;
     private readonly ConcurrentDictionary<string, ConcurrentDictionary<int, byte[]>> keysByScope = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, int> currentGenerations = new(StringComparer.Ordinal);
 
-    public ConversationKeyStore(KeysClient client, KeyVault vault)
+    public ConversationKeyStore(IKeysClient client, IKeyVault vault, IWrapRecipientGuard? guard = null)
     {
         this.client = client;
         this.vault = vault;
+        this.guard = guard;
         vault.Changed += OnVaultChanged;
     }
 
@@ -129,6 +131,7 @@ internal sealed class ConversationKeyStore
                 break;
             }
 
+            keys = RestrictToMembers(keys, myUserId, otherId);
             CacheWraps(scope, keys.CurrentGeneration, keys.MyWraps);
 
             if (keys.CurrentGeneration == 0)
@@ -273,6 +276,7 @@ internal sealed class ConversationKeyStore
                 break;
             }
 
+            keys = RestrictToMembers(keys, myUserId, otherId);
             CacheWraps(scope, keys.CurrentGeneration, keys.MyWraps);
 
             if (keys.CurrentGeneration == 0)
@@ -534,12 +538,66 @@ internal sealed class ConversationKeyStore
         }
     }
 
-    private static NewWrapDto[]? BuildWraps(byte[] cek, IReadOnlyList<UserPublicKeyDto> recipients)
+    private static ConversationKeysDto RestrictToMembers(ConversationKeysDto keys, string first, string second)
     {
-        var wraps = new NewWrapDto[recipients.Count];
+        return keys with
+        {
+            MemberKeys = FilterKeys(keys.MemberKeys, first, second),
+            MembersWithoutKeys = FilterIds(keys.MembersWithoutKeys, first, second),
+            StaleWrapUserIds = FilterIds(keys.StaleWrapUserIds, first, second),
+            MissingWrapUserIds = FilterIds(keys.MissingWrapUserIds, first, second),
+        };
+    }
+
+    private static UserPublicKeyDto[] FilterKeys(UserPublicKeyDto[] items, string first, string second)
+    {
+        var result = new List<UserPublicKeyDto>(items.Length);
+        for (var index = 0; index < items.Length; index++)
+        {
+            if (items[index].UserId == first || items[index].UserId == second)
+            {
+                result.Add(items[index]);
+            }
+        }
+
+        return result.ToArray();
+    }
+
+    private static string[] FilterIds(string[] items, string first, string second)
+    {
+        var result = new List<string>(items.Length);
+        for (var index = 0; index < items.Length; index++)
+        {
+            if (items[index] == first || items[index] == second)
+            {
+                result.Add(items[index]);
+            }
+        }
+
+        return result.ToArray();
+    }
+
+    private NewWrapDto[]? BuildWraps(byte[] cek, IReadOnlyList<UserPublicKeyDto> recipients)
+    {
+        var authorized = new List<UserPublicKeyDto>(recipients.Count);
         for (var index = 0; index < recipients.Count; index++)
         {
             var recipient = recipients[index];
+            if (guard is null || guard.IsAuthorized(recipient))
+            {
+                authorized.Add(recipient);
+            }
+        }
+
+        if (authorized.Count == 0)
+        {
+            return null;
+        }
+
+        var wraps = new NewWrapDto[authorized.Count];
+        for (var index = 0; index < authorized.Count; index++)
+        {
+            var recipient = authorized[index];
             var wrapped = CryptoBox.WrapCek(cek, recipient.PublicKey);
             if (wrapped is null)
             {

--- a/src/Aetherphone/Core/Crypto/IKeyVault.cs
+++ b/src/Aetherphone/Core/Crypto/IKeyVault.cs
@@ -1,0 +1,10 @@
+namespace Aetherphone.Core.Crypto;
+
+internal interface IKeyVault
+{
+    event Action? Changed;
+
+    KeyVaultState State { get; }
+
+    byte[]? UnwrapCek(string wrappedKey);
+}

--- a/src/Aetherphone/Core/Crypto/IWrapRecipientGuard.cs
+++ b/src/Aetherphone/Core/Crypto/IWrapRecipientGuard.cs
@@ -1,0 +1,8 @@
+using Aetherphone.Core.Aethernet.Contracts;
+
+namespace Aetherphone.Core.Crypto;
+
+internal interface IWrapRecipientGuard
+{
+    bool IsAuthorized(UserPublicKeyDto recipient);
+}

--- a/src/Aetherphone/Core/Crypto/KeyVault.cs
+++ b/src/Aetherphone/Core/Crypto/KeyVault.cs
@@ -6,16 +6,7 @@ using Aetherphone.Core.Aethernet.Contracts;
 
 namespace Aetherphone.Core.Crypto;
 
-internal enum KeyVaultState
-{
-    Unavailable = 0,
-    Provisioning = 1,
-    Unlocked = 2,
-    Unsupported = 3,
-    Locked = 4,
-}
-
-internal sealed class KeyVault : IDisposable
+internal sealed class KeyVault : IDisposable, IKeyVault
 {
     private readonly Configuration configuration;
     private readonly AethernetSession session;

--- a/src/Aetherphone/Core/Crypto/KeyVaultState.cs
+++ b/src/Aetherphone/Core/Crypto/KeyVaultState.cs
@@ -1,0 +1,10 @@
+namespace Aetherphone.Core.Crypto;
+
+internal enum KeyVaultState
+{
+    Unavailable = 0,
+    Provisioning = 1,
+    Unlocked = 2,
+    Unsupported = 3,
+    Locked = 4,
+}

--- a/src/Aetherphone/Core/Crypto/PinnedRecipientGuard.cs
+++ b/src/Aetherphone/Core/Crypto/PinnedRecipientGuard.cs
@@ -1,0 +1,59 @@
+using System.Collections.Concurrent;
+using Aetherphone.Core.Aethernet.Contracts;
+
+namespace Aetherphone.Core.Crypto;
+
+internal sealed class PinnedRecipientGuard : IWrapRecipientGuard
+{
+    private readonly ConcurrentDictionary<string, byte> authorizedMembers = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, (int Version, string PublicKey)> pins = new(StringComparer.Ordinal);
+    private readonly ConcurrentQueue<(string UserId, string Reason)> rejections = new();
+    private volatile bool rosterConfigured;
+
+    public IReadOnlyCollection<(string UserId, string Reason)> Rejections => rejections.ToArray();
+
+    public void SetAuthorizedMembers(params string[] userIds)
+    {
+        authorizedMembers.Clear();
+        for (var index = 0; index < userIds.Length; index++)
+        {
+            authorizedMembers[userIds[index]] = 1;
+        }
+
+        rosterConfigured = true;
+    }
+
+    public void Pin(string userId, int keyVersion, string publicKey)
+    {
+        pins[userId] = (keyVersion, publicKey);
+    }
+
+    public bool IsAuthorized(UserPublicKeyDto recipient)
+    {
+        if (rosterConfigured && !authorizedMembers.ContainsKey(recipient.UserId))
+        {
+            rejections.Enqueue((recipient.UserId, "not an authorized member"));
+            return false;
+        }
+
+        if (pins.TryGetValue(recipient.UserId, out var pinned))
+        {
+            if (recipient.KeyVersion > pinned.Version)
+            {
+                pins[recipient.UserId] = (recipient.KeyVersion, recipient.PublicKey);
+                return true;
+            }
+
+            if (!string.Equals(pinned.PublicKey, recipient.PublicKey, StringComparison.Ordinal))
+            {
+                rejections.Enqueue((recipient.UserId, "key material changed"));
+                return false;
+            }
+
+            return true;
+        }
+
+        pins[recipient.UserId] = (recipient.KeyVersion, recipient.PublicKey);
+        return true;
+    }
+}

--- a/src/Aetherphone/Core/PhoneServices.cs
+++ b/src/Aetherphone/Core/PhoneServices.cs
@@ -150,7 +150,7 @@ internal sealed class PhoneServices : IDisposable
         var aethernet = new AethernetApi(http, aethernetSession);
         var keyVault = new KeyVault(configuration, aethernetSession, aethernet.Keys);
         var peerKeys = new PeerKeyDirectory(configuration, aethernet.Keys);
-        var conversationKeys = new ConversationKeyStore(aethernet.Keys, keyVault);
+        var conversationKeys = new ConversationKeyStore(aethernet.Keys, keyVault, new PinnedRecipientGuard());
         var marketIndex = new MarketItemIndex(dataManager);
         var market = new MarketboardService(http);
         var marketLauncher = new MarketLauncher();


### PR DESCRIPTION
## What
Add a guard that runs before the client wraps a conversation key, so it only wraps for recipients it can vouch for. `PinnedRecipientGuard` refuses a wrap when a member's key material changes at the same or lower version, and (when a roster is configured) when the recipient isn't a known member. Velvet and Gram 1:1 threads are additionally restricted to the two known participants. I also split `KeysClient`/`KeyVault` behind `IKeysClient`/`IKeyVault` so the flow is testable.

## Why

The client wrapped the conversation key for whatever recipients the server named in the `/keys` response, without checking they belonged to the conversation or that their key material hadn't changed. A malicious or compromised server could inject a recipient, or swap a member's key at the same version, and have the client hand it a usable wrap, defeating E2E for that thread. A single stale-wrap response can even re-wrap every cached generation.

This is client-side defense-in-depth. The server still has to enforce membership when it hands out wraps; that is the authoritative fix and it lives in the backend, not here.

Closes # <!-- flagged to the dev directly; no public issue -->

## How to test
- `dotnet build Aetherphone.sln -c Release` and `dotnet test`. The new `PinnedRecipientGuardTests` and `ConversationKeyStoreSecurityTests` cover the guard and the DM restriction: an injected recipient is refused, a same-version key swap is refused, a higher-version rotation is still accepted, a group member off the roster is refused, and a 1:1 DM drops an injected third party.
- In-game: open `/phone` and send messages in Messages, Velvet, and Aethergram DMs. Normal encrypted messaging is unaffected. The guard only changes behavior when the server names an illegitimate recipient, so honest conversations behave exactly as before.

## Checklist

- [x] `dotnet build -c Release` passes
- [ ] Verified in-game: opened the phone and exercised the affected app/screen
- [x] If this changes user-visible behavior, README is updated (no user-visible change)
- [x] Matches existing style: uses the shared `Windows/Components/` widgets, no `what` comments (core change, no UI touched; no comments added)
