### PR TITLE
fix(jobs): reserve header space and marquee row text

### DIFF
--- a/src/Aetherphone/Apps/Jobs/JobsApp.cs
+++ b/src/Aetherphone/Apps/Jobs/JobsApp.cs
@@ -217,7 +217,8 @@ internal sealed partial class JobsApp : IPhoneApp
         var categoriesCenter = new Vector2(buttonCenter.X - radius * 2f - 10f * scale, rowCenterY);
         var clusterLeftEdge = (hasCategories ? categoriesCenter.X : buttonCenter.X) - radius;
         var rightReserve = content.Max.X - clusterLeftEdge + 8f * scale;
-        AppHeader.DrawTitleWithReserve(content, "jobs.header.title", DisplayName, rightReserve, ui.TitleInk, scale);
+        AppHeader.DrawTitleWithReserve(content, "jobs.header.title", DisplayName, rightReserve, ui.TitleInk, scale,
+            leftReserve: 0f);
 
         colorButtonRect = new Rect(buttonCenter - new Vector2(radius, radius), buttonCenter + new Vector2(radius, radius));
         UiAnchors.Report("jobs.color", colorButtonRect);
@@ -386,13 +387,12 @@ internal sealed partial class JobsApp : IPhoneApp
         var textRight = noteRight -
                         (note.Length == 0 ? 0f : Typography.Measure(note, TextStyles.Caption2).X + 28f * scale);
         var maxTextWidth = MathF.Max(1f, textRight - textLeft);
-        var rowId = job.Kind == JobEntryKind.Gearset ? "jobs.row.gearset." + job.GearsetId : "jobs.row.class." + job.ClassJobId;
-        Marquee.DrawLeftAuto(drawList, rowId + ".name", job.Name, textLeft, contentRect.Min.Y + 12f * scale,
+        Marquee.DrawLeftAuto(drawList, job.NameRowId, job.Name, textLeft, contentRect.Min.Y + 12f * scale,
             maxTextWidth, TextStyles.Headline, ui.TitleInk);
         var subtitle = job.ItemLevel >= 0
             ? Loc.T(L.Jobs.LevelItemLevel, job.Abbreviation, job.Level, job.ItemLevel)
             : Loc.T(L.Jobs.LevelOnly, job.Abbreviation, job.Level);
-        Marquee.DrawLeftAuto(drawList, rowId + ".sub", subtitle, textLeft, contentRect.Min.Y + 36f * scale,
+        Marquee.DrawLeftAuto(drawList, job.SubRowId, subtitle, textLeft, contentRect.Min.Y + 36f * scale,
             maxTextWidth, TextStyles.Footnote, ui.MutedInk);
 
         var noteCenter = new Vector2(noteRight, contentRect.Center.Y);

--- a/src/Aetherphone/Apps/Jobs/JobsApp.cs
+++ b/src/Aetherphone/Apps/Jobs/JobsApp.cs
@@ -211,10 +211,14 @@ internal sealed partial class JobsApp : IPhoneApp
     private void DrawHeader(Rect content, float scale)
     {
         var rowCenterY = content.Min.Y + AppHeader.Height * scale * 0.5f;
-        Typography.DrawCentered(new Vector2(content.Center.X, rowCenterY), DisplayName, ui.TitleInk, 1.15f,
-            FontWeight.SemiBold);
         var radius = 15f * scale;
         var buttonCenter = new Vector2(content.Max.X - Metrics.Space.Lg * scale - radius, rowCenterY);
+        var hasCategories = gameData.LocalPlayer is not null;
+        var categoriesCenter = new Vector2(buttonCenter.X - radius * 2f - 10f * scale, rowCenterY);
+        var clusterLeftEdge = (hasCategories ? categoriesCenter.X : buttonCenter.X) - radius;
+        var rightReserve = content.Max.X - clusterLeftEdge + 8f * scale;
+        AppHeader.DrawTitleWithReserve(content, "jobs.header.title", DisplayName, rightReserve, ui.TitleInk, scale);
+
         colorButtonRect = new Rect(buttonCenter - new Vector2(radius, radius), buttonCenter + new Vector2(radius, radius));
         UiAnchors.Report("jobs.color", colorButtonRect);
         if (ui.IconButton(buttonCenter, radius, FontAwesomeIcon.Palette.ToIconString(), ui.TitleInk,
@@ -223,12 +227,11 @@ internal sealed partial class JobsApp : IPhoneApp
             menu.Toggle(ColorMenuId, colorButtonRect);
         }
 
-        if (gameData.LocalPlayer is null)
+        if (!hasCategories)
         {
             return;
         }
 
-        var categoriesCenter = new Vector2(buttonCenter.X - radius * 2f - 10f * scale, rowCenterY);
         var categoriesRect = new Rect(categoriesCenter - new Vector2(radius, radius),
             categoriesCenter + new Vector2(radius, radius));
         UiAnchors.Report("jobs.categories", categoriesRect);
@@ -382,15 +385,15 @@ internal sealed partial class JobsApp : IPhoneApp
         var noteRight = hasMenu ? menuCenter.X - menuRadius - 8f * scale : contentRect.Max.X;
         var textRight = noteRight -
                         (note.Length == 0 ? 0f : Typography.Measure(note, TextStyles.Caption2).X + 28f * scale);
-        var name = Typography.FitText(job.Name, textRight - textLeft, TextStyles.Headline);
-        Typography.Draw(drawList, new Vector2(textLeft, contentRect.Min.Y + 12f * scale), name, ui.TitleInk,
-            TextStyles.Headline);
+        var maxTextWidth = MathF.Max(1f, textRight - textLeft);
+        var rowId = job.Kind == JobEntryKind.Gearset ? "jobs.row.gearset." + job.GearsetId : "jobs.row.class." + job.ClassJobId;
+        Marquee.DrawLeftAuto(drawList, rowId + ".name", job.Name, textLeft, contentRect.Min.Y + 12f * scale,
+            maxTextWidth, TextStyles.Headline, ui.TitleInk);
         var subtitle = job.ItemLevel >= 0
             ? Loc.T(L.Jobs.LevelItemLevel, job.Abbreviation, job.Level, job.ItemLevel)
             : Loc.T(L.Jobs.LevelOnly, job.Abbreviation, job.Level);
-        var fittedSubtitle = Typography.FitText(subtitle, textRight - textLeft, TextStyles.Footnote);
-        Typography.Draw(drawList, new Vector2(textLeft, contentRect.Min.Y + 36f * scale), fittedSubtitle, ui.MutedInk,
-            TextStyles.Footnote);
+        Marquee.DrawLeftAuto(drawList, rowId + ".sub", subtitle, textLeft, contentRect.Min.Y + 36f * scale,
+            maxTextWidth, TextStyles.Footnote, ui.MutedInk);
 
         var noteCenter = new Vector2(noteRight, contentRect.Center.Y);
         if (job.IsActive)

--- a/src/Aetherphone/Core/Jobs/JobsModel.cs
+++ b/src/Aetherphone/Core/Jobs/JobsModel.cs
@@ -33,6 +33,9 @@ internal sealed class JobEntry
         ItemLevel = itemLevel;
         IconId = iconId;
         IsActive = isActive;
+        var rowId = kind == JobEntryKind.Gearset ? "jobs.row.gearset." + gearsetId : "jobs.row.class." + classJobId;
+        NameRowId = rowId + ".name";
+        SubRowId = rowId + ".sub";
     }
 
     public JobEntryKind Kind { get; }
@@ -41,6 +44,8 @@ internal sealed class JobEntry
     public string Abbreviation { get; }
     public string Name { get; }
     public int Level { get; }
+    public string NameRowId { get; }
+    public string SubRowId { get; }
 
     /// <summary>-1 when the item level is unknown (a class with no gearset that isn't currently active).</summary>
     public int ItemLevel { get; }

--- a/src/Aetherphone/Windows/Components/AppHeader.cs
+++ b/src/Aetherphone/Windows/Components/AppHeader.cs
@@ -38,10 +38,10 @@ internal static class AppHeader
     }
 
     public static void DrawTitleWithReserve(Rect area, string id, string title, float rightReserve, Vector4 color,
-        float scale)
+        float scale, float leftReserve = 44f)
     {
         var rowCenterY = area.Min.Y + Height * scale * 0.5f;
-        var leftLimit = area.Min.X + 44f * scale;
+        var leftLimit = area.Min.X + leftReserve * scale;
         var rightLimit = area.Max.X - rightReserve;
         var maxWidth = MathF.Max(1f, rightLimit - leftLimit);
         var titleSize = Typography.Measure(title, 1.15f, FontWeight.SemiBold);

--- a/src/Aetherphone/Windows/Components/Marquee.cs
+++ b/src/Aetherphone/Windows/Components/Marquee.cs
@@ -50,7 +50,7 @@ internal static class Marquee
         float maxWidth, in TextStyle style, Vector4 color)
     {
         var size = Typography.Measure(fullText, style);
-        var hovering = ImGui.IsMouseHoveringRect(new Vector2(boxLeft, y),
+        var hovering = UiInteract.Hover(new Vector2(boxLeft, y),
             new Vector2(boxLeft + MathF.Min(size.X, maxWidth), y + size.Y));
         return DrawLeft(drawList, id, fullText, boxLeft, y, maxWidth, style, color, hovering);
     }
@@ -63,7 +63,7 @@ internal static class Marquee
         float maxWidth, in TextStyle style, Vector4 color)
     {
         var size = Typography.Measure(fullText, style);
-        var hovering = ImGui.IsMouseHoveringRect(new Vector2(boxRight - MathF.Min(size.X, maxWidth), y),
+        var hovering = UiInteract.Hover(new Vector2(boxRight - MathF.Min(size.X, maxWidth), y),
             new Vector2(boxRight, y + size.Y));
         DrawRight(drawList, id, fullText, boxRight, y, maxWidth, style, color, hovering);
     }
@@ -77,7 +77,7 @@ internal static class Marquee
     {
         var size = Typography.Measure(fullText, style);
         var clampedWidth = MathF.Min(size.X, maxWidth);
-        var hovering = ImGui.IsMouseHoveringRect(new Vector2(centerX - clampedWidth * 0.5f, y),
+        var hovering = UiInteract.Hover(new Vector2(centerX - clampedWidth * 0.5f, y),
             new Vector2(centerX + clampedWidth * 0.5f, y + size.Y));
         DrawCentered(drawList, id, fullText, centerX, y, maxWidth, style, color, hovering);
     }


### PR DESCRIPTION
## Summary

Jobs was the one app left off #71's text-truncation/marquee sweep. Two spots still used static clipping instead of the shared reserve/marquee pattern:

- **Header title**: used plain `Typography.DrawCentered` across the full header width, ignoring the palette + categories icon buttons in the corner. Long localized titles (e.g. Spanish "Trabajos", Turkish "Sınıflar") could run into the buttons. Switched to `AppHeader.DrawTitleWithReserve`, same helper used by Feedback, Market, Venues, Chirper, Aethergram, and Velvet.
- **Gearset rows**: name and level/ilvl subtitle used static `Typography.FitText`, silently clipping to an ellipsis with no way to read the full text. Switched each line to its own `Marquee.DrawLeftAuto` call (separate ids/hover checks per line, following the pattern in #71's `TimersApp.DrawTimerRow` and `NotesApp.DrawReminderRow`), so long names now scroll on hover instead of clipping.

## Test plan

- `dotnet build` clean
- Verified in-game via full plugin reload: header title no longer overlaps the button cluster, row name/subtitle scroll independently on hover