### PR TITLE
[Velvet] Word Wrapping on Comments Bug

### DIFF
--- a/src/Aetherphone/Apps/Velvet/VelvetShell.Detail.cs
+++ b/src/Aetherphone/Apps/Velvet/VelvetShell.Detail.cs
@@ -291,7 +291,7 @@ internal sealed partial class VelvetShell
 
         if (commentLayout is null)
         {
-            ImGui.PushTextWrapPos(textLeft + wrapWidth);
+            ImGui.PushTextWrapPos(textLeft + wrapWidth - ImGui.GetWindowPos().X);
             using (ImRaii.PushColor(ImGuiCol.Text, VelvetTheme.BodyInk))
             using (Plugin.Fonts.Push(0.9f))
             {


### PR DESCRIPTION
## Summary
- Comment text in Velvet's post detail view (`DrawCommentRow`) could overflow the card's right edge instead of wrapping, for any comment that doesn't contain a `@mention`, link, or `:shortcode:` emoji (those route through the RichText renderer instead, which wraps correctly).
- Root cause: `ImGui.PushTextWrapPos` expects a window-local X coordinate, but the call site was passing an absolute screen-space X (`textLeft + wrapWidth`). Every other wrap call site in the codebase already subtracts `ImGui.GetWindowPos().X` for exactly this reason — this was the one spot missing it.
- Reused the existing, already-established pattern from the other correct call sites rather than introducing new wrapping logic.

## Test plan
- [x] `dotnet test` — 139/139 pass
- [x] Reproduced in-game: long plain-text comment on a post overflowed past the card edge; confirmed fixed after the change
- [ ] Xeldar to confirm on their end if desired

🤖 Generated with [Claude Code](https://claude.com/claude-code)