### PR TITLE
fix(input): stop clicks passing through occluding windows

### DIFF
--- a/src/Aetherphone/Apps/Activity/ActivityApp.cs
+++ b/src/Aetherphone/Apps/Activity/ActivityApp.cs
@@ -423,7 +423,7 @@ internal sealed partial class ActivityApp : IPhoneApp
         var minusCenter = new Vector2(row.Max.X - radius - 106f * scale, row.Center.Y);
         var valueCenter = new Vector2((plusCenter.X + minusCenter.X) * 0.5f, row.Center.Y);
         var labelMaxWidth = MathF.Max(1f, minusCenter.X - radius - 12f * scale - row.Min.X);
-        var labelHovering = ImGui.IsMouseHoveringRect(new Vector2(row.Min.X, row.Min.Y),
+        var labelHovering = UiInteract.Hover(new Vector2(row.Min.X, row.Min.Y),
             new Vector2(row.Min.X + labelMaxWidth, row.Max.Y));
         Marquee.DrawLeft("activity.goalrow." + label, label, row.Min.X, row.Center.Y - 8f * scale, labelMaxWidth,
             TextStyles.Subheadline, AppPalettes.Activity.BodyInk, labelHovering);

--- a/src/Aetherphone/Apps/Aethergram/AethergramApp.Compose.cs
+++ b/src/Aetherphone/Apps/Aethergram/AethergramApp.Compose.cs
@@ -491,7 +491,7 @@ internal sealed partial class AethergramApp
             var nameTop = avatarCenter.Y - 8f * scale;
             var nameMaxWidth = MathF.Max(1f, card.Max.X - padding - nameLeft);
             var nameHeight = Typography.Measure(displayName, nameStyle).Y;
-            var nameHovering = ImGui.IsMouseHoveringRect(new Vector2(nameLeft, nameTop),
+            var nameHovering = UiInteract.Hover(new Vector2(nameLeft, nameTop),
                 new Vector2(nameLeft + nameMaxWidth, nameTop + nameHeight));
             Marquee.DrawLeft("aethergram.compose.author." + me.Handle, displayName, nameLeft, nameTop, nameMaxWidth,
                 nameStyle, theme.TextStrong, nameHovering);
@@ -554,7 +554,7 @@ internal sealed partial class AethergramApp
     {
         var scale = ImGuiHelpers.GlobalScale;
         var drawList = ImGui.GetWindowDrawList();
-        var hovered = enabled && ImGui.IsMouseHoveringRect(rect.Min, rect.Max);
+        var hovered = enabled && UiInteract.Hover(rect.Min, rect.Max);
         var radius = rect.Height * 0.5f;
         var fill = enabled
             ? (hovered ? Palette.Mix(Accent, theme.TextStrong, 0.12f) : Accent)

--- a/src/Aetherphone/Apps/Aethergram/AethergramApp.Detail.cs
+++ b/src/Aetherphone/Apps/Aethergram/AethergramApp.Detail.cs
@@ -58,12 +58,12 @@ internal sealed partial class AethergramApp
             var headerMetaSize = Typography.Measure(headerMeta, 0.78f);
             var headerTextGap = 3f * scale;
             var headerNameY = avatarCenter.Y - (headerNameSize.Y + headerTextGap + headerMetaSize.Y) * 0.5f;
-            var headerNameHovering = ImGui.IsMouseHoveringRect(new Vector2(nameLeft, headerNameY),
+            var headerNameHovering = UiInteract.Hover(new Vector2(nameLeft, headerNameY),
                 new Vector2(nameLeft + headerTextMaxWidth, headerNameY + headerNameSize.Y));
             Marquee.DrawLeft("aethergram.detail.header." + post.Id, displayName, nameLeft, headerNameY,
                 headerTextMaxWidth, headerNameStyle, theme.TextStrong, headerNameHovering);
             var headerMetaTop = headerNameY + headerNameSize.Y + headerTextGap;
-            var headerMetaHovering = ImGui.IsMouseHoveringRect(new Vector2(nameLeft, headerMetaTop),
+            var headerMetaHovering = UiInteract.Hover(new Vector2(nameLeft, headerMetaTop),
                 new Vector2(nameLeft + headerTextMaxWidth, headerMetaTop + headerMetaSize.Y));
             Marquee.DrawLeft("aethergram.detail.headermeta." + post.Id, headerMeta, nameLeft, headerMetaTop,
                 headerTextMaxWidth, new TextStyle(0.78f, FontWeight.Regular), AppPalettes.Aethergram.MutedInk,
@@ -173,7 +173,7 @@ internal sealed partial class AethergramApp
                 var captionPos = ImGui.GetCursorScreenPos();
                 var captionNameMaxWidth = width * 0.5f;
                 var captionNameSize = Typography.Measure(displayName, 0.9f, FontWeight.SemiBold);
-                var captionNameHovering = ImGui.IsMouseHoveringRect(captionPos,
+                var captionNameHovering = UiInteract.Hover(captionPos,
                     new Vector2(captionPos.X + captionNameMaxWidth, captionPos.Y + captionNameSize.Y));
                 var nameWidth = Marquee.DrawLeft("aethergram.detail.captionname." + post.Id, displayName,
                     captionPos.X, captionPos.Y, captionNameMaxWidth, new TextStyle(0.9f, FontWeight.SemiBold),
@@ -285,7 +285,7 @@ internal sealed partial class AethergramApp
             string.Empty, comment.AuthorAvatarUrl, 0.8f, 28);
 
         var nameTop = bubbleTop + padTop;
-        var commentNameHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, nameTop),
+        var commentNameHovering = UiInteract.Hover(new Vector2(textLeft, nameTop),
             new Vector2(textRight, nameTop + nameHeight));
         var nameWidth = Marquee.DrawLeft("aethergram.comment." + comment.Id, displayName, textLeft, nameTop,
             textRight - textLeft, commentNameStyle, theme.TextStrong, commentNameHovering);

--- a/src/Aetherphone/Apps/Aethergram/AethergramApp.cs
+++ b/src/Aetherphone/Apps/Aethergram/AethergramApp.cs
@@ -851,14 +851,14 @@ internal sealed partial class AethergramApp : IPhoneApp
         var headerTextMaxWidth = MathF.Max(1f, headerTextRight - nameLeft);
         var cardNameStyle = new TextStyle(1f, FontWeight.SemiBold);
         var cardNameHeight = Typography.Measure(displayName, cardNameStyle).Y;
-        var cardNameHovering = ImGui.IsMouseHoveringRect(new Vector2(nameLeft, origin.Y + pad),
+        var cardNameHovering = UiInteract.Hover(new Vector2(nameLeft, origin.Y + pad),
             new Vector2(nameLeft + headerTextMaxWidth, origin.Y + pad + cardNameHeight));
         Marquee.DrawLeft("aethergram.card." + post.Id, displayName, nameLeft, origin.Y + pad, headerTextMaxWidth,
             cardNameStyle, theme.TextStrong, cardNameHovering);
         var subline = SocialIdentity.FeedMeta(post.AuthorHandle, TimeText.Short(post.CreatedAtUnix));
         var sublineTop = origin.Y + pad + PostCardMetrics.SublineTop * scale;
         var sublineSize = Typography.Measure(subline, 0.85f);
-        var sublineHovering = ImGui.IsMouseHoveringRect(new Vector2(nameLeft, sublineTop),
+        var sublineHovering = UiInteract.Hover(new Vector2(nameLeft, sublineTop),
             new Vector2(nameLeft + headerTextMaxWidth, sublineTop + sublineSize.Y));
         Marquee.DrawLeft("aethergram.card.sub." + post.Id, subline, nameLeft, sublineTop, headerTextMaxWidth,
             new TextStyle(0.85f, FontWeight.Regular), AppPalettes.Aethergram.MutedInk, sublineHovering);
@@ -1025,7 +1025,7 @@ internal sealed partial class AethergramApp : IPhoneApp
 
     private void HandleLikeGesture(Rect imageRect, PostDto post, string[] photos, int page)
     {
-        if (!ImGui.IsMouseHoveringRect(imageRect.Min, imageRect.Max))
+        if (!UiInteract.Hover(imageRect.Min, imageRect.Max))
         {
             return;
         }

--- a/src/Aetherphone/Apps/Announcements/AnnouncementsApp.List.cs
+++ b/src/Aetherphone/Apps/Announcements/AnnouncementsApp.List.cs
@@ -154,7 +154,7 @@ internal sealed partial class AnnouncementsApp
         Typography.Draw(drawList, new Vector2(stampLeft, footerCenterY - stampSize.Y * 0.5f), stamp, ui.MutedInk,
             TextStyles.Footnote);
 
-        var hovered = ImGui.IsMouseHoveringRect(origin, cardMax);
+        var hovered = UiInteract.Hover(origin, cardMax);
         DrawChevron(drawList, new Vector2(cardMax.X - pad, footerCenterY), 5f * scale, Metrics.Stroke.Thin * scale,
             hovered ? ui.TitleInk : Palette.WithAlpha(ui.MutedInk, 0.7f));
         if (hovered)

--- a/src/Aetherphone/Apps/AppStore/AppStoreApp.Catalog.cs
+++ b/src/Aetherphone/Apps/AppStore/AppStoreApp.Catalog.cs
@@ -79,7 +79,7 @@ internal sealed partial class AppStoreApp
         var labelLeft = card.Min.X + pad;
         var labelTop = card.Max.Y - 28f * scale;
         var labelSize = Typography.Measure(label, TextStyles.Headline);
-        var labelHovering = ImGui.IsMouseHoveringRect(new Vector2(labelLeft, labelTop),
+        var labelHovering = UiInteract.Hover(new Vector2(labelLeft, labelTop),
             new Vector2(labelLeft + MathF.Min(labelSize.X, maxLabelWidth), labelTop + labelSize.Y));
         Marquee.DrawLeft("appstore.category.label.shadow." + category, label, labelLeft, labelTop + 1f * scale,
             maxLabelWidth, TextStyles.Headline, CardInkShadow, labelHovering);

--- a/src/Aetherphone/Apps/AppStore/AppStoreApp.Detail.cs
+++ b/src/Aetherphone/Apps/AppStore/AppStoreApp.Detail.cs
@@ -65,7 +65,7 @@ internal sealed partial class AppStoreApp
         var textLeft = origin.X + (DetailIconSize + 14f) * scale;
         var textWidth = origin.X + width - textLeft;
         var nameY = top + 6f * scale;
-        var nameHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, nameY),
+        var nameHovering = UiInteract.Hover(new Vector2(textLeft, nameY),
             new Vector2(textLeft + textWidth, nameY + Typography.Measure(app.DisplayName, TextStyles.Title2).Y));
         Marquee.DrawLeft("appstore.detail.name." + app.Id, app.DisplayName, textLeft, nameY, textWidth,
             TextStyles.Title2, ui.TitleInk, nameHovering);

--- a/src/Aetherphone/Apps/AppStore/AppStoreApp.Rows.cs
+++ b/src/Aetherphone/Apps/AppStore/AppStoreApp.Rows.cs
@@ -53,13 +53,13 @@ internal sealed partial class AppStoreApp
         var textWidth = pill.Min.X - textLeft - 10f * scale;
         var entry = AppStoreCatalog.For(app.Id);
         var nameY = row.Center.Y - 18f * scale;
-        var nameHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, nameY),
+        var nameHovering = UiInteract.Hover(new Vector2(textLeft, nameY),
             new Vector2(textLeft + textWidth, nameY + Typography.Measure(app.DisplayName, TextStyles.Headline).Y));
         Marquee.DrawLeft("appstore.row.name." + app.Id, app.DisplayName, textLeft, nameY, textWidth,
             TextStyles.Headline, ui.TitleInk, nameHovering);
         var subtitle = Loc.T(entry.Subtitle);
         var subtitleY = row.Center.Y + 2f * scale;
-        var subtitleHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, subtitleY),
+        var subtitleHovering = UiInteract.Hover(new Vector2(textLeft, subtitleY),
             new Vector2(textLeft + textWidth, subtitleY + Typography.Measure(subtitle, TextStyles.Footnote).Y));
         Marquee.DrawLeft("appstore.row.subtitle." + app.Id, subtitle, textLeft, subtitleY, textWidth,
             TextStyles.Footnote, ui.MutedInk, subtitleHovering);

--- a/src/Aetherphone/Apps/AppStore/AppStoreApp.Today.cs
+++ b/src/Aetherphone/Apps/AppStore/AppStoreApp.Today.cs
@@ -83,7 +83,7 @@ internal sealed partial class AppStoreApp
             Palette.WithAlpha(new Vector4(1f, 1f, 1f, 1f), 0.78f), TextStyles.Caption1);
         var nameY = card.Min.Y + pad + 20f * scale;
         var nameMaxWidth = card.Width - pad * 2f;
-        var nameHovering = ImGui.IsMouseHoveringRect(new Vector2(card.Min.X + pad, nameY),
+        var nameHovering = UiInteract.Hover(new Vector2(card.Min.X + pad, nameY),
             new Vector2(card.Min.X + pad + nameMaxWidth, nameY + Typography.Measure(app.DisplayName, TextStyles.Title1).Y));
         Marquee.DrawLeft("appstore.today.name." + app.Id, app.DisplayName, card.Min.X + pad, nameY, nameMaxWidth,
             TextStyles.Title1, new Vector4(1f, 1f, 1f, 1f), nameHovering);

--- a/src/Aetherphone/Apps/Calculator/CalculatorApp.cs
+++ b/src/Aetherphone/Apps/Calculator/CalculatorApp.cs
@@ -123,7 +123,7 @@ internal sealed class CalculatorApp : IPhoneApp
                 var entry = history[index];
                 var origin = ImGui.GetCursorScreenPos();
                 var row = new Rect(origin, new Vector2(origin.X + width, origin.Y + rowHeight));
-                var hovered = ImGui.IsMouseHoveringRect(row.Min, row.Max);
+                var hovered = UiInteract.Hover(row.Min, row.Max);
                 if (hovered)
                 {
                     Squircle.Fill(drawList, row.Min, row.Max, 6f * scale,
@@ -253,7 +253,7 @@ internal sealed class CalculatorApp : IPhoneApp
         var min = new Vector2(left, top);
         var max = new Vector2(left + button * 2f + gap, top + button);
         var center = new Vector2((min.X + max.X) * 0.5f, (min.Y + max.Y) * 0.5f);
-        var hovered = ImGui.IsMouseHoveringRect(min, max);
+        var hovered = UiInteract.Hover(min, max);
         var fill = hovered ? Palette.Mix(DigitBg, White, 0.14f) : DigitBg;
         var drawList = ImGui.GetWindowDrawList();
         Squircle.Fill(drawList, min, max, radius, ImGui.GetColorU32(fill));
@@ -281,7 +281,7 @@ internal sealed class CalculatorApp : IPhoneApp
     {
         var min = center - new Vector2(radius, radius);
         var max = center + new Vector2(radius, radius);
-        var hovered = ImGui.IsMouseHoveringRect(min, max);
+        var hovered = UiInteract.Hover(min, max);
         var fill = hovered ? Palette.Mix(background, White, 0.14f) : background;
         var drawList = ImGui.GetWindowDrawList();
         drawList.AddCircleFilled(center, radius, ImGui.GetColorU32(fill), 40);

--- a/src/Aetherphone/Apps/Calendar/CalendarApp.cs
+++ b/src/Aetherphone/Apps/Calendar/CalendarApp.cs
@@ -152,7 +152,7 @@ internal sealed class CalendarApp : IPhoneApp
     {
         var drawList = ImGui.GetWindowDrawList();
         var iconColor = ui.Theme.TextStrong;
-        var hovered = ImGui.IsMouseHoveringRect(center - new Vector2(radius, radius), center + new Vector2(radius, radius));
+        var hovered = UiInteract.Hover(center - new Vector2(radius, radius), center + new Vector2(radius, radius));
         drawList.AddCircleFilled(center, radius, ImGui.GetColorU32(Palette.WithAlpha(iconColor, hovered ? 0.20f : 0.12f)), 32);
         using (ImRaii.PushFont(UiBuilder.IconFont))
         {
@@ -251,7 +251,7 @@ internal sealed class CalendarApp : IPhoneApp
     private bool DrawSaveButton(Rect rect, float scale, bool enabled)
     {
         var drawList = ImGui.GetWindowDrawList();
-        var hovered = enabled && ImGui.IsMouseHoveringRect(rect.Min, rect.Max);
+        var hovered = enabled && UiInteract.Hover(rect.Min, rect.Max);
         var fill = !enabled ? Palette.WithAlpha(ui.Accent, 0.35f) :
             hovered ? Palette.Mix(ui.Accent, new Vector4(0f, 0f, 0f, 1f), 0.12f) : ui.Accent;
         Squircle.Fill(drawList, rect.Min, rect.Max, rect.Height * 0.5f, ImGui.GetColorU32(fill));

--- a/src/Aetherphone/Apps/Calendar/CalendarDayList.cs
+++ b/src/Aetherphone/Apps/Calendar/CalendarDayList.cs
@@ -54,7 +54,7 @@ internal static class CalendarDayList
             var cardHeight = Math.Max(textHeight + CardPaddingY * 2f * scale, 40f * scale);
             var cardMax = new Vector2(cardMin.X + contentWidth, cardMin.Y + cardHeight);
             var clickable = !string.IsNullOrEmpty(dayEvent.Url);
-            var cardHovered = ImGui.IsMouseHoveringRect(cardMin, cardMax);
+            var cardHovered = UiInteract.Hover(cardMin, cardMax);
             var hovered = clickable && cardHovered;
 
             ui.Card(drawList, cardMin, cardMax, CardRounding * scale);
@@ -101,7 +101,7 @@ internal static class CalendarDayList
         var center = new Vector2(cardMax.X - AccentBarInset * scale - radius, cardMax.Y - AccentBarInset * scale - radius + 2f * scale);
         var min = center - new Vector2(radius, radius);
         var max = center + new Vector2(radius, radius);
-        var hovered = ImGui.IsMouseHoveringRect(min, max);
+        var hovered = UiInteract.Hover(min, max);
         if (hovered)
         {
             ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);

--- a/src/Aetherphone/Apps/Calendar/CalendarMonthView.cs
+++ b/src/Aetherphone/Apps/Calendar/CalendarMonthView.cs
@@ -193,7 +193,7 @@ internal static class CalendarMonthView
         var height = NavHeight * scale * 0.68f;
         var max = new Vector2(rightLimitX - gapX, navY + NavHeight * scale * 0.5f + height * 0.5f);
         var min = new Vector2(max.X - textSize.X - padX * 2f, max.Y - height);
-        var hovered = ImGui.IsMouseHoveringRect(min, max);
+        var hovered = UiInteract.Hover(min, max);
         Squircle.Fill(drawList, min, max, height * 0.5f,
             ImGui.GetColorU32(Palette.WithAlpha(ui.Accent, hovered ? 0.24f : 0.14f)));
         Typography.DrawCentered(drawList, (min + max) * 0.5f, todayText, ui.Accent, feScale, feWeight);
@@ -212,7 +212,7 @@ internal static class CalendarMonthView
         var min = new Vector2(origin.X + 4f * scale, origin.Y);
         var max = new Vector2(min.X + 30f * scale, min.Y + NavHeight * scale);
         var mid = (min + max) * 0.5f;
-        var hovered = ImGui.IsMouseHoveringRect(min, max);
+        var hovered = UiInteract.Hover(min, max);
         if (hovered)
         {
             Squircle.Fill(drawList, min, max, (max.Y - min.Y) * 0.5f, ImGui.GetColorU32(ui.HoverTint));

--- a/src/Aetherphone/Apps/Camera/CameraApp.cs
+++ b/src/Aetherphone/Apps/Camera/CameraApp.cs
@@ -1,3 +1,4 @@
+using Aetherphone.Windows.Components;
 using Aetherphone.Core;
 using Aetherphone.Core.Apps;
 using Aetherphone.Core.Localization;
@@ -391,7 +392,7 @@ internal sealed class CameraApp : IPhoneApp
         }
 
         var mouse = ImGui.GetMousePos();
-        if (!viewfinder.Contains(mouse))
+        if (!UiInteract.Hover(viewfinder.Min, viewfinder.Max))
         {
             return;
         }

--- a/src/Aetherphone/Apps/Camera/CameraApp.cs
+++ b/src/Aetherphone/Apps/Camera/CameraApp.cs
@@ -1,9 +1,9 @@
-using Aetherphone.Windows.Components;
 using Aetherphone.Core;
 using Aetherphone.Core.Apps;
 using Aetherphone.Core.Localization;
 using Aetherphone.Core.Photos;
 using Aetherphone.Core.Theme;
+using Aetherphone.Windows.Components;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Game.Gui.NamePlate;
 using Dalamud.Interface.Textures;

--- a/src/Aetherphone/Apps/Camera/CameraChrome.cs
+++ b/src/Aetherphone/Apps/Camera/CameraChrome.cs
@@ -72,7 +72,7 @@ internal static class CameraChrome
         var min = center - half;
         var max = center + half;
         UiAnchors.Report("camera.flash", new Rect(min, max));
-        var hovered = ImGui.IsMouseHoveringRect(min, max);
+        var hovered = UiInteract.Hover(min, max);
         var rounding = Metrics.Radius.Field * scale;
         var fill = flashEnabled
             ? SelectedMode
@@ -97,7 +97,7 @@ internal static class CameraChrome
         var half = new Vector2(16f * scale, 16f * scale);
         var min = center - half;
         var max = center + half;
-        var hovered = ImGui.IsMouseHoveringRect(min, max);
+        var hovered = UiInteract.Hover(min, max);
         var rounding = Metrics.Radius.Field * scale;
         var fill = landscapeEnabled
             ? SelectedMode
@@ -261,7 +261,7 @@ internal static class CameraChrome
             Typography.DrawCentered(labelCenter, Loc.T(modes[index]), color, modeScale);
             var hitMin = new Vector2(cursorX - gap * 0.4f, rowCenterY - 14f * scale);
             var hitMax = new Vector2(cursorX + widths[index] + gap * 0.4f, rowCenterY + 14f * scale);
-            if (!selected && ImGui.IsMouseHoveringRect(hitMin, hitMax))
+            if (!selected && UiInteract.Hover(hitMin, hitMax))
             {
                 ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
                 if (ImGui.IsMouseClicked(ImGuiMouseButton.Left))
@@ -296,7 +296,7 @@ internal static class CameraChrome
             Typography.DrawCentered(new Vector2(columnCenterX, cursorY), Loc.T(modes[index]), color, modeScale);
             var hitMin = new Vector2(columnCenterX - halfWidth, cursorY - rowHeight * 0.5f);
             var hitMax = new Vector2(columnCenterX + halfWidth, cursorY + rowHeight * 0.5f);
-            if (!selected && ImGui.IsMouseHoveringRect(hitMin, hitMax))
+            if (!selected && UiInteract.Hover(hitMin, hitMax))
             {
                 ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
                 if (ImGui.IsMouseClicked(ImGuiMouseButton.Left))
@@ -317,7 +317,7 @@ internal static class CameraChrome
         var outerRadius = ShutterRadius * scale;
         UiAnchors.Report("camera.shutter",
             new Rect(center - new Vector2(outerRadius, outerRadius), center + new Vector2(outerRadius, outerRadius)));
-        var hovered = ImGui.IsMouseHoveringRect(center - new Vector2(outerRadius, outerRadius),
+        var hovered = UiInteract.Hover(center - new Vector2(outerRadius, outerRadius),
             center + new Vector2(outerRadius, outerRadius));
         dl.AddCircle(center, outerRadius, ImGui.GetColorU32(ShutterRing), 48, 3f * scale);
         var innerRadius = (outerRadius - Metrics.Space.Xs * scale) * (1f - 0.16f * shutterPress);
@@ -338,7 +338,7 @@ internal static class CameraChrome
         var half = 22f * scale;
         var min = center - new Vector2(half, half);
         var max = center + new Vector2(half, half);
-        var hovered = ImGui.IsMouseHoveringRect(min, max);
+        var hovered = UiInteract.Hover(min, max);
         var rounding = Metrics.Radius.Sm * scale;
         if (lastShot is { } shot)
         {
@@ -368,7 +368,7 @@ internal static class CameraChrome
         var dl = ImGui.GetWindowDrawList();
         var radius = 19f * scale;
         var hovered =
-            ImGui.IsMouseHoveringRect(center - new Vector2(radius, radius), center + new Vector2(radius, radius));
+            UiInteract.Hover(center - new Vector2(radius, radius), center + new Vector2(radius, radius));
         if (gridEnabled || hovered)
         {
             var bg = gridEnabled ? new Vector4(1f, 1f, 1f, 0.16f) : new Vector4(1f, 1f, 1f, 0.08f);

--- a/src/Aetherphone/Apps/Chirper/ChirperApp.cs
+++ b/src/Aetherphone/Apps/Chirper/ChirperApp.cs
@@ -445,7 +445,7 @@ internal sealed partial class ChirperApp : IPhoneApp
             OpenProfile(post.AuthorId);
         }
 
-        var nameHovering = ImGui.IsMouseHoveringRect(new Vector2(contentLeft, contentTop + pad),
+        var nameHovering = UiInteract.Hover(new Vector2(contentLeft, contentTop + pad),
             new Vector2(contentLeft + nameMaxWidth, contentTop + pad + nameSize.Y));
         var drawnNameWidth = Marquee.DrawLeft("chirper.post.author." + post.Id, rawDisplayName, contentLeft,
             contentTop + pad, nameMaxWidth, new TextStyle(1.05f, FontWeight.SemiBold), theme.TextStrong, nameHovering);
@@ -459,7 +459,7 @@ internal sealed partial class ChirperApp : IPhoneApp
         var metaMaxWidth = MathF.Max(1f, headerRight - metaLeft);
         var metaSize = Typography.Measure(Typography.FitText(meta, metaMaxWidth, 0.95f, FontWeight.Regular), 0.95f);
         var metaTop = contentTop + pad + (nameSize.Y - metaSize.Y) * 0.5f;
-        var metaHovering = ImGui.IsMouseHoveringRect(new Vector2(metaLeft, metaTop),
+        var metaHovering = UiInteract.Hover(new Vector2(metaLeft, metaTop),
             new Vector2(metaLeft + metaMaxWidth, metaTop + metaSize.Y));
         Marquee.DrawLeft("chirper.post.meta." + post.Id, meta, metaLeft, metaTop, metaMaxWidth,
             new TextStyle(0.95f, FontWeight.Regular), AppPalettes.Chirper.MutedInk, metaHovering);
@@ -883,7 +883,7 @@ internal sealed partial class ChirperApp : IPhoneApp
         var unavailableText = Loc.T(L.Chirper.Unavailable);
         var unavailableMaxWidth = MathF.Max(1f, width - pad * 2f);
         var unavailableSize = Typography.Measure(unavailableText, 0.9f);
-        var unavailableHovering = ImGui.IsMouseHoveringRect(new Vector2(origin.X + pad, origin.Y + pad),
+        var unavailableHovering = UiInteract.Hover(new Vector2(origin.X + pad, origin.Y + pad),
             new Vector2(origin.X + pad + unavailableMaxWidth, origin.Y + pad + unavailableSize.Y));
         Marquee.DrawLeft("chirper.card.unavailable", unavailableText, origin.X + pad, origin.Y + pad,
             unavailableMaxWidth, new TextStyle(0.9f, FontWeight.Regular), AppPalettes.Chirper.MutedInk,
@@ -923,7 +923,7 @@ internal sealed partial class ChirperApp : IPhoneApp
             var unavailableText = Loc.T(L.Chirper.Unavailable);
             var unavailableMaxWidth = MathF.Max(1f, width - innerPad * 2f);
             var unavailableSize = Typography.Measure(unavailableText, 0.85f);
-            var unavailableHovering = ImGui.IsMouseHoveringRect(new Vector2(min.X + innerPad, min.Y + innerPad),
+            var unavailableHovering = UiInteract.Hover(new Vector2(min.X + innerPad, min.Y + innerPad),
                 new Vector2(min.X + innerPad + unavailableMaxWidth, min.Y + innerPad + unavailableSize.Y));
             Marquee.DrawLeft("chirper.quoted.unavailable", unavailableText, min.X + innerPad, min.Y + innerPad,
                 unavailableMaxWidth, new TextStyle(0.85f, FontWeight.Regular), AppPalettes.Chirper.MutedInk,
@@ -936,7 +936,7 @@ internal sealed partial class ChirperApp : IPhoneApp
         var nameMaxWidth = innerWidth * 0.55f;
         var name = Typography.FitText(rawName, nameMaxWidth, 0.85f, FontWeight.SemiBold);
         var nameSize = Typography.Measure(name, 0.85f, FontWeight.SemiBold);
-        var nameHovering = ImGui.IsMouseHoveringRect(new Vector2(min.X + innerPad, min.Y + innerPad),
+        var nameHovering = UiInteract.Hover(new Vector2(min.X + innerPad, min.Y + innerPad),
             new Vector2(min.X + innerPad + nameMaxWidth, min.Y + innerPad + nameSize.Y));
         Marquee.DrawLeft("chirper.quote.author." + hostId, rawName, min.X + innerPad, min.Y + innerPad,
             nameMaxWidth, new TextStyle(0.85f, FontWeight.SemiBold), theme.TextStrong, nameHovering);
@@ -1127,7 +1127,7 @@ internal sealed partial class ChirperApp : IPhoneApp
         var nameMaxWidth = headerWidth * 0.55f;
         var displayName = Typography.FitText(rawDisplayName, nameMaxWidth, 0.95f, FontWeight.SemiBold);
         var nameSize = Typography.Measure(displayName, 0.95f, FontWeight.SemiBold);
-        var nameHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, origin.Y),
+        var nameHovering = UiInteract.Hover(new Vector2(textLeft, origin.Y),
             new Vector2(textLeft + nameMaxWidth, origin.Y + nameSize.Y));
         Marquee.DrawLeft("chirper.comment.author." + comment.Id, rawDisplayName, textLeft, origin.Y,
             nameMaxWidth, new TextStyle(0.95f, FontWeight.SemiBold), theme.TextStrong, nameHovering);
@@ -1138,7 +1138,7 @@ internal sealed partial class ChirperApp : IPhoneApp
         var metaMaxWidth = MathF.Max(1f, commentRight - metaLeft - 34f * scale);
         var metaFullSize = Typography.Measure(meta, 0.85f);
         var metaY = origin.Y + (nameSize.Y - metaFullSize.Y) * 0.5f;
-        var metaHovering = ImGui.IsMouseHoveringRect(new Vector2(metaLeft, metaY),
+        var metaHovering = UiInteract.Hover(new Vector2(metaLeft, metaY),
             new Vector2(metaLeft + metaMaxWidth, metaY + metaFullSize.Y));
         var metaWidth = Marquee.DrawLeft("chirper.comment.meta." + comment.Id, meta, metaLeft, metaY, metaMaxWidth,
             new TextStyle(0.85f, FontWeight.Regular), AppPalettes.Chirper.MutedInk, metaHovering);

--- a/src/Aetherphone/Apps/Clock/ClockApp.Stopwatch.cs
+++ b/src/Aetherphone/Apps/Clock/ClockApp.Stopwatch.cs
@@ -146,7 +146,7 @@ internal sealed partial class ClockApp
         var drawList = ImGui.GetWindowDrawList();
         var min = center - new Vector2(radius, radius);
         var max = center + new Vector2(radius, radius);
-        var hovered = enabled && ImGui.IsMouseHoveringRect(min, max);
+        var hovered = enabled && UiInteract.Hover(min, max);
         var shown = enabled ? color : Palette.WithAlpha(color, 0.4f);
         drawList.AddCircleFilled(center, radius,
             ImGui.GetColorU32(Palette.WithAlpha(shown, hovered ? 0.34f : 0.22f)), 40);

--- a/src/Aetherphone/Apps/Clock/ClockApp.World.cs
+++ b/src/Aetherphone/Apps/Clock/ClockApp.World.cs
@@ -148,7 +148,7 @@ internal sealed partial class ClockApp
         var scale = ImGuiHelpers.GlobalScale;
         var added = configuration.WorldClocks.Exists(entry => entry.TimeZoneId == city.TimeZoneId &&
                                                               entry.City == city.City);
-        var hovering = ImGui.IsMouseHoveringRect(row.Min, row.Max);
+        var hovering = UiInteract.Hover(row.Min, row.Max);
         var textMaxWidth = MathF.Max(1f, row.Max.X - 34f * scale - row.Min.X);
         Marquee.DrawLeft("clock.cityPicker.name." + city.City, city.City, row.Min.X, row.Center.Y - 16f * scale,
             textMaxWidth, TextStyles.Headline, ui.TitleInk, hovering);

--- a/src/Aetherphone/Apps/Clock/ClockApp.cs
+++ b/src/Aetherphone/Apps/Clock/ClockApp.cs
@@ -161,7 +161,7 @@ internal sealed partial class ClockApp : IPhoneApp
     private bool DrawPillButton(Rect rect, string label, Vector4 fill, Vector4 ink)
     {
         var drawList = ImGui.GetWindowDrawList();
-        var hovered = ImGui.IsMouseHoveringRect(rect.Min, rect.Max);
+        var hovered = UiInteract.Hover(rect.Min, rect.Max);
         var shown = hovered ? Palette.Mix(fill, new Vector4(1f, 1f, 1f, 1f), 0.12f) : fill;
         Squircle.Fill(drawList, rect.Min, rect.Max, rect.Height * 0.5f, ImGui.GetColorU32(shown));
         Typography.DrawCentered(drawList, rect.Center, label, ink, TextStyles.Headline.Scale, TextStyles.Headline.Weight);

--- a/src/Aetherphone/Apps/Collections/CollectionsApp.Browse.cs
+++ b/src/Aetherphone/Apps/Collections/CollectionsApp.Browse.cs
@@ -443,13 +443,13 @@ internal sealed partial class CollectionsApp
         {
             var nameY = row.Center.Y - 16f * scale;
             var nameSize = Typography.Measure(item.Name, TextStyles.BodyEmphasized);
-            var nameHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, nameY),
+            var nameHovering = UiInteract.Hover(new Vector2(textLeft, nameY),
                 new Vector2(textLeft + textWidth, nameY + nameSize.Y));
             Marquee.DrawLeft("collections.item." + item.Id, item.Name, textLeft, nameY,
                 textWidth, TextStyles.BodyEmphasized, ui.TitleInk, nameHovering);
             var subY = row.Center.Y + 4f * scale;
             var subSize = Typography.Measure(subtitle, TextStyles.Footnote);
-            var subHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, subY),
+            var subHovering = UiInteract.Hover(new Vector2(textLeft, subY),
                 new Vector2(textLeft + textWidth, subY + subSize.Y));
             Marquee.DrawLeft("collections.item.sub." + item.Id, subtitle, textLeft, subY, textWidth,
                 TextStyles.Footnote, ui.MutedInk, subHovering);
@@ -458,7 +458,7 @@ internal sealed partial class CollectionsApp
         {
             var nameSize = Typography.Measure(item.Name, TextStyles.BodyEmphasized);
             var nameY = row.Center.Y - nameSize.Y * 0.5f;
-            var nameHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, nameY),
+            var nameHovering = UiInteract.Hover(new Vector2(textLeft, nameY),
                 new Vector2(textLeft + textWidth, nameY + nameSize.Y));
             Marquee.DrawLeft("collections.item." + item.Id, item.Name, textLeft, nameY,
                 textWidth, TextStyles.BodyEmphasized, ui.TitleInk, nameHovering);
@@ -638,7 +638,7 @@ internal sealed partial class CollectionsApp
             var centerY = (rowMin.Y + rowMax.Y) * 0.5f;
             var label = index == 0 ? Loc.T(L.Collections.AllSources) : sourceList[index - 1];
             var selected = index == sourceIndex;
-            var hovered = ImGui.IsMouseHoveringRect(rowMin, rowMax);
+            var hovered = UiInteract.Hover(rowMin, rowMax);
             if (hovered)
             {
                 Squircle.Fill(drawList, rowMin, rowMax, 9f * scale, ImGui.GetColorU32(ui.HoverTint));
@@ -670,8 +670,8 @@ internal sealed partial class CollectionsApp
             return;
         }
 
-        if (ImGui.IsMouseClicked(ImGuiMouseButton.Left) && !ImGui.IsMouseHoveringRect(min, max, false) &&
-            !ImGui.IsMouseHoveringRect(sourceMenuAnchor.Min, sourceMenuAnchor.Max, false))
+        if (ImGui.IsMouseClicked(ImGuiMouseButton.Left) && !UiInteract.Hover(min, max, false) &&
+            !UiInteract.Hover(sourceMenuAnchor.Min, sourceMenuAnchor.Max, false))
         {
             sourceMenuOpen = false;
         }

--- a/src/Aetherphone/Apps/Collections/CollectionsApp.Browse.cs
+++ b/src/Aetherphone/Apps/Collections/CollectionsApp.Browse.cs
@@ -638,7 +638,7 @@ internal sealed partial class CollectionsApp
             var centerY = (rowMin.Y + rowMax.Y) * 0.5f;
             var label = index == 0 ? Loc.T(L.Collections.AllSources) : sourceList[index - 1];
             var selected = index == sourceIndex;
-            var hovered = UiInteract.Hover(rowMin, rowMax);
+            var hovered = UiInteract.HoverWindowOnly(rowMin, rowMax);
             if (hovered)
             {
                 Squircle.Fill(drawList, rowMin, rowMax, 9f * scale, ImGui.GetColorU32(ui.HoverTint));
@@ -670,8 +670,8 @@ internal sealed partial class CollectionsApp
             return;
         }
 
-        if (ImGui.IsMouseClicked(ImGuiMouseButton.Left) && !UiInteract.Hover(min, max, false) &&
-            !UiInteract.Hover(sourceMenuAnchor.Min, sourceMenuAnchor.Max, false))
+        if (ImGui.IsMouseClicked(ImGuiMouseButton.Left) && !UiInteract.HoverWindowOnly(min, max, false) &&
+            !UiInteract.HoverWindowOnly(sourceMenuAnchor.Min, sourceMenuAnchor.Max, false))
         {
             sourceMenuOpen = false;
         }

--- a/src/Aetherphone/Apps/Dailies/DailiesApp.cs
+++ b/src/Aetherphone/Apps/Dailies/DailiesApp.cs
@@ -317,7 +317,7 @@ internal sealed class DailiesApp : IPhoneApp
         var name = Loc.T(item.Label);
         var sublabel = BuildSublabel(item, utcNow);
         var nameColor = complete && tappable ? AppPalettes.Dailies.MutedInk : AppPalettes.Dailies.TitleInk;
-        var textHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, band.Min.Y), new Vector2(textRight, band.Max.Y));
+        var textHovering = UiInteract.Hover(new Vector2(textLeft, band.Min.Y), new Vector2(textRight, band.Max.Y));
 
         if (sublabel.Length > 0)
         {

--- a/src/Aetherphone/Apps/Feedback/FeedbackApp.cs
+++ b/src/Aetherphone/Apps/Feedback/FeedbackApp.cs
@@ -265,7 +265,7 @@ internal sealed class FeedbackApp : IPhoneApp
 
         var badgeRadius = 8.5f * scale;
         var badgeCenter = new Vector2(max.X - badgeRadius - 2f * scale, min.Y + badgeRadius + 2f * scale);
-        var badgeHovered = ImGui.IsMouseHoveringRect(badgeCenter - new Vector2(badgeRadius, badgeRadius),
+        var badgeHovered = UiInteract.Hover(badgeCenter - new Vector2(badgeRadius, badgeRadius),
             badgeCenter + new Vector2(badgeRadius, badgeRadius));
         drawList.AddCircleFilled(badgeCenter, badgeRadius,
             ImGui.GetColorU32(new Vector4(0f, 0f, 0f, badgeHovered ? 0.9f : 0.62f)), 20);
@@ -281,7 +281,7 @@ internal sealed class FeedbackApp : IPhoneApp
 
     private bool DrawAddTile(ImDrawListPtr drawList, Vector2 min, Vector2 max, float rounding, float scale)
     {
-        var hovered = ImGui.IsMouseHoveringRect(min, max);
+        var hovered = UiInteract.Hover(min, max);
         Squircle.Fill(drawList, min, max, rounding,
             ImGui.GetColorU32(hovered ? ui.HoverTint : AppPalettes.Feedback.FieldSurface));
         Squircle.Stroke(drawList, min, max, rounding, ImGui.GetColorU32(AddTileStroke), 1f);

--- a/src/Aetherphone/Apps/Fishing/FishingApp.cs
+++ b/src/Aetherphone/Apps/Fishing/FishingApp.cs
@@ -121,7 +121,7 @@ internal sealed class FishingApp : IPhoneApp
         IconTile.Draw(tileCenter, tile, tint, TimeOfDayIcon(plan.TimeOfDay));
 
         var titleMaxWidth = innerRight - tile - 10f * scale - innerLeft;
-        var titleHovering = ImGui.IsMouseHoveringRect(new Vector2(innerLeft, min.Y + 30f * scale),
+        var titleHovering = UiInteract.Hover(new Vector2(innerLeft, min.Y + 30f * scale),
             new Vector2(innerLeft + titleMaxWidth, min.Y + 58f * scale));
         Marquee.DrawLeft("fishing.hero." + plan.RouteName, plan.RouteName, innerLeft, min.Y + 34f * scale,
             titleMaxWidth, TextStyles.Title2, ui.TitleInk, titleHovering);
@@ -288,7 +288,7 @@ internal sealed class FishingApp : IPhoneApp
         {
             var nameSize = Typography.Measure(plan.RouteName, TextStyles.Headline);
             var nameY = row.Center.Y - nameSize.Y * 0.5f;
-            var nameHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, nameY),
+            var nameHovering = UiInteract.Hover(new Vector2(textLeft, nameY),
                 new Vector2(textLeft + rowMaxWidth, nameY + nameSize.Y));
             Marquee.DrawLeft(rowId, plan.RouteName,
                 textLeft, nameY, rowMaxWidth, TextStyles.Headline, ui.TitleInk, nameHovering);
@@ -297,7 +297,7 @@ internal sealed class FishingApp : IPhoneApp
         {
             var nameY = row.Center.Y - 18f * scale;
             var nameSize = Typography.Measure(plan.RouteName, TextStyles.Headline);
-            var nameHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, nameY),
+            var nameHovering = UiInteract.Hover(new Vector2(textLeft, nameY),
                 new Vector2(textLeft + rowMaxWidth, nameY + nameSize.Y));
             Marquee.DrawLeft(rowId, plan.RouteName, textLeft, nameY,
                 rowMaxWidth, TextStyles.Headline, ui.TitleInk, nameHovering);
@@ -308,7 +308,7 @@ internal sealed class FishingApp : IPhoneApp
             var blueFishMaxWidth = MathF.Max(1f, textRight - blueFishLeft);
             var blueFishNames = BlueFishNames(plan);
             var blueFishSize = Typography.Measure(blueFishNames, TextStyles.Footnote);
-            var blueFishHovering = ImGui.IsMouseHoveringRect(new Vector2(blueFishLeft, blueFishY),
+            var blueFishHovering = UiInteract.Hover(new Vector2(blueFishLeft, blueFishY),
                 new Vector2(blueFishLeft + blueFishMaxWidth, blueFishY + blueFishSize.Y));
             Marquee.DrawLeft(rowId + ".sub", blueFishNames, blueFishLeft, blueFishY, blueFishMaxWidth,
                 TextStyles.Footnote, ui.MutedInk, blueFishHovering);

--- a/src/Aetherphone/Apps/Games/Beat/BeatApp.cs
+++ b/src/Aetherphone/Apps/Games/Beat/BeatApp.cs
@@ -147,8 +147,7 @@ internal sealed class BeatApp : IMiniGame
             return;
         }
 
-        var mouse = ImGui.GetMousePos();
-        if (!field.Contains(mouse))
+        if (!UiInteract.Hover(field.Min, field.Max))
         {
             return;
         }
@@ -160,7 +159,7 @@ internal sealed class BeatApp : IMiniGame
         }
 
         var laneWidth = BeatRenderer.LaneWidthOf(field);
-        var lane = (int)((mouse.X - field.Min.X) / laneWidth);
+        var lane = (int)((ImGui.GetMousePos().X - field.Min.X) / laneWidth);
         if (lane < 0)
         {
             lane = 0;

--- a/src/Aetherphone/Apps/Games/Blade/BladeApp.cs
+++ b/src/Aetherphone/Apps/Games/Blade/BladeApp.cs
@@ -130,7 +130,8 @@ internal sealed class BladeApp : IMiniGame
             return;
         }
 
-        if (board.State == BladeState.Over || !ImGui.IsMouseClicked(ImGuiMouseButton.Left))
+        if (board.State == BladeState.Over || !ImGui.IsMouseClicked(ImGuiMouseButton.Left) ||
+            !UiInteract.Hover(area.Min, area.Max))
         {
             return;
         }

--- a/src/Aetherphone/Apps/Games/Breakout/BreakoutApp.cs
+++ b/src/Aetherphone/Apps/Games/Breakout/BreakoutApp.cs
@@ -1,3 +1,4 @@
+using Aetherphone.Windows.Components;
 using Aetherphone.Apps.Games.Framework;
 using Aetherphone.Core.Animation;
 using Aetherphone.Core;
@@ -155,9 +156,8 @@ internal sealed class BreakoutApp : IMiniGame
 
     private void HandleInput(Rect field, float factor)
     {
-        var mouse = ImGui.GetMousePos();
-        board.SetPaddle((mouse.X - field.Min.X) / factor);
-        if (board.Attached && ImGui.IsMouseClicked(ImGuiMouseButton.Left) && field.Contains(mouse))
+        board.SetPaddle((ImGui.GetMousePos().X - field.Min.X) / factor);
+        if (board.Attached && ImGui.IsMouseClicked(ImGuiMouseButton.Left) && UiInteract.Hover(field.Min, field.Max))
         {
             board.Launch();
         }

--- a/src/Aetherphone/Apps/Games/Breakout/BreakoutApp.cs
+++ b/src/Aetherphone/Apps/Games/Breakout/BreakoutApp.cs
@@ -1,10 +1,10 @@
-using Aetherphone.Windows.Components;
 using Aetherphone.Apps.Games.Framework;
-using Aetherphone.Core.Animation;
 using Aetherphone.Core;
+using Aetherphone.Core.Animation;
 using Aetherphone.Core.Apps;
 using Aetherphone.Core.Localization;
 using Aetherphone.Core.Theme;
+using Aetherphone.Windows.Components;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Utility;
 

--- a/src/Aetherphone/Apps/Games/BubbleShooter/BubbleShooterApp.cs
+++ b/src/Aetherphone/Apps/Games/BubbleShooter/BubbleShooterApp.cs
@@ -151,8 +151,7 @@ internal sealed class BubbleShooterApp : IMiniGame
 
     private Vector2 ComputeAim(Rect field, float factor)
     {
-        var mouse = ImGui.GetMousePos();
-        var mouseNorm = (mouse - field.Min) / factor;
+        var mouseNorm = (ImGui.GetMousePos() - field.Min) / factor;
         var direction = mouseNorm - board.LauncherPosition;
         if (direction.LengthSquared() < 0.0001f)
         {
@@ -169,8 +168,7 @@ internal sealed class BubbleShooterApp : IMiniGame
 
     private void HandleInput(Rect field, float factor, float scale, Vector2 aim)
     {
-        var mouse = ImGui.GetMousePos();
-        if (!field.Contains(mouse))
+        if (!UiInteract.Hover(field.Min, field.Max))
         {
             return;
         }

--- a/src/Aetherphone/Apps/Games/Chess/ChessApp.cs
+++ b/src/Aetherphone/Apps/Games/Chess/ChessApp.cs
@@ -250,13 +250,12 @@ internal sealed class ChessApp : IMiniGame
 
     private int ResolveHover()
     {
-        var mouse = ImGui.GetMousePos();
-        if (!layout.Bounds.Contains(mouse))
+        if (!UiInteract.Hover(layout.Bounds.Min, layout.Bounds.Max))
         {
             return -1;
         }
 
-        var square = layout.HitTest(mouse);
+        var square = layout.HitTest(ImGui.GetMousePos());
         if (square >= 0)
         {
             ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
@@ -608,7 +607,7 @@ internal sealed class ChessApp : IMiniGame
         var drawList = ImGui.GetWindowDrawList();
         var min = center - new Vector2(radius, radius);
         var max = center + new Vector2(radius, radius);
-        var hovered = enabled && ImGui.IsMouseHoveringRect(min, max);
+        var hovered = enabled && UiInteract.Hover(min, max);
         Material.Frosted(drawList, min, max, radius, scale, enabled ? 0.92f : 0.55f);
         if (hovered)
         {

--- a/src/Aetherphone/Apps/Games/CrystalDrop/CrystalDropApp.cs
+++ b/src/Aetherphone/Apps/Games/CrystalDrop/CrystalDropApp.cs
@@ -127,17 +127,17 @@ internal sealed class CrystalDropApp : IMiniGame
             return;
         }
 
-        var mouse = ImGui.GetMousePos();
-        if (body.Contains(mouse))
+        var bodyHovered = UiInteract.Hover(body.Min, body.Max);
+        if (bodyHovered)
         {
-            pointerX = (mouse.X - jar.Min.X) / jar.Width;
+            pointerX = (ImGui.GetMousePos().X - jar.Min.X) / jar.Width;
             if (board.CanDrop)
             {
                 ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
             }
         }
 
-        if (!ImGui.IsMouseClicked(ImGuiMouseButton.Left) || !body.Contains(mouse))
+        if (!ImGui.IsMouseClicked(ImGuiMouseButton.Left) || !bodyHovered)
         {
             return;
         }

--- a/src/Aetherphone/Apps/Games/Flap/FlapApp.cs
+++ b/src/Aetherphone/Apps/Games/Flap/FlapApp.cs
@@ -145,7 +145,7 @@ internal sealed class FlapApp : IMiniGame
             return;
         }
 
-        if (!ImGui.IsMouseClicked(ImGuiMouseButton.Left))
+        if (!ImGui.IsMouseClicked(ImGuiMouseButton.Left) || !UiInteract.Hover(area.Min, area.Max))
         {
             return;
         }

--- a/src/Aetherphone/Apps/Games/Flow/FlowApp.cs
+++ b/src/Aetherphone/Apps/Games/Flow/FlowApp.cs
@@ -155,12 +155,13 @@ internal sealed class FlowApp : IMiniGame
 
     private int ResolveHover(GameGrid grid)
     {
-        if (!grid.Bounds.Contains(ImGui.GetMousePos()))
+        var mouse = ImGui.GetMousePos();
+        if (!grid.Bounds.Contains(mouse))
         {
             return -1;
         }
 
-        var local = ImGui.GetMousePos() - grid.Origin;
+        var local = mouse - grid.Origin;
         var column = (int)(local.X / grid.Pitch);
         var row = (int)(local.Y / grid.Pitch);
         if (column < 0 || column >= board.Columns || row < 0 || row >= board.Rows)

--- a/src/Aetherphone/Apps/Games/Flow/FlowApp.cs
+++ b/src/Aetherphone/Apps/Games/Flow/FlowApp.cs
@@ -155,13 +155,12 @@ internal sealed class FlowApp : IMiniGame
 
     private int ResolveHover(GameGrid grid)
     {
-        var mouse = ImGui.GetMousePos();
-        if (!grid.Bounds.Contains(mouse))
+        if (!grid.Bounds.Contains(ImGui.GetMousePos()))
         {
             return -1;
         }
 
-        var local = mouse - grid.Origin;
+        var local = ImGui.GetMousePos() - grid.Origin;
         var column = (int)(local.X / grid.Pitch);
         var row = (int)(local.Y / grid.Pitch);
         if (column < 0 || column >= board.Columns || row < 0 || row >= board.Rows)
@@ -181,7 +180,10 @@ internal sealed class FlowApp : IMiniGame
 
         if (ImGui.IsMouseClicked(ImGuiMouseButton.Left))
         {
-            board.Press(hovered);
+            if (UiInteract.Hover(grid.Bounds.Min, grid.Bounds.Max))
+            {
+                board.Press(hovered);
+            }
         }
         else if (ImGui.IsMouseDown(ImGuiMouseButton.Left) && board.ActiveColor >= 0)
         {

--- a/src/Aetherphone/Apps/Games/Framework/GameHud.cs
+++ b/src/Aetherphone/Apps/Games/Framework/GameHud.cs
@@ -60,7 +60,7 @@ internal static class GameHud
         var drawList = ImGui.GetWindowDrawList();
         var min = center - new Vector2(radius, radius);
         var max = center + new Vector2(radius, radius);
-        var hovered = ImGui.IsMouseHoveringRect(min, max);
+        var hovered = UiInteract.Hover(min, max);
         Material.Frosted(drawList, min, max, radius, scale, hovered ? 1f : 0.92f);
         if (hovered)
         {
@@ -78,7 +78,7 @@ internal static class GameHud
         var scale = ImGuiHelpers.GlobalScale;
         var drawList = ImGui.GetWindowDrawList();
         var hoverHalf = size * 0.5f;
-        var hovered = ImGui.IsMouseHoveringRect(center - hoverHalf, center + hoverHalf);
+        var hovered = UiInteract.Hover(center - hoverHalf, center + hoverHalf);
         var pressed = hovered && ImGui.IsMouseDown(ImGuiMouseButton.Left);
         var visualScale = pressed ? 0.955f : 1f;
         var half = hoverHalf * visualScale;

--- a/src/Aetherphone/Apps/Games/GamesApp.cs
+++ b/src/Aetherphone/Apps/Games/GamesApp.cs
@@ -300,7 +300,7 @@ internal sealed class GamesApp : IPhoneApp
         var drawList = ImGui.GetWindowDrawList();
         var hitMin = new Vector2(row.Min.X - Metrics.Space.Lg * scale, row.Min.Y);
         var hitMax = new Vector2(row.Max.X + Metrics.Space.Lg * scale, row.Max.Y);
-        var hovered = ImGui.IsMouseHoveringRect(hitMin, hitMax);
+        var hovered = UiInteract.Hover(hitMin, hitMax);
         if (hovered)
         {
             drawList.AddRectFilled(hitMin, hitMax, ImGui.GetColorU32(new Vector4(1f, 1f, 1f, 0.045f)),
@@ -332,7 +332,7 @@ internal sealed class GamesApp : IPhoneApp
         var textMaxWidth = MathF.Max(1f, row.Max.X - pillWidth - 8f * scale - textX);
         var titleY = row.Center.Y - 17f * scale;
         var titleSize = Typography.Measure(game.Title, TextStyles.Headline);
-        var titleHovering = ImGui.IsMouseHoveringRect(new Vector2(textX, titleY),
+        var titleHovering = UiInteract.Hover(new Vector2(textX, titleY),
             new Vector2(textX + textMaxWidth, titleY + titleSize.Y));
         Marquee.DrawLeft("games.row.title." + game.Id, game.Title, textX, titleY, textMaxWidth,
             TextStyles.Headline, theme.TextStrong, titleHovering);
@@ -340,7 +340,7 @@ internal sealed class GamesApp : IPhoneApp
         var subtitle = string.IsNullOrEmpty(best) ? game.Genre : $"{Loc.T(L.Games.Best)} · {best}";
         var subtitleY = row.Center.Y + 2f * scale;
         var subtitleSize = Typography.Measure(subtitle, TextStyles.Footnote);
-        var subtitleHovering = ImGui.IsMouseHoveringRect(new Vector2(textX, subtitleY),
+        var subtitleHovering = UiInteract.Hover(new Vector2(textX, subtitleY),
             new Vector2(textX + textMaxWidth, subtitleY + subtitleSize.Y));
         Marquee.DrawLeft("games.row.subtitle." + game.Id, subtitle, textX, subtitleY, textMaxWidth,
             TextStyles.Footnote, theme.TextMuted, subtitleHovering);
@@ -356,7 +356,7 @@ internal sealed class GamesApp : IPhoneApp
         var pillHeight = 26f * scale;
         var pillMax = new Vector2(row.Max.X, row.Center.Y + pillHeight * 0.5f);
         var pillMin = new Vector2(row.Max.X - pillWidth, row.Center.Y - pillHeight * 0.5f);
-        var pillHovered = ImGui.IsMouseHoveringRect(pillMin, pillMax);
+        var pillHovered = UiInteract.Hover(pillMin, pillMax);
         Squircle.Fill(drawList, pillMin, pillMax, pillHeight * 0.5f,
             ImGui.GetColorU32(accent with { W = pillHovered ? 0.32f : 0.18f }));
         Typography.DrawCentered((pillMin + pillMax) * 0.5f, label, GamePalette.Lighten(accent, 0.38f),
@@ -371,7 +371,7 @@ internal sealed class GamesApp : IPhoneApp
         }
 
         var drawList = ImGui.GetWindowDrawList();
-        var hovered = ImGui.IsMouseHoveringRect(rect.Min, rect.Max);
+        var hovered = UiInteract.Hover(rect.Min, rect.Max);
         var pressed = hovered && ImGui.IsMouseDown(ImGuiMouseButton.Left);
         var target = pressed ? 0.975f :
             hovered ? 1.012f : 1f;
@@ -413,13 +413,13 @@ internal sealed class GamesApp : IPhoneApp
             TextStyles.Caption2);
         var heroTitleY = center.Y - 18f * scale;
         var heroTitleSize = Typography.Measure(game.Title, TextStyles.Title2);
-        var heroTitleHovering = ImGui.IsMouseHoveringRect(new Vector2(textX, heroTitleY),
+        var heroTitleHovering = UiInteract.Hover(new Vector2(textX, heroTitleY),
             new Vector2(textX + heroTextMaxWidth, heroTitleY + heroTitleSize.Y));
         Marquee.DrawLeft("games.hero.title." + game.Id, game.Title, textX, heroTitleY, heroTextMaxWidth,
             TextStyles.Title2, ink, heroTitleHovering);
         var heroGenreY = center.Y + 8f * scale;
         var heroGenreSize = Typography.Measure(game.Genre, TextStyles.Footnote);
-        var heroGenreHovering = ImGui.IsMouseHoveringRect(new Vector2(textX, heroGenreY),
+        var heroGenreHovering = UiInteract.Hover(new Vector2(textX, heroGenreY),
             new Vector2(textX + heroTextMaxWidth, heroGenreY + heroGenreSize.Y));
         Marquee.DrawLeft("games.hero.genre." + game.Id, game.Genre, textX, heroGenreY, heroTextMaxWidth,
             TextStyles.Footnote, ink with { W = 0.72f }, heroGenreHovering);

--- a/src/Aetherphone/Apps/Games/GemSwap/GemSwapApp.cs
+++ b/src/Aetherphone/Apps/Games/GemSwap/GemSwapApp.cs
@@ -273,7 +273,7 @@ internal sealed class GemSwapApp : IMiniGame
     private void HandleInput(GameGrid grid, float deltaSeconds)
     {
         var mouse = ImGui.GetMousePos();
-        if (!grid.Bounds.Contains(mouse) || !ImGui.IsMouseClicked(ImGuiMouseButton.Left))
+        if (!UiInteract.Hover(grid.Bounds.Min, grid.Bounds.Max) || !ImGui.IsMouseClicked(ImGuiMouseButton.Left))
         {
             UpdateHoverCursor(grid, mouse);
             return;
@@ -288,7 +288,8 @@ internal sealed class GemSwapApp : IMiniGame
         }
 
         var index = row * GemSwapBoard.Columns + column;
-        if (!grid.Cell(column, row).Contains(mouse))
+        var cell = grid.Cell(column, row);
+        if (!UiInteract.Hover(cell.Min, cell.Max))
         {
             return;
         }
@@ -323,7 +324,7 @@ internal sealed class GemSwapApp : IMiniGame
 
     private void UpdateHoverCursor(GameGrid grid, Vector2 mouse)
     {
-        if (grid.Bounds.Contains(mouse))
+        if (UiInteract.Hover(grid.Bounds.Min, grid.Bounds.Max))
         {
             ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
         }

--- a/src/Aetherphone/Apps/Games/Nonogram/NonogramApp.cs
+++ b/src/Aetherphone/Apps/Games/Nonogram/NonogramApp.cs
@@ -102,7 +102,7 @@ internal sealed class NonogramApp : IMiniGame
         var area = new Rect(new Vector2(body.Min.X + 6f * scale, body.Min.Y + 96f * scale),
             new Vector2(body.Max.X - 6f * scale, body.Max.Y - 8f * scale));
         var layout = NonogramRenderer.Layout(area, board, scale);
-        var hoveredCell = ResolveHover(layout);
+        var hoveredCell = ResolveHover(layout, area);
         if (!board.Solved)
         {
             HandleInput(hoveredCell);
@@ -150,10 +150,14 @@ internal sealed class NonogramApp : IMiniGame
             GameNumber.Label(board.FilledRemaining()), Accent, theme);
     }
 
-    private int ResolveHover(NonogramLayout layout)
+    private int ResolveHover(NonogramLayout layout, Rect area)
     {
-        var mouse = ImGui.GetMousePos();
-        var index = layout.HitTest(mouse, board.Size);
+        if (!UiInteract.Hover(area.Min, area.Max))
+        {
+            return -1;
+        }
+
+        var index = layout.HitTest(ImGui.GetMousePos(), board.Size);
         if (index >= 0)
         {
             ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);

--- a/src/Aetherphone/Apps/Games/Pairs/PairsApp.cs
+++ b/src/Aetherphone/Apps/Games/Pairs/PairsApp.cs
@@ -1,3 +1,4 @@
+using Aetherphone.Windows.Components;
 using Aetherphone.Apps.Games.Framework;
 using Aetherphone.Core;
 using Aetherphone.Core.Apps;
@@ -175,7 +176,7 @@ internal sealed class PairsApp : IMiniGame
                 var half = fullCell.Size * 0.5f * pop;
                 var cell = new Rect(fullCell.Center - half, fullCell.Center + half);
                 var hovered = phase == Phase.Selecting && board.CanReveal(index) && flipProgress[index] < 0.02f &&
-                              ImGui.IsMouseHoveringRect(cell.Min, cell.Max);
+                              UiInteract.Hover(cell.Min, cell.Max);
                 var shakeX = shakePhase[index] > 0f
                     ? MathF.Sin(shakePhase[index] * MathF.PI * 8f) * 5f * scale * shakePhase[index]
                     : 0f;

--- a/src/Aetherphone/Apps/Games/Pairs/PairsApp.cs
+++ b/src/Aetherphone/Apps/Games/Pairs/PairsApp.cs
@@ -1,10 +1,10 @@
-using Aetherphone.Windows.Components;
 using Aetherphone.Apps.Games.Framework;
 using Aetherphone.Core;
 using Aetherphone.Core.Apps;
 using Aetherphone.Core.Games;
 using Aetherphone.Core.Localization;
 using Aetherphone.Core.Theme;
+using Aetherphone.Windows.Components;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Utility;
 

--- a/src/Aetherphone/Apps/Games/Reversi/ReversiApp.cs
+++ b/src/Aetherphone/Apps/Games/Reversi/ReversiApp.cs
@@ -1,3 +1,4 @@
+using Aetherphone.Windows.Components;
 using Aetherphone.Apps.Games.Framework;
 using Aetherphone.Core;
 using Aetherphone.Core.Apps;
@@ -266,13 +267,12 @@ internal sealed class ReversiApp : IMiniGame
 
     private int HitTest(GameGrid grid)
     {
-        var mouse = ImGui.GetMousePos();
-        if (!grid.Bounds.Contains(mouse))
+        if (!UiInteract.Hover(grid.Bounds.Min, grid.Bounds.Max))
         {
             return -1;
         }
 
-        var local = mouse - grid.Origin;
+        var local = ImGui.GetMousePos() - grid.Origin;
         var column = (int)(local.X / grid.Pitch);
         var row = (int)(local.Y / grid.Pitch);
         if (column < 0 || column >= ReversiBoard.Size || row < 0 || row >= ReversiBoard.Size)

--- a/src/Aetherphone/Apps/Games/Reversi/ReversiApp.cs
+++ b/src/Aetherphone/Apps/Games/Reversi/ReversiApp.cs
@@ -1,9 +1,9 @@
-using Aetherphone.Windows.Components;
 using Aetherphone.Apps.Games.Framework;
 using Aetherphone.Core;
 using Aetherphone.Core.Apps;
 using Aetherphone.Core.Localization;
 using Aetherphone.Core.Theme;
+using Aetherphone.Windows.Components;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Utility;
 

--- a/src/Aetherphone/Apps/Games/Simon/SimonApp.cs
+++ b/src/Aetherphone/Apps/Games/Simon/SimonApp.cs
@@ -1,3 +1,4 @@
+using Aetherphone.Windows.Components;
 using Aetherphone.Apps.Games.Framework;
 using Aetherphone.Core;
 using Aetherphone.Core.Apps;
@@ -259,15 +260,15 @@ internal sealed class SimonApp : IMiniGame
 
     private int PadHitTest(GameGrid grid)
     {
-        var mouse = ImGui.GetMousePos();
-        if (!grid.Bounds.Contains(mouse))
+        if (!UiInteract.Hover(grid.Bounds.Min, grid.Bounds.Max))
         {
             return -1;
         }
 
         for (var pad = 0; pad < SimonBoard.PadCount; pad++)
         {
-            if (SimonRenderer.PadRect(grid, pad).Contains(mouse))
+            var padRect = SimonRenderer.PadRect(grid, pad);
+            if (UiInteract.Hover(padRect.Min, padRect.Max))
             {
                 return pad;
             }

--- a/src/Aetherphone/Apps/Games/Simon/SimonApp.cs
+++ b/src/Aetherphone/Apps/Games/Simon/SimonApp.cs
@@ -1,9 +1,9 @@
-using Aetherphone.Windows.Components;
 using Aetherphone.Apps.Games.Framework;
 using Aetherphone.Core;
 using Aetherphone.Core.Apps;
 using Aetherphone.Core.Localization;
 using Aetherphone.Core.Theme;
+using Aetherphone.Windows.Components;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Utility;
 

--- a/src/Aetherphone/Apps/Games/Snake/SnakeApp.cs
+++ b/src/Aetherphone/Apps/Games/Snake/SnakeApp.cs
@@ -95,7 +95,8 @@ internal sealed class SnakeApp : IMiniGame
         particles.Update(deltaSeconds);
         fx.Update(deltaSeconds);
         eatPulse = MathF.Max(0f, eatPulse - deltaSeconds * 3.4f);
-        if (board.State == SnakeState.Ready && ImGui.IsMouseClicked(ImGuiMouseButton.Left))
+        if (board.State == SnakeState.Ready && ImGui.IsMouseClicked(ImGuiMouseButton.Left) &&
+            UiInteract.Hover(area.Min, area.Max))
         {
             board.Begin(mouse);
         }

--- a/src/Aetherphone/Apps/Games/Solitaire/SolitaireApp.cs
+++ b/src/Aetherphone/Apps/Games/Solitaire/SolitaireApp.cs
@@ -1,3 +1,4 @@
+using Aetherphone.Windows.Components;
 using Aetherphone.Apps.Games.Framework;
 using Aetherphone.Core;
 using Aetherphone.Core.Apps;
@@ -97,7 +98,7 @@ internal sealed class SolitaireApp : IMiniGame
         var dropTarget = SolitaireHit.None;
         if (!finished)
         {
-            dropTarget = HandleInput(layout, scale);
+            dropTarget = HandleInput(layout, area, scale);
         }
 
         renderer.Draw(board, layout, theme, Accent, scale, grabSource, dropTarget);
@@ -136,10 +137,10 @@ internal sealed class SolitaireApp : IMiniGame
         }
     }
 
-    private SolitaireHit HandleInput(in SolitaireLayout layout, float scale)
+    private SolitaireHit HandleInput(in SolitaireLayout layout, Rect area, float scale)
     {
         var mouse = ImGui.GetMousePos();
-        if (grabCount == 0 && ImGui.IsMouseClicked(ImGuiMouseButton.Left))
+        if (grabCount == 0 && ImGui.IsMouseClicked(ImGuiMouseButton.Left) && UiInteract.Hover(area.Min, area.Max))
         {
             var hit = layout.Hit(mouse);
             if (hit.Kind == SolitairePileKind.Stock)

--- a/src/Aetherphone/Apps/Games/Solitaire/SolitaireApp.cs
+++ b/src/Aetherphone/Apps/Games/Solitaire/SolitaireApp.cs
@@ -1,9 +1,9 @@
-using Aetherphone.Windows.Components;
 using Aetherphone.Apps.Games.Framework;
 using Aetherphone.Core;
 using Aetherphone.Core.Apps;
 using Aetherphone.Core.Localization;
 using Aetherphone.Core.Theme;
+using Aetherphone.Windows.Components;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Utility;
 

--- a/src/Aetherphone/Apps/Games/Stack/StackApp.cs
+++ b/src/Aetherphone/Apps/Games/Stack/StackApp.cs
@@ -130,7 +130,8 @@ internal sealed class StackApp : IMiniGame
             return;
         }
 
-        if (board.State == StackState.Over || !ImGui.IsMouseClicked(ImGuiMouseButton.Left))
+        if (board.State == StackState.Over || !ImGui.IsMouseClicked(ImGuiMouseButton.Left) ||
+            !UiInteract.Hover(area.Min, area.Max))
         {
             return;
         }

--- a/src/Aetherphone/Apps/Games/Sudoku/SudokuApp.cs
+++ b/src/Aetherphone/Apps/Games/Sudoku/SudokuApp.cs
@@ -176,13 +176,12 @@ internal sealed class SudokuApp : IMiniGame
 
     private int ResolveHover()
     {
-        var mouse = ImGui.GetMousePos();
-        if (!layout.Bounds.Contains(mouse))
+        if (!UiInteract.Hover(layout.Bounds.Min, layout.Bounds.Max))
         {
             return -1;
         }
 
-        var cell = layout.HitTest(mouse);
+        var cell = layout.HitTest(ImGui.GetMousePos());
         if (cell >= 0)
         {
             ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);

--- a/src/Aetherphone/Apps/Games/Sweeper/SweeperApp.cs
+++ b/src/Aetherphone/Apps/Games/Sweeper/SweeperApp.cs
@@ -141,12 +141,12 @@ internal sealed class SweeperApp : IMiniGame
 
     private int ResolveHover(GameGrid grid)
     {
-        var mouse = ImGui.GetMousePos();
-        if (!grid.Bounds.Contains(mouse))
+        if (!UiInteract.Hover(grid.Bounds.Min, grid.Bounds.Max))
         {
             return -1;
         }
 
+        var mouse = ImGui.GetMousePos();
         var local = mouse - grid.Origin;
         var column = (int)(local.X / grid.Pitch);
         var row = (int)(local.Y / grid.Pitch);
@@ -157,7 +157,7 @@ internal sealed class SweeperApp : IMiniGame
 
         var index = row * board.Columns + column;
         var cell = grid.Cell(column, row);
-        return cell.Contains(mouse) ? index : -1;
+        return UiInteract.Hover(cell.Min, cell.Max) ? index : -1;
     }
 
     private void HandleInput(int hoveredIndex, GameGrid grid)

--- a/src/Aetherphone/Apps/Games/Tetris/TetrisApp.cs
+++ b/src/Aetherphone/Apps/Games/Tetris/TetrisApp.cs
@@ -1,3 +1,4 @@
+using Aetherphone.Windows.Components;
 using Aetherphone.Apps.Games.Framework;
 using Aetherphone.Core;
 using Aetherphone.Core.Apps;
@@ -111,7 +112,7 @@ internal sealed class TetrisApp : IMiniGame
             new Vector2(body.Min.X + 12f * scale + slotSize, slotTop + slotSize));
         var nextRect = new Rect(new Vector2(body.Max.X - 12f * scale - slotSize, slotTop),
             new Vector2(body.Max.X - 12f * scale, slotTop + slotSize));
-        var holdHovered = ImGui.IsMouseHoveringRect(holdRect.Min, holdRect.Max);
+        var holdHovered = UiInteract.Hover(holdRect.Min, holdRect.Max);
         renderer.DrawHoldSlot(board, holdRect, theme, Accent, holdHovered, scale);
         if (holdHovered)
         {

--- a/src/Aetherphone/Apps/Games/Tetris/TetrisApp.cs
+++ b/src/Aetherphone/Apps/Games/Tetris/TetrisApp.cs
@@ -1,9 +1,9 @@
-using Aetherphone.Windows.Components;
 using Aetherphone.Apps.Games.Framework;
 using Aetherphone.Core;
 using Aetherphone.Core.Apps;
 using Aetherphone.Core.Localization;
 using Aetherphone.Core.Theme;
+using Aetherphone.Windows.Components;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Utility;
 

--- a/src/Aetherphone/Apps/Games/Trivia/TriviaApp.cs
+++ b/src/Aetherphone/Apps/Games/Trivia/TriviaApp.cs
@@ -142,11 +142,11 @@ internal sealed class TriviaApp : IMiniGame
             return -1;
         }
 
-        var mouse = ImGui.GetMousePos();
         var hovered = -1;
         for (var index = 0; index < TriviaBoard.Options; index++)
         {
-            if (!TriviaRenderer.OptionRect(area, index, scale).Contains(mouse))
+            var optionRect = TriviaRenderer.OptionRect(area, index, scale);
+            if (!UiInteract.Hover(optionRect.Min, optionRect.Max))
             {
                 continue;
             }
@@ -174,7 +174,6 @@ internal sealed class TriviaApp : IMiniGame
 
     private int HandlePicker(Rect area, float scale)
     {
-        var mouse = ImGui.GetMousePos();
         var hovered = -1;
         for (var index = 0; index < TriviaBoard.PickableCount; index++)
         {
@@ -183,7 +182,8 @@ internal sealed class TriviaApp : IMiniGame
                 continue;
             }
 
-            if (!TriviaRenderer.CategoryRect(area, index, scale).Contains(mouse))
+            var categoryRect = TriviaRenderer.CategoryRect(area, index, scale);
+            if (!UiInteract.Hover(categoryRect.Min, categoryRect.Max))
             {
                 continue;
             }

--- a/src/Aetherphone/Apps/Games/Twenty48/Twenty48App.cs
+++ b/src/Aetherphone/Apps/Games/Twenty48/Twenty48App.cs
@@ -1,3 +1,4 @@
+using Aetherphone.Windows.Components;
 using Aetherphone.Apps.Games.Framework;
 using Aetherphone.Core;
 using Aetherphone.Core.Apps;
@@ -240,9 +241,9 @@ internal sealed class Twenty48App : IMiniGame
 
     private void HandleSwipe(GameGrid grid)
     {
-        var mouse = ImGui.GetMousePos();
         var bounds = grid.Bounds;
-        if (ImGui.IsMouseDown(ImGuiMouseButton.Left) && bounds.Contains(mouse) && !swipeActive)
+        var mouse = ImGui.GetMousePos();
+        if (ImGui.IsMouseDown(ImGuiMouseButton.Left) && UiInteract.Hover(bounds.Min, bounds.Max) && !swipeActive)
         {
             swipeActive = true;
             swipeStart = mouse;

--- a/src/Aetherphone/Apps/Games/Twenty48/Twenty48App.cs
+++ b/src/Aetherphone/Apps/Games/Twenty48/Twenty48App.cs
@@ -1,9 +1,9 @@
-using Aetherphone.Windows.Components;
 using Aetherphone.Apps.Games.Framework;
 using Aetherphone.Core;
 using Aetherphone.Core.Apps;
 using Aetherphone.Core.Localization;
 using Aetherphone.Core.Theme;
+using Aetherphone.Windows.Components;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Utility;
 

--- a/src/Aetherphone/Apps/Games/WaterSort/WaterSortApp.cs
+++ b/src/Aetherphone/Apps/Games/WaterSort/WaterSortApp.cs
@@ -1,3 +1,4 @@
+using Aetherphone.Windows.Components;
 using Aetherphone.Apps.Games.Framework;
 using Aetherphone.Core;
 using Aetherphone.Core.Apps;
@@ -137,11 +138,11 @@ internal sealed class WaterSortApp : IMiniGame
 
     private void HandleClick(Rect area, float scale)
     {
-        var mouse = ImGui.GetMousePos();
         var hoveredTube = -1;
         for (var tube = 0; tube < board.TubeCount; tube++)
         {
-            if (WaterSortRenderer.TubeRect(area, tube, board.TubeCount, scale).Contains(mouse))
+            var tubeRect = WaterSortRenderer.TubeRect(area, tube, board.TubeCount, scale);
+            if (UiInteract.Hover(tubeRect.Min, tubeRect.Max))
             {
                 hoveredTube = tube;
                 break;

--- a/src/Aetherphone/Apps/Games/WaterSort/WaterSortApp.cs
+++ b/src/Aetherphone/Apps/Games/WaterSort/WaterSortApp.cs
@@ -1,10 +1,10 @@
-using Aetherphone.Windows.Components;
 using Aetherphone.Apps.Games.Framework;
 using Aetherphone.Core;
-using Aetherphone.Core.Apps;
 using Aetherphone.Core.Animation;
+using Aetherphone.Core.Apps;
 using Aetherphone.Core.Localization;
 using Aetherphone.Core.Theme;
+using Aetherphone.Windows.Components;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Utility;
 

--- a/src/Aetherphone/Apps/Games/Whack/WhackApp.cs
+++ b/src/Aetherphone/Apps/Games/Whack/WhackApp.cs
@@ -1,3 +1,4 @@
+using Aetherphone.Windows.Components;
 using Aetherphone.Apps.Games.Framework;
 using Aetherphone.Core.Animation;
 using Aetherphone.Core;
@@ -181,13 +182,12 @@ internal sealed class WhackApp : IMiniGame
 
     private int HoleHit(GameGrid grid)
     {
-        var mouse = ImGui.GetMousePos();
-        if (!grid.Bounds.Contains(mouse))
+        if (!UiInteract.Hover(grid.Bounds.Min, grid.Bounds.Max))
         {
             return -1;
         }
 
-        var local = mouse - grid.Origin;
+        var local = ImGui.GetMousePos() - grid.Origin;
         var column = (int)(local.X / grid.Pitch);
         var row = (int)(local.Y / grid.Pitch);
         if (column < 0 || column >= WhackBoard.Columns || row < 0 || row >= WhackBoard.Rows)

--- a/src/Aetherphone/Apps/Games/Whack/WhackApp.cs
+++ b/src/Aetherphone/Apps/Games/Whack/WhackApp.cs
@@ -1,10 +1,10 @@
-using Aetherphone.Windows.Components;
 using Aetherphone.Apps.Games.Framework;
-using Aetherphone.Core.Animation;
 using Aetherphone.Core;
+using Aetherphone.Core.Animation;
 using Aetherphone.Core.Apps;
 using Aetherphone.Core.Localization;
 using Aetherphone.Core.Theme;
+using Aetherphone.Windows.Components;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Utility;
 

--- a/src/Aetherphone/Apps/Inventory/InventoryApp.cs
+++ b/src/Aetherphone/Apps/Inventory/InventoryApp.cs
@@ -352,13 +352,13 @@ internal sealed class InventoryApp : IPhoneApp
         {
             var titleY = row.Min.Y + 15f * scale;
             var titleSize = Typography.Measure(title, TextStyles.Headline);
-            var titleHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, titleY),
+            var titleHovering = UiInteract.Hover(new Vector2(textLeft, titleY),
                 new Vector2(textLeft + textMaxWidth, titleY + titleSize.Y));
             Marquee.DrawLeft("inventory.storage.title." + kind, title, textLeft, titleY,
                 textMaxWidth, TextStyles.Headline, ui.TitleInk, titleHovering);
             var subtitleY = row.Min.Y + 38f * scale;
             var subtitleSize = Typography.Measure(subtitle, TextStyles.Footnote);
-            var subtitleHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, subtitleY),
+            var subtitleHovering = UiInteract.Hover(new Vector2(textLeft, subtitleY),
                 new Vector2(textLeft + textMaxWidth, subtitleY + subtitleSize.Y));
             Marquee.DrawLeft("inventory.storage.subtitle." + kind, subtitle, textLeft, subtitleY,
                 textMaxWidth, TextStyles.Footnote, ui.MutedInk, subtitleHovering);
@@ -430,7 +430,7 @@ internal sealed class InventoryApp : IPhoneApp
         var valueMaxWidth = columnWidth - 20f * scale;
         var valueY = columnTop.Y + 68f * scale;
         var valueSize = Typography.Measure(value, TextStyles.Title2);
-        var valueHovering = ImGui.IsMouseHoveringRect(
+        var valueHovering = UiInteract.Hover(
             new Vector2(columnTop.X - valueMaxWidth * 0.5f, valueY - valueSize.Y * 0.5f),
             new Vector2(columnTop.X + valueMaxWidth * 0.5f, valueY + valueSize.Y * 0.5f));
         Marquee.DrawCentered("inventory.herostat." + label, value, columnTop.X, valueY - valueSize.Y * 0.5f,

--- a/src/Aetherphone/Apps/Jobs/JobsApp.Categories.cs
+++ b/src/Aetherphone/Apps/Jobs/JobsApp.Categories.cs
@@ -312,7 +312,7 @@ internal sealed partial class JobsApp
     private void DrawCategorySaveButton(ImDrawListPtr drawList, Rect rect, PhoneTheme theme, float scale)
     {
         var enabled = categoryEditorName.Trim().Length > 0;
-        var hovered = enabled && UiInteract.Hover(rect.Min, rect.Max);
+        var hovered = enabled && UiInteract.HoverWindowOnly(rect.Min, rect.Max);
         var fill = !enabled
             ? Palette.WithAlpha(theme.TextMuted, 0.2f)
             : hovered

--- a/src/Aetherphone/Apps/Jobs/JobsApp.Categories.cs
+++ b/src/Aetherphone/Apps/Jobs/JobsApp.Categories.cs
@@ -312,7 +312,7 @@ internal sealed partial class JobsApp
     private void DrawCategorySaveButton(ImDrawListPtr drawList, Rect rect, PhoneTheme theme, float scale)
     {
         var enabled = categoryEditorName.Trim().Length > 0;
-        var hovered = enabled && ImGui.IsMouseHoveringRect(rect.Min, rect.Max);
+        var hovered = enabled && UiInteract.Hover(rect.Min, rect.Max);
         var fill = !enabled
             ? Palette.WithAlpha(theme.TextMuted, 0.2f)
             : hovered

--- a/src/Aetherphone/Apps/Jobs/JobsApp.ColorPicker.cs
+++ b/src/Aetherphone/Apps/Jobs/JobsApp.ColorPicker.cs
@@ -243,7 +243,7 @@ internal sealed partial class JobsApp
         {
             var center = new Vector2(area.Min.X + cellWidth * (index % PresetColumns + 0.5f),
                 area.Min.Y + rowHeight * (index / PresetColumns + 0.5f));
-            var hovered = ImGui.IsMouseHoveringRect(center - new Vector2(radius), center + new Vector2(radius));
+            var hovered = UiInteract.Hover(center - new Vector2(radius), center + new Vector2(radius));
             var selected = string.Equals(Presets[index].Digits, pickerDigits, StringComparison.Ordinal);
             drawList.AddCircleFilled(center, hovered ? radius + scale : radius,
                 ImGui.GetColorU32(Presets[index].Color), 32);
@@ -272,7 +272,7 @@ internal sealed partial class JobsApp
         float scale)
     {
         var editing = pickerSavedIndex >= 0 && pickerSavedIndex < configuration.JobsCustomColors.Count;
-        var hovered = enabled && ImGui.IsMouseHoveringRect(rect.Min, rect.Max);
+        var hovered = enabled && UiInteract.Hover(rect.Min, rect.Max);
         var fill = !enabled
             ? Palette.WithAlpha(theme.TextMuted, 0.2f)
             : hovered

--- a/src/Aetherphone/Apps/Jobs/JobsApp.ColorPicker.cs
+++ b/src/Aetherphone/Apps/Jobs/JobsApp.ColorPicker.cs
@@ -243,7 +243,7 @@ internal sealed partial class JobsApp
         {
             var center = new Vector2(area.Min.X + cellWidth * (index % PresetColumns + 0.5f),
                 area.Min.Y + rowHeight * (index / PresetColumns + 0.5f));
-            var hovered = UiInteract.Hover(center - new Vector2(radius), center + new Vector2(radius));
+            var hovered = UiInteract.HoverWindowOnly(center - new Vector2(radius), center + new Vector2(radius));
             var selected = string.Equals(Presets[index].Digits, pickerDigits, StringComparison.Ordinal);
             drawList.AddCircleFilled(center, hovered ? radius + scale : radius,
                 ImGui.GetColorU32(Presets[index].Color), 32);
@@ -272,7 +272,7 @@ internal sealed partial class JobsApp
         float scale)
     {
         var editing = pickerSavedIndex >= 0 && pickerSavedIndex < configuration.JobsCustomColors.Count;
-        var hovered = enabled && UiInteract.Hover(rect.Min, rect.Max);
+        var hovered = enabled && UiInteract.HoverWindowOnly(rect.Min, rect.Max);
         var fill = !enabled
             ? Palette.WithAlpha(theme.TextMuted, 0.2f)
             : hovered

--- a/src/Aetherphone/Apps/Linkpearl/LinkpearlApp.Chats.cs
+++ b/src/Aetherphone/Apps/Linkpearl/LinkpearlApp.Chats.cs
@@ -160,7 +160,7 @@ internal sealed partial class LinkpearlApp
         var min = center - new Vector2(radius, radius);
         var max = center + new Vector2(radius, radius);
         var paused = notificationGate.Paused;
-        var hovered = ImGui.IsMouseHoveringRect(min, max);
+        var hovered = UiInteract.Hover(min, max);
         var color = paused ? context.Theme.Accent : hovered ? context.Theme.TextStrong : context.Theme.TextMuted;
         ProgressRing.CenterIcon(ImGui.GetWindowDrawList(), center,
             paused ? FontAwesomeIcon.BellSlash : FontAwesomeIcon.Bell, color, 15f * scale);
@@ -220,7 +220,7 @@ internal sealed partial class LinkpearlApp
         var radius = 16f * scale;
         var min = center - new Vector2(radius, radius);
         var max = center + new Vector2(radius, radius);
-        var hovered = ImGui.IsMouseHoveringRect(min, max);
+        var hovered = UiInteract.Hover(min, max);
         ProgressRing.CenterIcon(ImGui.GetWindowDrawList(), center, FontAwesomeIcon.TrashAlt,
             hovered ? frameTheme.Danger : frameTheme.TextMuted, 15f * scale);
         if (hovered)
@@ -295,7 +295,7 @@ internal sealed partial class LinkpearlApp
         var min = center - new Vector2(radius, radius);
         var max = center + new Vector2(radius, radius);
         var muted = mutes.IsMuted(channel);
-        var hovered = ImGui.IsMouseHoveringRect(min, max);
+        var hovered = UiInteract.Hover(min, max);
         var color = muted ? frameTheme.Accent : hovered ? frameTheme.TextStrong : frameTheme.TextMuted;
         ProgressRing.CenterIcon(ImGui.GetWindowDrawList(), center,
             muted ? FontAwesomeIcon.BellSlash : FontAwesomeIcon.Bell, color, 15f * scale);
@@ -397,7 +397,7 @@ internal sealed partial class LinkpearlApp
         ProgressRing.CenterIcon(sendCenter, FontAwesomeIcon.ArrowUp, new Vector4(1f, 1f, 1f, 1f), sendDiameter * 0.46f);
         var sendMin = sendCenter - new Vector2(sendDiameter * 0.5f, sendDiameter * 0.5f);
         var sendMax = sendCenter + new Vector2(sendDiameter * 0.5f, sendDiameter * 0.5f);
-        if (hasText && ImGui.IsMouseHoveringRect(sendMin, sendMax))
+        if (hasText && UiInteract.Hover(sendMin, sendMax))
         {
             ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
             if (ImGui.IsMouseClicked(ImGuiMouseButton.Left))

--- a/src/Aetherphone/Apps/Linkpearl/LinkpearlApp.Contacts.cs
+++ b/src/Aetherphone/Apps/Linkpearl/LinkpearlApp.Contacts.cs
@@ -264,7 +264,7 @@ internal sealed partial class LinkpearlApp
         var center = new Vector2(content.Max.X - 14f * scale, content.Min.Y + AppHeader.Height * scale * 0.5f);
         UiAnchors.Report("contacts.refresh", new Rect(center - new Vector2(16f * scale, 16f * scale),
             center + new Vector2(16f * scale, 16f * scale)));
-        var hovered = ImGui.IsMouseHoveringRect(center - new Vector2(16f * scale, 16f * scale),
+        var hovered = UiInteract.Hover(center - new Vector2(16f * scale, 16f * scale),
             center + new Vector2(16f * scale, 16f * scale));
         var glyph = FontAwesomeIcon.Sync.ToIconString();
         using (ImRaii.PushFont(UiBuilder.IconFont))

--- a/src/Aetherphone/Apps/Linkpearl/LinkpearlApp.Find.cs
+++ b/src/Aetherphone/Apps/Linkpearl/LinkpearlApp.Find.cs
@@ -184,7 +184,7 @@ internal sealed partial class LinkpearlApp
     private static bool DrawResultRow(Rect row, PhoneTheme theme, float scale, string title, string subtitle,
         AvatarHandle image)
     {
-        var hovered = ImGui.IsMouseHoveringRect(row.Min, row.Max);
+        var hovered = UiInteract.Hover(row.Min, row.Max);
         var drawList = ImGui.GetWindowDrawList();
         var avatarRadius = 20f * scale;
         var avatarCenter = new Vector2(row.Min.X + avatarRadius, row.Center.Y);
@@ -194,7 +194,7 @@ internal sealed partial class LinkpearlApp
         var textMaxWidth = MathF.Max(1f, textRight - textX);
         var titleY = row.Center.Y - 16f * scale;
         var titleSize = Typography.Measure(title, 0.95f, FontWeight.Medium);
-        var titleHovering = ImGui.IsMouseHoveringRect(new Vector2(textX, titleY),
+        var titleHovering = UiInteract.Hover(new Vector2(textX, titleY),
             new Vector2(textX + textMaxWidth, titleY + titleSize.Y));
         Marquee.DrawLeft("linkpearl.result." + title + "." + subtitle, title, textX, titleY,
             textMaxWidth, new TextStyle(0.95f, FontWeight.Medium), theme.TextStrong, titleHovering);
@@ -202,7 +202,7 @@ internal sealed partial class LinkpearlApp
         {
             var subtitleY = row.Center.Y + 3f * scale;
             var subtitleSize = Typography.Measure(subtitle, 0.8f, FontWeight.Regular);
-            var subtitleHovering = ImGui.IsMouseHoveringRect(new Vector2(textX, subtitleY),
+            var subtitleHovering = UiInteract.Hover(new Vector2(textX, subtitleY),
                 new Vector2(textX + textMaxWidth, subtitleY + subtitleSize.Y));
             Marquee.DrawLeft("linkpearl.result.sub." + title + "." + subtitle, subtitle, textX,
                 subtitleY, textMaxWidth, new TextStyle(0.8f, FontWeight.Regular), theme.TextMuted,
@@ -475,7 +475,7 @@ internal sealed partial class LinkpearlApp
     {
         var style = new TextStyle(0.86f, FontWeight.Regular);
         var maxWidth = MathF.Max(1f, row.Width);
-        var hovering = ImGui.IsMouseHoveringRect(row.Min, row.Max);
+        var hovering = UiInteract.Hover(row.Min, row.Max);
         Marquee.DrawLeft("linkpearl.slogan." + slogan, slogan, row.Min.X, row.Center.Y - Typography.Measure(slogan, style).Y * 0.5f,
             maxWidth, style, theme.TextMuted, hovering);
     }
@@ -547,7 +547,7 @@ internal sealed partial class LinkpearlApp
         var box = 16f * scale;
         var min = center - new Vector2(box, box);
         var max = center + new Vector2(box, box);
-        var hovered = enabled && ImGui.IsMouseHoveringRect(min, max);
+        var hovered = enabled && UiInteract.Hover(min, max);
         var color = enabled ? (hovered ? theme.TextStrong : theme.Accent) : Palette.WithAlpha(theme.TextMuted, 0.35f);
         ProgressRing.CenterIcon(center, icon, color, 16f * scale);
         if (!enabled)

--- a/src/Aetherphone/Apps/Maps/MapsApp.cs
+++ b/src/Aetherphone/Apps/Maps/MapsApp.cs
@@ -122,13 +122,13 @@ internal sealed class MapsApp : IPhoneApp
         var textMaxWidth = MathF.Max(1f, cardMax.X - 14f * scale - textLeft);
         var zoneY = cardMin.Y + 14f * scale;
         var zoneSize = Typography.Measure(zoneName, TextStyles.Headline);
-        var zoneHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, zoneY),
+        var zoneHovering = UiInteract.Hover(new Vector2(textLeft, zoneY),
             new Vector2(textLeft + textMaxWidth, zoneY + zoneSize.Y));
         Marquee.DrawLeft("maps.location.zone", zoneName, textLeft, zoneY, textMaxWidth,
             TextStyles.Headline, frameTheme.TextStrong, zoneHovering);
         var regionY = cardMin.Y + 36f * scale;
         var regionSize = Typography.Measure(regionName, TextStyles.Footnote);
-        var regionHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, regionY),
+        var regionHovering = UiInteract.Hover(new Vector2(textLeft, regionY),
             new Vector2(textLeft + textMaxWidth, regionY + regionSize.Y));
         Marquee.DrawLeft("maps.location.region", regionName, textLeft, regionY, textMaxWidth,
             TextStyles.Footnote, frameTheme.TextMuted, regionHovering);
@@ -266,7 +266,7 @@ internal sealed class MapsApp : IPhoneApp
         var height = ExpansionHeaderHeight * scale;
         var min = origin;
         var max = new Vector2(origin.X + width, origin.Y + height);
-        var hovered = ImGui.IsMouseHoveringRect(min, max);
+        var hovered = UiInteract.Hover(min, max);
         var drawList = ImGui.GetWindowDrawList();
         if (hovered)
         {
@@ -315,7 +315,7 @@ internal sealed class MapsApp : IPhoneApp
         var textRight = row.Max.X - 14f * scale;
         var textMaxWidth = MathF.Max(1f, textRight - textLeft);
         var labelSize = Typography.Measure(aetheryte.Name, TextStyles.Body);
-        var textHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, row.Min.Y), new Vector2(textRight, row.Max.Y));
+        var textHovering = UiInteract.Hover(new Vector2(textLeft, row.Min.Y), new Vector2(textRight, row.Max.Y));
         Marquee.DrawLeft("maps.destination." + aetheryte.RowId, aetheryte.Name, textLeft,
             row.Center.Y - labelSize.Y * 0.5f, textMaxWidth, TextStyles.Body, frameTheme.TextStrong, textHovering);
         var arrowTip = new Vector2(row.Max.X, row.Center.Y);

--- a/src/Aetherphone/Apps/Market/MarketApp.Detail.cs
+++ b/src/Aetherphone/Apps/Market/MarketApp.Detail.cs
@@ -271,7 +271,7 @@ internal sealed partial class MarketApp
         var height = 42f * scale;
         var min = origin;
         var max = new Vector2(origin.X + width, origin.Y + height);
-        var hovered = ImGui.IsMouseHoveringRect(min, max);
+        var hovered = UiInteract.Hover(min, max);
         var pressed = hovered && ImGui.IsMouseDown(ImGuiMouseButton.Left);
         var fill = pressed ? Palette.Mix(frameTheme.Accent, new Vector4(0f, 0f, 0f, 1f), 0.14f) :
             hovered ? Palette.Mix(frameTheme.Accent, frameTheme.TextStrong, 0.10f) : frameTheme.Accent;
@@ -413,7 +413,7 @@ internal sealed partial class MarketApp
     {
         var scale = ImGuiHelpers.GlobalScale;
         var box = 14f * scale;
-        var hovered = ImGui.IsMouseHoveringRect(center - new Vector2(box, box), center + new Vector2(box, box));
+        var hovered = UiInteract.Hover(center - new Vector2(box, box), center + new Vector2(box, box));
         var glyph = icon.ToIconString();
         using (ImRaii.PushFont(UiBuilder.IconFont))
         {

--- a/src/Aetherphone/Apps/Message/MessageApp.Calls.cs
+++ b/src/Aetherphone/Apps/Message/MessageApp.Calls.cs
@@ -182,7 +182,7 @@ internal sealed partial class MessageApp
         var textWidth = actionLeft - textLeft;
         var titleTop = origin.Y + 13f * scale;
         var titleSize = Typography.Measure(title, TextStyles.Headline);
-        var titleHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, titleTop),
+        var titleHovering = UiInteract.Hover(new Vector2(textLeft, titleTop),
             new Vector2(textLeft + textWidth, titleTop + titleSize.Y));
         Marquee.DrawLeft("messageapp.calls.title." + entry.UserId + entry.TimestampUnix, title, textLeft, titleTop,
             textWidth, TextStyles.Headline, missed ? theme.Danger : ui.TitleInk, titleHovering);
@@ -507,7 +507,7 @@ internal sealed partial class MessageApp
         var scale = ImGuiHelpers.GlobalScale;
         var min = center - new Vector2(radius, radius);
         var max = center + new Vector2(radius, radius);
-        var hovered = enabled && ImGui.IsMouseHoveringRect(min, max);
+        var hovered = enabled && UiInteract.Hover(min, max);
         var baseFill = hovered ? Palette.Mix(fill, White, 0.14f) : fill;
         var fillAlpha = enabled ? MathF.Max(baseFill.W, 0.16f) : baseFill.W * 0.4f;
         drawList.AddCircleFilled(center, radius, ImGui.GetColorU32(Palette.WithAlpha(baseFill, fillAlpha)), 40);

--- a/src/Aetherphone/Apps/Message/MessageApp.Chats.cs
+++ b/src/Aetherphone/Apps/Message/MessageApp.Chats.cs
@@ -225,7 +225,7 @@ internal sealed partial class MessageApp
         var textWidth = markerRight - 8f * scale - textLeft;
         var titleTop = origin.Y + 12f * scale;
         var titleSize = Typography.Measure(title, 1f, FontWeight.SemiBold);
-        var titleHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, titleTop),
+        var titleHovering = UiInteract.Hover(new Vector2(textLeft, titleTop),
             new Vector2(textLeft + textWidth, titleTop + titleSize.Y));
         Marquee.DrawLeft("messageapp.chats.title." + item.Id, title, textLeft, titleTop, textWidth,
             new TextStyle(1f, FontWeight.SemiBold), theme.TextStrong, titleHovering);

--- a/src/Aetherphone/Apps/Message/MessageApp.Compose.cs
+++ b/src/Aetherphone/Apps/Message/MessageApp.Compose.cs
@@ -145,7 +145,7 @@ internal sealed partial class MessageApp
         var textLeft = avatarCenter.X + radius + 12f * scale;
         var labelWidth = origin.X + width - 44f * scale - textLeft;
         var labelY = origin.Y + rowHeight * 0.5f - 9f * scale;
-        var labelHover = ImGui.IsMouseHoveringRect(new Vector2(textLeft, labelY),
+        var labelHover = UiInteract.Hover(new Vector2(textLeft, labelY),
             new Vector2(origin.X + width - 44f * scale, labelY + Typography.Measure(label, 1f, FontWeight.SemiBold).Y));
         Marquee.DrawLeft("compose.pick." + contact.UserId, label, textLeft, labelY, labelWidth,
             new TextStyle(1f, FontWeight.SemiBold), theme.TextStrong, labelHover);

--- a/src/Aetherphone/Apps/Message/MessageApp.ContactDetail.cs
+++ b/src/Aetherphone/Apps/Message/MessageApp.ContactDetail.cs
@@ -268,7 +268,7 @@ internal sealed partial class MessageApp
         var labelSize = Typography.Measure(label, TextStyles.Footnote);
         Typography.Draw(new Vector2(left, centerY - 8f * scale), label, ui.MutedInk, TextStyles.Footnote);
         var valueMaxWidth = MathF.Max(1f, right - left - labelSize.X - 10f * scale);
-        var valueHovering = ImGui.IsMouseHoveringRect(new Vector2(right - valueMaxWidth, top),
+        var valueHovering = UiInteract.Hover(new Vector2(right - valueMaxWidth, top),
             new Vector2(right, top + rowHeight));
         Marquee.DrawRight(label + ":value", value, right, centerY - Typography.Measure(value, TextStyles.Subheadline).Y * 0.5f,
             valueMaxWidth, TextStyles.Subheadline, ui.BodyInk, valueHovering);

--- a/src/Aetherphone/Apps/Message/MessageApp.Contacts.cs
+++ b/src/Aetherphone/Apps/Message/MessageApp.Contacts.cs
@@ -250,7 +250,7 @@ internal sealed partial class MessageApp
         var nameTop = origin.Y + 12f * scale;
         var contactName = ContactBook.DisplayLabel(contact);
         var nameSize = Typography.Measure(contactName, 1f, FontWeight.SemiBold);
-        var nameHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, nameTop),
+        var nameHovering = UiInteract.Hover(new Vector2(textLeft, nameTop),
             new Vector2(textLeft + textWidth, nameTop + nameSize.Y));
         Marquee.DrawLeft("messageapp.contacts.name." + contact.UserId, contactName, textLeft, nameTop, textWidth,
             new TextStyle(1f, FontWeight.SemiBold), theme.TextStrong, nameHovering);

--- a/src/Aetherphone/Apps/Message/MessageApp.Encryption.cs
+++ b/src/Aetherphone/Apps/Message/MessageApp.Encryption.cs
@@ -296,7 +296,7 @@ internal sealed partial class MessageApp
             lodestone, 0.85f, 32);
         var textLeft = avatarCenter.X + radius + 12f * scale;
         var textMaxWidth = MathF.Max(1f, origin.X + width - pad - 28f * scale - textLeft);
-        var rowHovering = ImGui.IsMouseHoveringRect(origin, new Vector2(origin.X + width, origin.Y + rowHeight));
+        var rowHovering = UiInteract.Hover(origin, new Vector2(origin.X + width, origin.Y + rowHeight));
         Marquee.DrawLeft("messageapp.encryption.member." + member.UserId, label, textLeft, origin.Y + 10f * scale,
             textMaxWidth, new TextStyle(1f, FontWeight.SemiBold), theme.TextStrong, rowHovering);
         Typography.Draw(new Vector2(textLeft, origin.Y + 31f * scale),

--- a/src/Aetherphone/Apps/Message/MessageApp.Forward.cs
+++ b/src/Aetherphone/Apps/Message/MessageApp.Forward.cs
@@ -110,7 +110,7 @@ internal sealed partial class MessageApp
         var textMaxWidth = MathF.Max(1f, iconCenterX - 12f * scale - textLeft);
         var titleTop = origin.Y + rowHeight * 0.5f - 9f * scale;
         var titleSize = Typography.Measure(title, 1f, FontWeight.SemiBold);
-        var titleHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, titleTop),
+        var titleHovering = UiInteract.Hover(new Vector2(textLeft, titleTop),
             new Vector2(textLeft + textMaxWidth, titleTop + titleSize.Y));
         Marquee.DrawLeft("picker.row." + item.Id, title, textLeft, titleTop, textMaxWidth,
             new TextStyle(1f, FontWeight.SemiBold), theme.TextStrong, titleHovering);

--- a/src/Aetherphone/Apps/Message/MessageApp.GroupInfo.cs
+++ b/src/Aetherphone/Apps/Message/MessageApp.GroupInfo.cs
@@ -123,7 +123,7 @@ internal sealed partial class MessageApp
         var rightReserve = isOwner ? Typography.Measure(ownerLabel, TextStyles.Footnote).X + pad
             : canRemove ? 28f * scale : 0f;
         var labelMaxWidth = MathF.Max(1f, origin.X + width - pad - rightReserve - textLeft);
-        var rowHovering = ImGui.IsMouseHoveringRect(origin, new Vector2(origin.X + width, origin.Y + rowHeight));
+        var rowHovering = UiInteract.Hover(origin, new Vector2(origin.X + width, origin.Y + rowHeight));
         Marquee.DrawLeft("messageapp.groupinfo.member." + member.UserId, label, textLeft,
             origin.Y + rowHeight * 0.5f - 9f * scale, labelMaxWidth, new TextStyle(1f, FontWeight.SemiBold),
             theme.TextStrong, rowHovering);

--- a/src/Aetherphone/Apps/Message/MessageApp.MessageInfo.cs
+++ b/src/Aetherphone/Apps/Message/MessageApp.MessageInfo.cs
@@ -230,7 +230,7 @@ internal sealed partial class MessageApp
         var textLeft = avatarCenter.X + radius + 12f * scale;
         var stampWidth = stamp.Length > 0 ? Typography.Measure(stamp, 0.80f).X + 10f * scale : 0f;
         var labelMaxWidth = MathF.Max(1f, origin.X + width - pad - 26f * scale - stampWidth - textLeft);
-        var rowHovering = ImGui.IsMouseHoveringRect(origin, new Vector2(origin.X + width, origin.Y + rowHeight));
+        var rowHovering = UiInteract.Hover(origin, new Vector2(origin.X + width, origin.Y + rowHeight));
         Marquee.DrawLeft("messageapp.messageinfo.member." + member.UserId, label, textLeft,
             origin.Y + rowHeight * 0.5f - 9f * scale, labelMaxWidth, new TextStyle(1f, FontWeight.SemiBold),
             theme.TextStrong, rowHovering);

--- a/src/Aetherphone/Apps/Message/MessageApp.Thread.cs
+++ b/src/Aetherphone/Apps/Message/MessageApp.Thread.cs
@@ -229,7 +229,7 @@ internal sealed partial class MessageApp
             var maxNameRight = area.Max.X - ChatHeaderControls.ReservedRightWidth * scale;
             nameCap = MathF.Max(1f, MathF.Min(nameCap, maxNameRight - nameLeft));
             var titleId = "messageapp.thread.title." + (conversation?.Id ?? "self");
-            var titleHovering = ImGui.IsMouseHoveringRect(new Vector2(avatarCenter.X - avatarRadius, area.Min.Y),
+            var titleHovering = UiInteract.Hover(new Vector2(avatarCenter.X - avatarRadius, area.Min.Y),
                 new Vector2(nameLeft + nameCap, area.Min.Y + AppHeader.Height * scale));
             if (isGroup && conversation is not null)
             {

--- a/src/Aetherphone/Apps/Music/MusicApp.Home.cs
+++ b/src/Aetherphone/Apps/Music/MusicApp.Home.cs
@@ -149,13 +149,13 @@ internal sealed partial class MusicApp
             var textWidth = max.X - trailing - textLeft;
             var chipTitleY = min.Y + 9f * scale;
             var chipTitleSize = Typography.Measure(song.Title, TextStyles.FootnoteEmphasized);
-            var chipTitleHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, chipTitleY),
+            var chipTitleHovering = UiInteract.Hover(new Vector2(textLeft, chipTitleY),
                 new Vector2(textLeft + textWidth, chipTitleY + chipTitleSize.Y));
             Marquee.DrawLeft("music.recentChip.title." + song.VideoId, song.Title, textLeft, chipTitleY,
                 textWidth, TextStyles.FootnoteEmphasized, current ? ui.Accent : ui.TitleInk, chipTitleHovering);
             var chipAuthorY = min.Y + 28f * scale;
             var chipAuthorSize = Typography.Measure(song.Author, TextStyles.Caption1);
-            var chipAuthorHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, chipAuthorY),
+            var chipAuthorHovering = UiInteract.Hover(new Vector2(textLeft, chipAuthorY),
                 new Vector2(textLeft + textWidth, chipAuthorY + chipAuthorSize.Y));
             Marquee.DrawLeft("music.recentChip.author." + song.VideoId, song.Author, textLeft, chipAuthorY,
                 textWidth, TextStyles.Caption1, ui.MutedInk, chipAuthorHovering);
@@ -234,13 +234,13 @@ internal sealed partial class MusicApp
             var textWidth = cardWidth - 2f * scale;
             var featTitleY = artMax.Y + 6f * scale;
             var featTitleSize = Typography.Measure(song.Title, TextStyles.FootnoteEmphasized);
-            var featTitleHovering = ImGui.IsMouseHoveringRect(new Vector2(artMin.X, featTitleY),
+            var featTitleHovering = UiInteract.Hover(new Vector2(artMin.X, featTitleY),
                 new Vector2(artMin.X + textWidth, featTitleY + featTitleSize.Y));
             Marquee.DrawLeft("music.featured.title." + song.VideoId, song.Title, artMin.X, featTitleY,
                 textWidth, TextStyles.FootnoteEmphasized, current ? ui.Accent : ui.TitleInk, featTitleHovering);
             var featAuthorY = artMax.Y + 24f * scale;
             var featAuthorSize = Typography.Measure(song.Author, TextStyles.Caption1);
-            var featAuthorHovering = ImGui.IsMouseHoveringRect(new Vector2(artMin.X, featAuthorY),
+            var featAuthorHovering = UiInteract.Hover(new Vector2(artMin.X, featAuthorY),
                 new Vector2(artMin.X + textWidth, featAuthorY + featAuthorSize.Y));
             Marquee.DrawLeft("music.featured.author." + song.VideoId, song.Author, artMin.X, featAuthorY,
                 textWidth, TextStyles.Caption1, ui.MutedInk, featAuthorHovering);
@@ -436,14 +436,14 @@ internal sealed partial class MusicApp
         var textWidth = max.X - trailing - textLeft;
         var stationNameY = min.Y + 10f * scale;
         var stationNameSize = Typography.Measure(station.Name, TextStyles.BodyEmphasized);
-        var stationNameHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, stationNameY),
+        var stationNameHovering = UiInteract.Hover(new Vector2(textLeft, stationNameY),
             new Vector2(textLeft + textWidth, stationNameY + stationNameSize.Y));
         Marquee.DrawLeft("music.stationRow.name." + station.StreamUrl, station.Name, textLeft, stationNameY,
             textWidth, TextStyles.BodyEmphasized, current ? ui.Accent : ui.TitleInk, stationNameHovering);
         var stationSub = StationSubtitle(station);
         var stationSubY = min.Y + 34f * scale;
         var stationSubSize = Typography.Measure(stationSub, TextStyles.Caption1);
-        var stationSubHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, stationSubY),
+        var stationSubHovering = UiInteract.Hover(new Vector2(textLeft, stationSubY),
             new Vector2(textLeft + textWidth, stationSubY + stationSubSize.Y));
         Marquee.DrawLeft("music.stationRow.subtitle." + station.StreamUrl, stationSub, textLeft,
             stationSubY, textWidth, TextStyles.Caption1, ui.MutedInk, stationSubHovering);

--- a/src/Aetherphone/Apps/Music/MusicApp.NowPlaying.cs
+++ b/src/Aetherphone/Apps/Music/MusicApp.NowPlaying.cs
@@ -176,14 +176,14 @@ internal sealed partial class MusicApp
         var caption = Loc.Culture.TextInfo.ToUpper(Loc.T(L.Music.PlayingFrom));
         var captionY = barCenterY - 8f * scale;
         var captionSize = Typography.Measure(caption, TextStyles.Caption2);
-        var captionHovering = ImGui.IsMouseHoveringRect(new Vector2(textCenterX - textMaxWidth * 0.5f, captionY),
+        var captionHovering = UiInteract.Hover(new Vector2(textCenterX - textMaxWidth * 0.5f, captionY),
             new Vector2(textCenterX + textMaxWidth * 0.5f, captionY + captionSize.Y));
         Marquee.DrawCentered("music.sheetTopBar.caption", caption, textCenterX, captionY, textMaxWidth,
             TextStyles.Caption2, ui.HeaderInk, captionHovering);
         var source = playSource.Length > 0 ? playSource : DisplayName;
         var sourceY = barCenterY + 8f * scale;
         var sourceSize = Typography.Measure(source, TextStyles.FootnoteEmphasized);
-        var sourceHovering = ImGui.IsMouseHoveringRect(new Vector2(textCenterX - textMaxWidth * 0.5f, sourceY),
+        var sourceHovering = UiInteract.Hover(new Vector2(textCenterX - textMaxWidth * 0.5f, sourceY),
             new Vector2(textCenterX + textMaxWidth * 0.5f, sourceY + sourceSize.Y));
         Marquee.DrawCentered("music.sheetTopBar.source", source, textCenterX, sourceY, textMaxWidth,
             TextStyles.FootnoteEmphasized, ui.TitleInk, sourceHovering);

--- a/src/Aetherphone/Apps/Music/MusicApp.Playlists.cs
+++ b/src/Aetherphone/Apps/Music/MusicApp.Playlists.cs
@@ -298,7 +298,7 @@ internal sealed partial class MusicApp
             }
 
             if (interactive && ImGui.IsMouseClicked(ImGuiMouseButton.Left) &&
-                !ImGui.IsMouseHoveringRect(cardMin, cardMax))
+                !UiInteract.Hover(cardMin, cardMax))
             {
                 if (overlay == OverlayMode.Name)
                 {
@@ -617,14 +617,14 @@ internal sealed partial class MusicApp
         var textWidth = max.X - trailing - textLeft;
         var songTitleY = min.Y + 10f * scale;
         var songTitleSize = Typography.Measure(song.Title, TextStyles.BodyEmphasized);
-        var songTitleHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, songTitleY),
+        var songTitleHovering = UiInteract.Hover(new Vector2(textLeft, songTitleY),
             new Vector2(textLeft + textWidth, songTitleY + songTitleSize.Y));
         Marquee.DrawLeft("music.playlistSongRow.title." + song.VideoId + "." + index, song.Title, textLeft,
             songTitleY, textWidth, TextStyles.BodyEmphasized, current ? ui.Accent : ui.TitleInk, songTitleHovering);
         var songSub = SongRowSubtitle(song);
         var songSubY = min.Y + 34f * scale;
         var songSubSize = Typography.Measure(songSub, TextStyles.Caption1);
-        var songSubHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, songSubY),
+        var songSubHovering = UiInteract.Hover(new Vector2(textLeft, songSubY),
             new Vector2(textLeft + textWidth, songSubY + songSubSize.Y));
         Marquee.DrawLeft("music.playlistSongRow.subtitle." + song.VideoId + "." + index, songSub,
             textLeft, songSubY, textWidth, TextStyles.Caption1, ui.MutedInk, songSubHovering);

--- a/src/Aetherphone/Apps/Music/MusicApp.Playlists.cs
+++ b/src/Aetherphone/Apps/Music/MusicApp.Playlists.cs
@@ -297,8 +297,7 @@ internal sealed partial class MusicApp
                 DrawPickCard(drawList, cardRect, scale, interactive);
             }
 
-            if (interactive && ImGui.IsMouseClicked(ImGuiMouseButton.Left) &&
-                !UiInteract.Hover(cardMin, cardMax))
+            if (interactive && UiInteract.ClickedOutside(cardMin, cardMax))
             {
                 if (overlay == OverlayMode.Name)
                 {

--- a/src/Aetherphone/Apps/Music/MusicApp.Search.cs
+++ b/src/Aetherphone/Apps/Music/MusicApp.Search.cs
@@ -124,14 +124,14 @@ internal sealed partial class MusicApp
         var textWidth = max.X - trailing - textLeft;
         var searchTitleY = min.Y + 10f * scale;
         var searchTitleSize = Typography.Measure(song.Title, TextStyles.BodyEmphasized);
-        var searchTitleHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, searchTitleY),
+        var searchTitleHovering = UiInteract.Hover(new Vector2(textLeft, searchTitleY),
             new Vector2(textLeft + textWidth, searchTitleY + searchTitleSize.Y));
         Marquee.DrawLeft("music.searchRow.title." + song.VideoId, song.Title, textLeft, searchTitleY,
             textWidth, TextStyles.BodyEmphasized, current ? ui.Accent : ui.TitleInk, searchTitleHovering);
         var searchSub = SongRowSubtitle(song);
         var searchSubY = min.Y + 34f * scale;
         var searchSubSize = Typography.Measure(searchSub, TextStyles.Caption1);
-        var searchSubHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, searchSubY),
+        var searchSubHovering = UiInteract.Hover(new Vector2(textLeft, searchSubY),
             new Vector2(textLeft + textWidth, searchSubY + searchSubSize.Y));
         Marquee.DrawLeft("music.searchRow.subtitle." + song.VideoId, searchSub, textLeft,
             searchSubY, textWidth, TextStyles.Caption1, ui.MutedInk, searchSubHovering);

--- a/src/Aetherphone/Apps/News/NewsApp.cs
+++ b/src/Aetherphone/Apps/News/NewsApp.cs
@@ -179,7 +179,7 @@ internal sealed class NewsApp : IPhoneApp
         for (var index = 0; index < count; index++)
         {
             var row = card.NextRow();
-            var hovered = ImGui.IsMouseHoveringRect(row.Min, row.Max);
+            var hovered = UiInteract.Hover(row.Min, row.Max);
             if (category == NewsCategory.Maintenance)
             {
                 DrawMaintenanceRow(row, items[index], scale, hovered);
@@ -401,7 +401,7 @@ internal sealed class NewsApp : IPhoneApp
 
         var box = 14f * scale;
         UiAnchors.Report("news.refresh", new Rect(center - new Vector2(box, box), center + new Vector2(box, box)));
-        var hovered = ImGui.IsMouseHoveringRect(center - new Vector2(box, box), center + new Vector2(box, box));
+        var hovered = UiInteract.Hover(center - new Vector2(box, box), center + new Vector2(box, box));
         var glyph = FontAwesomeIcon.Sync.ToIconString();
         using (ImRaii.PushFont(UiBuilder.IconFont))
         {
@@ -435,7 +435,7 @@ internal sealed class NewsApp : IPhoneApp
 
     private void InteractCard(Rect rect, float rounding, string url, ImDrawListPtr drawList)
     {
-        var hovered = ImGui.IsMouseHoveringRect(rect.Min, rect.Max);
+        var hovered = UiInteract.Hover(rect.Min, rect.Max);
         if (hovered)
         {
             var pressed = ImGui.IsMouseDown(ImGuiMouseButton.Left);

--- a/src/Aetherphone/Apps/Notes/NotesApp.cs
+++ b/src/Aetherphone/Apps/Notes/NotesApp.cs
@@ -195,7 +195,7 @@ internal sealed class NotesApp : IPhoneApp
         var titleText = hasTitle ? title : Loc.T(L.Notes.Untitled);
         var titleY = row.Min.Y + 12f * scale;
         var titleSize = Typography.Measure(titleText, TextStyles.Headline);
-        var titleHovering = ImGui.IsMouseHoveringRect(new Vector2(row.Min.X, titleY),
+        var titleHovering = UiInteract.Hover(new Vector2(row.Min.X, titleY),
             new Vector2(row.Min.X + row.Width, titleY + titleSize.Y));
         Marquee.DrawLeft("notes.noteRow.title." + note.Id, titleText, row.Min.X, titleY, row.Width,
             TextStyles.Headline, hasTitle ? ui.TitleInk : ui.MutedInk, titleHovering);
@@ -205,7 +205,7 @@ internal sealed class NotesApp : IPhoneApp
         var secondLine = preview.Length > 0 ? $"{meta}  {preview}" : (hasTitle ? meta : Loc.T(L.Notes.NoAdditionalText));
         var subY = row.Min.Y + 36f * scale;
         var subSize = Typography.Measure(secondLine, TextStyles.Footnote);
-        var subHovering = ImGui.IsMouseHoveringRect(new Vector2(row.Min.X, subY),
+        var subHovering = UiInteract.Hover(new Vector2(row.Min.X, subY),
             new Vector2(row.Min.X + row.Width, subY + subSize.Y));
         Marquee.DrawLeft("notes.noteRow.sub." + note.Id, secondLine, row.Min.X, subY, row.Width,
             TextStyles.Footnote, ui.MutedInk, subHovering);
@@ -482,7 +482,7 @@ internal sealed class NotesApp : IPhoneApp
         var labelLeft = rect.Min.X + Metrics.Space.Md * scale;
         var labelMaxWidth = MathF.Max(1f, min.X - 8f * scale - labelLeft);
         var labelSize = Typography.Measure(label, TextStyles.Body);
-        var labelHovering = ImGui.IsMouseHoveringRect(new Vector2(labelLeft, rect.Center.Y - labelSize.Y * 0.5f),
+        var labelHovering = UiInteract.Hover(new Vector2(labelLeft, rect.Center.Y - labelSize.Y * 0.5f),
             new Vector2(labelLeft + labelMaxWidth, rect.Center.Y + labelSize.Y * 0.5f));
         Marquee.DrawLeft("notes.remind.label", label, labelLeft, rect.Center.Y - 9f * scale, labelMaxWidth,
             TextStyles.Body, ui.TitleInk, labelHovering);
@@ -492,7 +492,7 @@ internal sealed class NotesApp : IPhoneApp
     private bool DrawSaveButton(Rect rect, string label, bool enabled)
     {
         var drawList = ImGui.GetWindowDrawList();
-        var hovered = enabled && ImGui.IsMouseHoveringRect(rect.Min, rect.Max);
+        var hovered = enabled && UiInteract.Hover(rect.Min, rect.Max);
         var fill = !enabled ? Palette.WithAlpha(ui.Accent, 0.35f) :
             hovered ? Palette.Mix(ui.Accent, new Vector4(0f, 0f, 0f, 1f), 0.12f) : ui.Accent;
         Squircle.Fill(drawList, rect.Min, rect.Max, rect.Height * 0.5f, ImGui.GetColorU32(fill));

--- a/src/Aetherphone/Apps/Photos/PhotosChrome.cs
+++ b/src/Aetherphone/Apps/Photos/PhotosChrome.cs
@@ -58,7 +58,7 @@ internal static class PhotosChrome
         var drawList = ImGui.GetWindowDrawList();
         var radius = 18f * scale;
         var hovered =
-            ImGui.IsMouseHoveringRect(center - new Vector2(radius, radius), center + new Vector2(radius, radius));
+            UiInteract.Hover(center - new Vector2(radius, radius), center + new Vector2(radius, radius));
         drawList.AddCircleFilled(center, radius, ImGui.GetColorU32(new Vector4(0f, 0f, 0f, hovered ? 0.5f : 0.34f)), 28);
         return Chevron(center, color, pointsLeft, scale) || Tapped(hovered);
     }
@@ -68,7 +68,7 @@ internal static class PhotosChrome
         var drawList = ImGui.GetWindowDrawList();
         var radius = 16f * scale;
         var hovered =
-            ImGui.IsMouseHoveringRect(center - new Vector2(radius, radius), center + new Vector2(radius, radius));
+            UiInteract.Hover(center - new Vector2(radius, radius), center + new Vector2(radius, radius));
         var ink = ImGui.GetColorU32(hovered ? color : color with { W = 0.85f });
         var size = Metrics.Space.Xs * scale;
         var direction = pointsLeft ? -1f : 1f;
@@ -83,7 +83,7 @@ internal static class PhotosChrome
         var drawList = ImGui.GetWindowDrawList();
         var radius = 17f * scale;
         var hovered =
-            ImGui.IsMouseHoveringRect(center - new Vector2(radius, radius), center + new Vector2(radius, radius));
+            UiInteract.Hover(center - new Vector2(radius, radius), center + new Vector2(radius, radius));
         drawList.AddCircleFilled(center, radius, ImGui.GetColorU32(new Vector4(0f, 0f, 0f, hovered ? 0.5f : 0.32f)), 28);
         var color = theme.Danger;
         var ink = ImGui.GetColorU32(hovered ? color : color with { W = 0.9f });
@@ -105,7 +105,7 @@ internal static class PhotosChrome
         var drawList = ImGui.GetWindowDrawList();
         var radius = 17f * scale;
         var hovered =
-            ImGui.IsMouseHoveringRect(center - new Vector2(radius, radius), center + new Vector2(radius, radius));
+            UiInteract.Hover(center - new Vector2(radius, radius), center + new Vector2(radius, radius));
         drawList.AddCircleFilled(center, radius, ImGui.GetColorU32(new Vector4(0f, 0f, 0f, hovered ? 0.5f : 0.32f)), 28);
         var ink = ImGui.GetColorU32(hovered ? color : color with { W = 0.9f });
         var extent = 7f * scale;

--- a/src/Aetherphone/Apps/Polls/PollsApp.cs
+++ b/src/Aetherphone/Apps/Polls/PollsApp.cs
@@ -204,7 +204,7 @@ internal sealed class PollsApp : IPhoneApp
         var interactive = !poll.Closed;
         var rowMin = new Vector2(left - 8f * scale, top - 4f * scale);
         var rowMax = new Vector2(left + width + 8f * scale, top + height);
-        var hovered = interactive && ImGui.IsMouseHoveringRect(rowMin, rowMax);
+        var hovered = interactive && UiInteract.Hover(rowMin, rowMax);
         if (hovered)
         {
             Squircle.Fill(drawList, rowMin, rowMax, 12f * scale, ImGui.GetColorU32(ui.HoverTint));

--- a/src/Aetherphone/Apps/Settings/Pages/AccountPage.cs
+++ b/src/Aetherphone/Apps/Settings/Pages/AccountPage.cs
@@ -204,14 +204,14 @@ internal sealed class AccountPage : ISettingsPage, IDisposable
         var avatarExtent = new Vector2(radius, radius);
         var avatarMin = avatarCenter - avatarExtent;
         var avatarMax = avatarCenter + avatarExtent;
-        var avatarHovered = ImGui.IsMouseHoveringRect(avatarMin, avatarMax);
+        var avatarHovered = UiInteract.Hover(avatarMin, avatarMax);
         var changeLabel = Loc.T(L.Account.ChangePhoto);
         var changeSize = Typography.Measure(changeLabel, TextStyles.Subheadline);
         var changeCenter = new Vector2(centerX, avatarCenter.Y + radius + 12f * scale + changeSize.Y * 0.5f);
         var changePadding = new Vector2(6f * scale, 4f * scale);
         var changeMin = changeCenter - changeSize * 0.5f - changePadding;
         var changeMax = changeCenter + changeSize * 0.5f + changePadding;
-        var changeHovered = ImGui.IsMouseHoveringRect(changeMin, changeMax);
+        var changeHovered = UiInteract.Hover(changeMin, changeMax);
         var changeInk = changeHovered ? Palette.Mix(theme.Accent, theme.TextStrong, 0.25f) : theme.Accent;
         Typography.DrawCentered(changeCenter, changeLabel, changeInk, TextStyles.Subheadline);
         var photoHovered = avatarHovered || changeHovered;
@@ -809,7 +809,7 @@ internal sealed class AccountPage : ISettingsPage, IDisposable
         var height = 52f * scale;
         var start = ImGui.GetCursorScreenPos();
         var max = new Vector2(start.X + width, start.Y + height);
-        var hovered = ImGui.IsMouseHoveringRect(start, max);
+        var hovered = UiInteract.Hover(start, max);
         var radius = 14f * scale;
         var background = hovered ? Palette.Mix(theme.GroupedCard, theme.Accent, 0.14f) : theme.GroupedCard;
         Squircle.Fill(drawList, start, max, radius, ImGui.GetColorU32(background));

--- a/src/Aetherphone/Apps/Settings/Pages/ProfilePage.cs
+++ b/src/Aetherphone/Apps/Settings/Pages/ProfilePage.cs
@@ -158,7 +158,7 @@ internal sealed class ProfilePage : ISettingsPage, IDisposable
     private static bool StepperButton(ImDrawListPtr drawList, Vector2 min, float size, string glyph, PhoneTheme theme)
     {
         var max = min + new Vector2(size, size);
-        var hovered = ImGui.IsMouseHoveringRect(min, max);
+        var hovered = UiInteract.Hover(min, max);
         var fill = hovered
             ? Palette.Mix(theme.GroupedCard, theme.Accent, 0.35f)
             : Palette.WithAlpha(theme.TextStrong, 0.10f);

--- a/src/Aetherphone/Apps/Settings/Pages/WallpaperCropPage.cs
+++ b/src/Aetherphone/Apps/Settings/Pages/WallpaperCropPage.cs
@@ -82,7 +82,7 @@ internal sealed class WallpaperCropPage : ISettingsPage
 
     private void HandleGestures(Rect preview, Vector2 size, float aspect, Vector2 visible)
     {
-        var hovering = ImGui.IsMouseHoveringRect(preview.Min, preview.Max);
+        var hovering = UiInteract.Hover(preview.Min, preview.Max);
         if (hovering)
         {
             ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
@@ -164,7 +164,7 @@ internal sealed class WallpaperCropPage : ISettingsPage
     {
         var dl = ImGui.GetWindowDrawList();
         var rounding = 12f * scale;
-        var hovered = enabled && ImGui.IsMouseHoveringRect(rect.Min, rect.Max);
+        var hovered = enabled && UiInteract.Hover(rect.Min, rect.Max);
         var fill = primary ? theme.Accent : theme.SurfaceMuted;
         if (!enabled)
         {

--- a/src/Aetherphone/Apps/Settings/Pages/WallpaperPage.cs
+++ b/src/Aetherphone/Apps/Settings/Pages/WallpaperPage.cs
@@ -137,7 +137,7 @@ internal sealed class WallpaperPage : ISettingsPage
             return;
         }
 
-        if (ImGui.IsMouseHoveringRect(rect.Min, new Vector2(rect.Max.X, rect.Max.Y + 24f * scale)))
+        if (UiInteract.Hover(rect.Min, new Vector2(rect.Max.X, rect.Max.Y + 24f * scale)))
         {
             ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
             if (ImGui.IsMouseClicked(ImGuiMouseButton.Left))
@@ -242,7 +242,7 @@ internal sealed class WallpaperPage : ISettingsPage
         var extent = new Vector2(radius, radius);
         var min = center - extent;
         var max = center + extent;
-        var hovered = ImGui.IsMouseHoveringRect(min, max);
+        var hovered = UiInteract.Hover(min, max);
         dl.AddCircleFilled(center, radius, ImGui.GetColorU32(new Vector4(0f, 0f, 0f, hovered ? 0.72f : 0.55f)), 24);
         var arm = 4f * scale;
         var ink = ImGui.GetColorU32(hovered ? theme.Danger : new Vector4(1f, 1f, 1f, 0.9f));
@@ -273,8 +273,8 @@ internal sealed class WallpaperPage : ISettingsPage
         var optionsTop = optionsBottom - rowHeight * 2f;
         var cardMin = new Vector2(left, optionsTop);
         var cardMax = new Vector2(right, cancelTop + rowHeight);
-        var overCard = ImGui.IsMouseHoveringRect(cardMin, cardMax);
-        if (canDismiss && !overCard && ImGui.IsMouseHoveringRect(body.Min, body.Max) &&
+        var overCard = UiInteract.Hover(cardMin, cardMax);
+        if (canDismiss && !overCard && UiInteract.Hover(body.Min, body.Max) &&
             ImGui.IsMouseClicked(ImGuiMouseButton.Left))
         {
             overlay = Overlay.None;
@@ -313,7 +313,7 @@ internal sealed class WallpaperPage : ISettingsPage
 
     private static bool DrawSheetRow(Rect rect, string label, Vector4 color)
     {
-        var hovered = ImGui.IsMouseHoveringRect(rect.Min, rect.Max);
+        var hovered = UiInteract.Hover(rect.Min, rect.Max);
         if (hovered)
         {
             ImGui.GetWindowDrawList().AddRectFilled(rect.Min, rect.Max,
@@ -417,7 +417,7 @@ internal sealed class WallpaperPage : ISettingsPage
         var dl = ImGui.GetWindowDrawList();
         var radius = 12f * scale;
         var hovered =
-            ImGui.IsMouseHoveringRect(center - new Vector2(radius, radius), center + new Vector2(radius, radius));
+            UiInteract.Hover(center - new Vector2(radius, radius), center + new Vector2(radius, radius));
         var arm = 5f * scale;
         var ink = ImGui.GetColorU32(hovered ? theme.TextStrong : theme.TextMuted);
         dl.AddLine(new Vector2(center.X - arm, center.Y - arm), new Vector2(center.X + arm, center.Y + arm), ink,

--- a/src/Aetherphone/Apps/Timers/TimersApp.cs
+++ b/src/Aetherphone/Apps/Timers/TimersApp.cs
@@ -219,7 +219,7 @@ internal sealed class TimersApp : IPhoneApp
         var textLeft = row.Min.X + tile + 12f * scale;
         var textRight = valueRight - valueSize.X - 12f * scale;
         var textMaxWidth = MathF.Max(1f, textRight - textLeft);
-        var rowHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, row.Min.Y), new Vector2(textRight, row.Max.Y));
+        var rowHovering = UiInteract.Hover(new Vector2(textLeft, row.Min.Y), new Vector2(textRight, row.Max.Y));
         if (sublabel.Length > 0)
         {
             Marquee.DrawLeft(id, name, textLeft, row.Center.Y - 16f * scale, textMaxWidth,
@@ -243,7 +243,7 @@ internal sealed class TimersApp : IPhoneApp
         var min = new Vector2(row.Max.X - width, row.Center.Y - height * 0.5f);
         var labelMaxWidth = MathF.Max(1f, min.X - 8f * scale - row.Min.X);
         var labelSize = Typography.Measure(label, TextStyles.Body);
-        var labelHovering = ImGui.IsMouseHoveringRect(new Vector2(row.Min.X, row.Center.Y - labelSize.Y * 0.5f),
+        var labelHovering = UiInteract.Hover(new Vector2(row.Min.X, row.Center.Y - labelSize.Y * 0.5f),
             new Vector2(row.Min.X + labelMaxWidth, row.Center.Y + labelSize.Y * 0.5f));
         Marquee.DrawLeft(label, label, row.Min.X, row.Center.Y - labelSize.Y * 0.5f, labelMaxWidth, TextStyles.Body,
             AppPalettes.Timers.BodyInk, labelHovering);

--- a/src/Aetherphone/Apps/Velvet/Kit/VHeader.cs
+++ b/src/Aetherphone/Apps/Velvet/Kit/VHeader.cs
@@ -39,7 +39,7 @@ internal static class VHeader
         var center = new Vector2(area.Min.X + 16f * scale, midY);
         var hitMin = new Vector2(area.Min.X, area.Min.Y);
         var hitMax = new Vector2(area.Min.X + 46f * scale, area.Min.Y + Height * scale);
-        var hovered = ImGui.IsMouseHoveringRect(hitMin, hitMax);
+        var hovered = UiInteract.Hover(hitMin, hitMax);
         var back = BackButton.Draw("velvet.back", center, 15f * scale, VelvetTheme.TitleInk, hovered, scale,
             shadow: true);
         var fittedTitle = Typography.FitText(title, area.Width - 92f * scale, TextStyles.Title3);

--- a/src/Aetherphone/Apps/Velvet/Kit/VRow.cs
+++ b/src/Aetherphone/Apps/Velvet/Kit/VRow.cs
@@ -171,13 +171,13 @@ internal static class VRow
         {
             var titleY = centerY - 15f * scale;
             var titleSize = Typography.Measure(titleText, TextStyles.Headline);
-            var titleHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, titleY),
+            var titleHovering = UiInteract.Hover(new Vector2(textLeft, titleY),
                 new Vector2(textLeft + innerWidth, titleY + titleSize.Y));
             Marquee.DrawLeft("vrow.title." + titleText, titleText, textLeft, titleY, innerWidth,
                 TextStyles.Headline, VelvetTheme.TitleInk, titleHovering);
             var subtitleY = centerY + 3f * scale;
             var subtitleSize = Typography.Measure(subtitleText, TextStyles.Subheadline);
-            var subtitleHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, subtitleY),
+            var subtitleHovering = UiInteract.Hover(new Vector2(textLeft, subtitleY),
                 new Vector2(textLeft + innerWidth, subtitleY + subtitleSize.Y));
             Marquee.DrawLeft("vrow.subtitle." + subtitleText, subtitleText, textLeft, subtitleY,
                 innerWidth, TextStyles.Subheadline, VelvetTheme.MutedInk, subtitleHovering);

--- a/src/Aetherphone/Apps/Velvet/VelvetShell.Detail.cs
+++ b/src/Aetherphone/Apps/Velvet/VelvetShell.Detail.cs
@@ -81,13 +81,13 @@ internal sealed partial class VelvetShell
             var nameMaxWidth = origin.X + width - 14f * scale - nameLeft;
             var authorY = avatarCenter.Y - 13f * scale;
             var authorSize = Typography.Measure(authorName, TextStyles.Headline);
-            var authorHovering = ImGui.IsMouseHoveringRect(new Vector2(nameLeft, authorY),
+            var authorHovering = UiInteract.Hover(new Vector2(nameLeft, authorY),
                 new Vector2(nameLeft + nameMaxWidth, authorY + authorSize.Y));
             Marquee.DrawLeft("velvet.detail.author." + post.Id, authorName, nameLeft,
                 authorY, nameMaxWidth, TextStyles.Headline, VelvetTheme.TitleInk, authorHovering);
             var ownerSubY = avatarCenter.Y + 3f * scale;
             var ownerSubSize = Typography.Measure(ownerSub, TextStyles.Subheadline);
-            var ownerSubHovering = ImGui.IsMouseHoveringRect(new Vector2(nameLeft, ownerSubY),
+            var ownerSubHovering = UiInteract.Hover(new Vector2(nameLeft, ownerSubY),
                 new Vector2(nameLeft + nameMaxWidth, ownerSubY + ownerSubSize.Y));
             Marquee.DrawLeft("velvet.detail.ownersub." + post.Id, ownerSub, nameLeft, ownerSubY,
                 nameMaxWidth, TextStyles.Subheadline, VelvetTheme.MutedInk, ownerSubHovering);
@@ -259,7 +259,7 @@ internal sealed partial class VelvetShell
         var textLeft = avatarCenter.X + avatarRadius + 10f * scale;
         var wrapWidth = origin.X + width - 28f * scale - textLeft;
         var nameMaxWidth = wrapWidth * 0.55f;
-        var nameHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, origin.Y),
+        var nameHovering = UiInteract.Hover(new Vector2(textLeft, origin.Y),
             new Vector2(textLeft + nameMaxWidth, origin.Y + 16f * scale));
         var nameWidth = Marquee.DrawLeft("velvet.comment.author." + comment.Id, authorName, textLeft, origin.Y,
             nameMaxWidth, TextStyles.SubheadlineEmphasized, VelvetTheme.TitleInk, nameHovering);

--- a/src/Aetherphone/Apps/Velvet/VelvetShell.Feed.cs
+++ b/src/Aetherphone/Apps/Velvet/VelvetShell.Feed.cs
@@ -182,14 +182,14 @@ internal sealed partial class VelvetShell
         var headerTextMaxWidth = MathF.Max(1f, headerTextRight - nameLeft);
         var nameTop = origin.Y + pad;
         var nameSize = Typography.Measure(authorName, TextStyles.Headline);
-        var nameHovering = ImGui.IsMouseHoveringRect(new Vector2(nameLeft, nameTop),
+        var nameHovering = UiInteract.Hover(new Vector2(nameLeft, nameTop),
             new Vector2(nameLeft + headerTextMaxWidth, nameTop + nameSize.Y));
         Marquee.DrawLeft("velvet.feed.author." + entry.Id, authorName, nameLeft, nameTop,
             headerTextMaxWidth, TextStyles.Headline, VelvetTheme.TitleInk, nameHovering);
         var ownerSub = SocialIdentity.FeedMeta(entry.OwnerHandle, TimeText.Short(entry.CreatedAtUnix));
         var ownerSubY = nameTop + PostCardMetrics.SublineTop * scale;
         var ownerSubSize = Typography.Measure(ownerSub, TextStyles.Subheadline);
-        var ownerSubHovering = ImGui.IsMouseHoveringRect(new Vector2(nameLeft, ownerSubY),
+        var ownerSubHovering = UiInteract.Hover(new Vector2(nameLeft, ownerSubY),
             new Vector2(nameLeft + headerTextMaxWidth, ownerSubY + ownerSubSize.Y));
         Marquee.DrawLeft("velvet.feed.ownersub." + entry.Id, ownerSub, nameLeft, ownerSubY,
             headerTextMaxWidth, TextStyles.Subheadline, VelvetTheme.MutedInk, ownerSubHovering);

--- a/src/Aetherphone/Apps/Velvet/VelvetShell.Thread.cs
+++ b/src/Aetherphone/Apps/Velvet/VelvetShell.Thread.cs
@@ -143,12 +143,12 @@ internal sealed partial class VelvetShell
                 subSize.X = MathF.Min(subSize.X, nameCap);
                 var gapY = 1f * scale;
                 var stackTop = rowCenterY - (nameSize.Y + gapY + subSize.Y) * 0.5f;
-                var titleHovering = ImGui.IsMouseHoveringRect(new Vector2(nameLeft, stackTop),
+                var titleHovering = UiInteract.Hover(new Vector2(nameLeft, stackTop),
                     new Vector2(nameLeft + nameCap, stackTop + nameSize.Y));
                 Marquee.DrawLeft("velvet.thread.title." + threadId, name, nameLeft, stackTop, nameCap,
                     new TextStyle(1f, FontWeight.SemiBold), Theme.TextStrong, titleHovering);
                 var subTop = stackTop + nameSize.Y + gapY;
-                var subHovering = ImGui.IsMouseHoveringRect(new Vector2(nameLeft, subTop),
+                var subHovering = UiInteract.Hover(new Vector2(nameLeft, subTop),
                     new Vector2(nameLeft + nameCap, subTop + subSize.Y));
                 Marquee.DrawLeft("velvet.thread.subtitle." + threadId, timeText, nameLeft, subTop, nameCap,
                     new TextStyle(0.72f, FontWeight.Regular), VelvetTheme.MutedInk, subHovering);
@@ -157,7 +157,7 @@ internal sealed partial class VelvetShell
             else
             {
                 var soloTop = rowCenterY - nameSize.Y * 0.5f;
-                var titleHovering = ImGui.IsMouseHoveringRect(new Vector2(nameLeft, soloTop),
+                var titleHovering = UiInteract.Hover(new Vector2(nameLeft, soloTop),
                     new Vector2(nameLeft + nameCap, soloTop + nameSize.Y));
                 Marquee.DrawLeft("velvet.thread.title." + threadId, name, nameLeft, soloTop,
                     nameCap, new TextStyle(1f, FontWeight.SemiBold), Theme.TextStrong, titleHovering);

--- a/src/Aetherphone/Apps/Venues/VenuesApp.cs
+++ b/src/Aetherphone/Apps/Venues/VenuesApp.cs
@@ -235,7 +235,7 @@ internal sealed partial class VenuesApp : IPhoneApp
         var deltaSeconds = io.DeltaTime;
         var mouseX = io.MousePos.X;
         var down = ImGui.IsMouseDown(ImGuiMouseButton.Left);
-        var hovering = ImGui.IsMouseHoveringRect(bar.Min, bar.Max);
+        var hovering = UiInteract.Hover(bar.Min, bar.Max);
         var shouldBlock = false;
 
         if (chipsPressed)

--- a/src/Aetherphone/Apps/YellowPages/YellowPagesApp.Compose.cs
+++ b/src/Aetherphone/Apps/YellowPages/YellowPagesApp.Compose.cs
@@ -256,7 +256,7 @@ internal sealed partial class YellowPagesApp
         {
             var min = PhotoSlot(origin, slot, tile, gap);
             var max = min + new Vector2(tile, tile);
-            var hovered = ImGui.IsMouseHoveringRect(min, max);
+            var hovered = UiInteract.Hover(min, max);
             Squircle.Fill(drawList, min, max, rounding,
                 ImGui.GetColorU32(hovered ? ui.HoverTint : AppPalettes.YellowPages.FieldSurface));
             Squircle.Stroke(drawList, min, max, rounding, ImGui.GetColorU32(AddTileStroke), 1f);
@@ -309,7 +309,7 @@ internal sealed partial class YellowPagesApp
 
         var badgeRadius = 8.5f * scale;
         var badgeCenter = new Vector2(max.X - badgeRadius - 2f * scale, min.Y + badgeRadius + 2f * scale);
-        var badgeHovered = ImGui.IsMouseHoveringRect(badgeCenter - new Vector2(badgeRadius, badgeRadius),
+        var badgeHovered = UiInteract.Hover(badgeCenter - new Vector2(badgeRadius, badgeRadius),
             badgeCenter + new Vector2(badgeRadius, badgeRadius));
         drawList.AddCircleFilled(badgeCenter, badgeRadius,
             ImGui.GetColorU32(new Vector4(0f, 0f, 0f, badgeHovered ? 0.9f : 0.62f)), 20);

--- a/src/Aetherphone/Apps/YellowPages/YellowPagesApp.Detail.cs
+++ b/src/Aetherphone/Apps/YellowPages/YellowPagesApp.Detail.cs
@@ -247,7 +247,7 @@ internal sealed partial class YellowPagesApp
         var expandCenter = new Vector2(rect.Max.X - expandRadius - 10f * scale,
             rect.Min.Y + expandRadius + 10f * scale);
         var expandHalf = new Vector2(expandRadius, expandRadius);
-        var overExpand = ImGui.IsMouseHoveringRect(expandCenter - expandHalf, expandCenter + expandHalf, false);
+        var overExpand = UiInteract.Hover(expandCenter - expandHalf, expandCenter + expandHalf, false);
         drawList.AddCircleFilled(expandCenter, expandRadius,
             ImGui.GetColorU32(new Vector4(0f, 0f, 0f, overExpand ? 0.78f : 0.55f)), 28);
         if (overExpand)
@@ -274,9 +274,9 @@ internal sealed partial class YellowPagesApp
         {
             DrawHeroDots(drawList, rect, photos.Length, scale);
             var midX = rect.Center.X;
-            var leftHovered = !overExpand && ImGui.IsMouseHoveringRect(rect.Min, new Vector2(midX, touchMax.Y), false);
+            var leftHovered = !overExpand && UiInteract.Hover(rect.Min, new Vector2(midX, touchMax.Y), false);
             var rightHovered = !overExpand
-                && ImGui.IsMouseHoveringRect(new Vector2(midX, rect.Min.Y), touchMax, false);
+                && UiInteract.Hover(new Vector2(midX, rect.Min.Y), touchMax, false);
             if (leftHovered || rightHovered)
             {
                 ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);

--- a/src/Aetherphone/Core/ControlCenter/ControlGallery.cs
+++ b/src/Aetherphone/Core/ControlCenter/ControlGallery.cs
@@ -113,7 +113,7 @@ internal sealed class ControlGallery
     private static bool DrawRow(ImDrawListPtr dl, Rect row, IControlModule module, PhoneTheme theme, float scale,
         float alpha, bool interactive)
     {
-        var hovered = interactive && ImGui.IsMouseHoveringRect(row.Min, row.Max);
+        var hovered = interactive && UiInteract.Hover(row.Min, row.Max);
         if (hovered)
         {
             Squircle.Fill(dl, row.Min, row.Max, 16f * scale, ImGui.GetColorU32(new Vector4(1f, 1f, 1f, 0.08f * alpha)));
@@ -140,7 +140,7 @@ internal sealed class ControlGallery
     private static bool IconButton(ImDrawListPtr dl, Rect rect, FontAwesomeIcon icon, PhoneTheme theme, float alpha,
         bool interactive)
     {
-        var hovered = interactive && ImGui.IsMouseHoveringRect(rect.Min, rect.Max);
+        var hovered = interactive && UiInteract.Hover(rect.Min, rect.Max);
         var bg = hovered ? 0.16f : 0.10f;
         Squircle.Fill(dl, rect.Min, rect.Max, rect.Width * 0.5f,
             ImGui.GetColorU32(new Vector4(1f, 1f, 1f, bg * alpha)));

--- a/src/Aetherphone/Core/ControlCenter/Modules/MediaModule.cs
+++ b/src/Aetherphone/Core/ControlCenter/Modules/MediaModule.cs
@@ -73,7 +73,7 @@ internal sealed class MediaModule : IControlModule
         var titleCenterY = MathF.Min(artRect.Max.Y + 16f * scale, contentBottom);
         var titleSize = Typography.Measure(title, TextStyles.Headline);
         var titleTopY = titleCenterY - titleSize.Y * 0.5f;
-        var titleHovering = ImGui.IsMouseHoveringRect(new Vector2(rect.Center.X - textWidth * 0.5f, titleTopY),
+        var titleHovering = UiInteract.Hover(new Vector2(rect.Center.X - textWidth * 0.5f, titleTopY),
             new Vector2(rect.Center.X + textWidth * 0.5f, titleTopY + titleSize.Y));
         Marquee.DrawCentered(dl, "media.large.title", title, rect.Center.X, titleTopY, textWidth, TextStyles.Headline,
             Palette.WithAlpha(theme.TextStrong, opacity), titleHovering);
@@ -106,13 +106,13 @@ internal sealed class MediaModule : IControlModule
         {
             var titleY = centerY - 19f * scale;
             var titleSize = Typography.Measure(title, TextStyles.Headline);
-            var titleHovering = ImGui.IsMouseHoveringRect(new Vector2(left, titleY),
+            var titleHovering = UiInteract.Hover(new Vector2(left, titleY),
                 new Vector2(left + width, titleY + titleSize.Y));
             Marquee.DrawLeft(dl, "media.bar.title", title, left, titleY, width, TextStyles.Headline,
                 Palette.WithAlpha(theme.TextStrong, opacity), titleHovering);
             var subtitleY = centerY + 3f * scale;
             var subtitleSize = Typography.Measure(subtitle, TextStyles.Footnote);
-            var subtitleHovering = ImGui.IsMouseHoveringRect(new Vector2(left, subtitleY),
+            var subtitleHovering = UiInteract.Hover(new Vector2(left, subtitleY),
                 new Vector2(left + width, subtitleY + subtitleSize.Y));
             Marquee.DrawLeft(dl, "media.bar.subtitle", subtitle, left, subtitleY, width, TextStyles.Footnote,
                 Palette.WithAlpha(theme.TextMuted, opacity), subtitleHovering);
@@ -121,7 +121,7 @@ internal sealed class MediaModule : IControlModule
 
         var soloY = centerY - 10f * scale;
         var soloSize = Typography.Measure(title, TextStyles.Headline);
-        var soloHovering = ImGui.IsMouseHoveringRect(new Vector2(left, soloY),
+        var soloHovering = UiInteract.Hover(new Vector2(left, soloY),
             new Vector2(left + width, soloY + soloSize.Y));
         Marquee.DrawLeft(dl, "media.bar.title", title, left, soloY, width, TextStyles.Headline,
             Palette.WithAlpha(theme.TextStrong, opacity), soloHovering);

--- a/src/Aetherphone/Core/Input/DragTracker.cs
+++ b/src/Aetherphone/Core/Input/DragTracker.cs
@@ -22,7 +22,7 @@ internal sealed class DragTracker
         }
 
         var position = ImGui.GetMousePos();
-        if (!UiInteract.Hover(startZone.Min, startZone.Max))
+        if (!UiInteract.HoverWindowOnly(startZone.Min, startZone.Max))
         {
             return false;
         }

--- a/src/Aetherphone/Core/Input/DragTracker.cs
+++ b/src/Aetherphone/Core/Input/DragTracker.cs
@@ -1,3 +1,4 @@
+using Aetherphone.Windows.Components;
 using Dalamud.Bindings.ImGui;
 
 namespace Aetherphone.Core.Input;
@@ -21,7 +22,7 @@ internal sealed class DragTracker
         }
 
         var position = ImGui.GetMousePos();
-        if (!startZone.Contains(position))
+        if (!UiInteract.Hover(startZone.Min, startZone.Max))
         {
             return false;
         }

--- a/src/Aetherphone/Core/Shell/ControlCenter.cs
+++ b/src/Aetherphone/Core/Shell/ControlCenter.cs
@@ -133,7 +133,7 @@ internal sealed class ControlCenter
         StepPoses(slots, placements, delta);
         if (interactive)
         {
-            UpdateEditInput(delta);
+            UpdateEditInput(screen, delta);
         }
 
         if (editing)
@@ -352,7 +352,7 @@ internal sealed class ControlCenter
         ProgressRing.CenterIcon(dl, handle, FontAwesomeIcon.ExpandAlt, new Vector4(1f, 1f, 1f, opacity), 9f * scale);
     }
 
-    private void UpdateEditInput(float delta)
+    private void UpdateEditInput(Rect screen, float delta)
     {
         var mouse = ImGui.GetMousePos();
         if (draggingSlot is not null)
@@ -369,7 +369,7 @@ internal sealed class ControlCenter
         var slots = layout.Slots;
         if (editing)
         {
-            if (ImGui.IsMouseClicked(ImGuiMouseButton.Left))
+            if (ImGui.IsMouseClicked(ImGuiMouseButton.Left) && UiInteract.Hover(screen.Min, screen.Max))
             {
                 for (var index = 0; index < slots.Count; index++)
                 {
@@ -391,11 +391,11 @@ internal sealed class ControlCenter
                 }
             }
 
-            BeginPress(mouse, slots, true);
+            BeginPress(mouse, slots, true, screen);
             return;
         }
 
-        BeginPress(mouse, slots, false);
+        BeginPress(mouse, slots, false, screen);
         if (pressSlot is not null && ImGui.IsMouseDown(ImGuiMouseButton.Left))
         {
             pressTime += delta;
@@ -408,9 +408,9 @@ internal sealed class ControlCenter
         }
     }
 
-    private void BeginPress(Vector2 mouse, IReadOnlyList<ControlSlot> slots, bool armDrag)
+    private void BeginPress(Vector2 mouse, IReadOnlyList<ControlSlot> slots, bool armDrag, Rect screen)
     {
-        if (ImGui.IsMouseClicked(ImGuiMouseButton.Left))
+        if (ImGui.IsMouseClicked(ImGuiMouseButton.Left) && UiInteract.Hover(screen.Min, screen.Max))
         {
             pressSlot = SlotAt(mouse, slots);
             pressOrigin = mouse;
@@ -534,7 +534,7 @@ internal sealed class ControlCenter
     private static bool TextPill(ImDrawListPtr dl, Rect rect, string text, Vector4 accent, float opacity,
         bool interactive)
     {
-        var hovered = interactive && ImGui.IsMouseHoveringRect(rect.Min, rect.Max);
+        var hovered = interactive && UiInteract.Hover(rect.Min, rect.Max);
         Squircle.Fill(dl, rect.Min, rect.Max, rect.Height * 0.5f,
             ImGui.GetColorU32(Palette.WithAlpha(accent, (hovered ? 1f : 0.9f) * opacity)));
         Typography.DrawCentered(dl, rect.Center, text, new Vector4(1f, 1f, 1f, opacity), 0.82f, FontWeight.SemiBold);
@@ -599,7 +599,7 @@ internal sealed class ControlCenter
             if (gesturesEnabled)
             {
                 var topBand = new Rect(screen.Min, new Vector2(screen.Max.X, screen.Min.Y + TopBandHeight * scale));
-                if (!drag.Active && topBand.Contains(ImGui.GetMousePos()))
+                if (!drag.Active && UiInteract.Hover(topBand.Min, topBand.Max))
                 {
                     ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
                 }

--- a/src/Aetherphone/Core/Shell/DynamicIsland.cs
+++ b/src/Aetherphone/Core/Shell/DynamicIsland.cs
@@ -64,12 +64,12 @@ internal sealed class DynamicIsland
             return false;
         }
 
-        if (ImGui.IsMouseHoveringRect(lastBounds.Min, lastBounds.Max))
+        if (UiInteract.Hover(lastBounds.Min, lastBounds.Max))
         {
             return true;
         }
 
-        return lastBubbleVisible && ImGui.IsMouseHoveringRect(lastBubble.Min, lastBubble.Max);
+        return lastBubbleVisible && UiInteract.Hover(lastBubble.Min, lastBubble.Max);
     }
 
     public void Draw(Rect screen, PhoneTheme theme, INavigator navigation, string? foregroundAppId)
@@ -112,7 +112,7 @@ internal sealed class DynamicIsland
         var expanded = ExpandedBounds(screen, rest, scale);
         var morphed = LerpRect(rest, compact, presenceValue);
         var hoverBounds = LerpRect(morphed, expanded, Easing.SmoothStep(Math.Clamp(expand.Value, 0f, 1f)));
-        var hovered = ImGui.IsMouseHoveringRect(hoverBounds.Min, hoverBounds.Max);
+        var hovered = UiInteract.Hover(hoverBounds.Min, hoverBounds.Max);
         var suppressExpand = shownKind == ActivityKind.Music &&
                              string.Equals(foregroundAppId, "music", StringComparison.Ordinal);
         expand.Step(hovered && presenceValue > 0.6f && !suppressExpand ? 1f : 0f, ExpandSmoothTime, delta);
@@ -184,7 +184,7 @@ internal sealed class DynamicIsland
             1.4f * scale);
         Equalizer.Draw(drawList, new Vector2(center.X + 5f * scale, center.Y), scale, radius * 0.66f, clock,
             MusicAccent, alpha, playback.IsPlaying);
-        var hovered = ImGui.IsMouseHoveringRect(lastBubble.Min, lastBubble.Max);
+        var hovered = UiInteract.Hover(lastBubble.Min, lastBubble.Max);
         if (!hovered)
         {
             return;
@@ -246,7 +246,7 @@ internal sealed class DynamicIsland
         var textMaxWidth = bounds.Max.X - 16f * scale - textLeft;
         var titleTop = top + 18f * scale;
         var titleSize = Typography.Measure(playback.Title, 1.0f, FontWeight.SemiBold);
-        var titleHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, titleTop),
+        var titleHovering = UiInteract.Hover(new Vector2(textLeft, titleTop),
             new Vector2(textLeft + textMaxWidth, titleTop + titleSize.Y));
         Marquee.DrawLeft("dynamicisland.music.title", playback.Title, textLeft, titleTop, textMaxWidth,
             new TextStyle(1.0f, FontWeight.SemiBold), Palette.WithAlpha(theme.TextStrong, alpha), titleHovering);
@@ -338,7 +338,7 @@ internal sealed class DynamicIsland
     {
         var drawList = ImGui.GetWindowDrawList();
         var hovered = active &&
-                      ImGui.IsMouseHoveringRect(center - new Vector2(radius, radius),
+                      UiInteract.Hover(center - new Vector2(radius, radius),
                           center + new Vector2(radius, radius));
         var color = hovered ? Palette.Mix(fill, Ink, 0.14f) : fill;
         drawList.AddCircleFilled(center, radius, ImGui.GetColorU32(Palette.WithAlpha(color, alpha * color.W)), 28);

--- a/src/Aetherphone/Core/Shell/Home/FolderOverlay.cs
+++ b/src/Aetherphone/Core/Shell/Home/FolderOverlay.cs
@@ -120,7 +120,7 @@ internal sealed class FolderOverlay
         var gridView = new Rect(new Vector2(panel.Min.X, gridTop), panel.Max);
         var drawList = ImGui.GetWindowDrawList();
         drawList.PushClipRect(gridView.Min, gridView.Max, true);
-        if (ImGui.IsMouseHoveringRect(gridView.Min, gridView.Max))
+        if (UiInteract.Hover(gridView.Min, gridView.Max))
         {
             scrollY -= ImGui.GetIO().MouseWheel * 40f * scale;
         }
@@ -160,7 +160,7 @@ internal sealed class FolderOverlay
                     return;
                 }
             }
-            else if (ImGui.IsMouseHoveringRect(iconRect.Min, iconRect.Max))
+            else if (UiInteract.Hover(iconRect.Min, iconRect.Max))
             {
                 ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
                 if (ImGui.IsMouseClicked(ImGuiMouseButton.Left))

--- a/src/Aetherphone/Core/Shell/Home/HomeChrome.cs
+++ b/src/Aetherphone/Core/Shell/Home/HomeChrome.cs
@@ -37,8 +37,7 @@ internal sealed class HomeChrome
         {
             var center = new Vector2(startX + index * spacing, y);
             var hovered = interactive && interaction.DragTile is null &&
-                          ImGui.IsMouseHoveringRect(center - new Vector2(spacing * 0.5f),
-                              center + new Vector2(spacing * 0.5f));
+                          UiInteract.Hover(center - new Vector2(spacing * 0.5f), center + new Vector2(spacing * 0.5f));
             var dotAlpha = index == active ? 0.95f : hovered ? 0.55f : 0.32f;
             drawList.AddCircleFilled(center, radius,
                 ImGui.GetColorU32(Palette.WithAlpha(theme.TextStrong, dotAlpha * alpha)), 16);
@@ -74,7 +73,7 @@ internal sealed class HomeChrome
             : new Rect(new Vector2(rightEdge - tabWidth, centerY - tabHalfHeight),
                 new Vector2(rightEdge, centerY + tabHalfHeight));
         var hit = new Rect(tab.Min - new Vector2(4f * scale), tab.Max + new Vector2(4f * scale));
-        var hovered = interactive && interaction.DragTile is null && ImGui.IsMouseHoveringRect(hit.Min, hit.Max);
+        var hovered = interactive && interaction.DragTile is null && UiInteract.Hover(hit.Min, hit.Max);
         var drawList = ImGui.GetWindowDrawList();
         var rounding = 7f * scale;
         var corners = direction < 0 ? ImDrawFlags.RoundCornersRight : ImDrawFlags.RoundCornersLeft;
@@ -114,7 +113,7 @@ internal sealed class HomeChrome
         var drawList = ImGui.GetWindowDrawList();
         var scale = metrics.Scale;
         var add = AddRect(content, metrics);
-        var addHovered = ImGui.IsMouseHoveringRect(add.Min, add.Max);
+        var addHovered = UiInteract.Hover(add.Min, add.Max);
         var addCenter = add.Center;
         drawList.AddCircleFilled(addCenter, add.Width * 0.5f,
             ImGui.GetColorU32(new Vector4(1f, 1f, 1f, addHovered ? 0.26f : 0.17f)), 32);
@@ -128,7 +127,7 @@ internal sealed class HomeChrome
         }
 
         var done = DoneRect(content, metrics);
-        var doneHovered = ImGui.IsMouseHoveringRect(done.Min, done.Max);
+        var doneHovered = UiInteract.Hover(done.Min, done.Max);
         Squircle.Fill(drawList, done.Min, done.Max, done.Height * 0.5f,
             ImGui.GetColorU32(Palette.WithAlpha(theme.Accent, doneHovered ? 1f : 0.88f)));
         Typography.DrawCentered(done.Center, Loc.T(L.Home.Done), new Vector4(1f, 1f, 1f, 1f), 0.82f,

--- a/src/Aetherphone/Core/Shell/Home/HomeInteractionController.cs
+++ b/src/Aetherphone/Core/Shell/Home/HomeInteractionController.cs
@@ -1,6 +1,7 @@
 using Aetherphone.Core.Animation;
 using Aetherphone.Core.Apps;
 using Aetherphone.Core.Home;
+using Aetherphone.Windows.Components;
 using Dalamud.Bindings.ImGui;
 
 namespace Aetherphone.Core.Shell.Home;
@@ -146,7 +147,7 @@ internal sealed class HomeInteractionController
     private void HandlePress(Rect content, in HomeMetrics metrics, INavigator navigation, float delta)
     {
         var mouse = ImGui.GetMousePos();
-        if (ImGui.IsMouseClicked(ImGuiMouseButton.Left) && content.Contains(mouse))
+        if (ImGui.IsMouseClicked(ImGuiMouseButton.Left) && UiInteract.Hover(content.Min, content.Max))
         {
             if (editing && HandleEditChromeClick(content, metrics, mouse))
             {
@@ -568,7 +569,7 @@ internal sealed class HomeInteractionController
         hoverPos = ImGui.GetMousePos();
         var active = motion.Interactive && !editing && dragTile is null && settleTile is null &&
                      !folder.Active && !gallery.Active && !sizeMenu.Active && !pager.Dragging &&
-                     content.Contains(hoverPos);
+                     UiInteract.Hover(content.Min, content.Max);
         magnifyGate.Step(active ? 1f : 0f, MagnifyFadeTime, delta);
     }
 

--- a/src/Aetherphone/Core/Shell/Home/WidgetGallery.cs
+++ b/src/Aetherphone/Core/Shell/Home/WidgetGallery.cs
@@ -83,7 +83,7 @@ internal sealed class WidgetGallery
         var closeCenter = new Vector2(sheet.Max.X - 26f * scale, sheet.Min.Y + 33f * scale);
         var closeRadius = 12f * scale;
         var hovered = interactive &&
-                      ImGui.IsMouseHoveringRect(closeCenter - new Vector2(closeRadius), closeCenter + new Vector2(closeRadius));
+                      UiInteract.Hover(closeCenter - new Vector2(closeRadius), closeCenter + new Vector2(closeRadius));
         drawList.AddCircleFilled(closeCenter, closeRadius,
             ImGui.GetColorU32(new Vector4(1f, 1f, 1f, hovered ? 0.22f : 0.13f)), 24);
         var arm = closeRadius * 0.42f;
@@ -192,7 +192,7 @@ internal sealed class WidgetGallery
         {
             var chip = new Rect(new Vector2(left, cursorY), new Vector2(left + widths[index], cursorY + chipHeight));
             var isSelected = options[index] == selected;
-            var hovered = interactive && ImGui.IsMouseHoveringRect(chip.Min, chip.Max);
+            var hovered = interactive && UiInteract.Hover(chip.Min, chip.Max);
             var fill = isSelected
                 ? theme.Accent
                 : new Vector4(1f, 1f, 1f, hovered ? 0.16f : 0.10f);
@@ -222,7 +222,7 @@ internal sealed class WidgetGallery
         var height = 32f * scale;
         var button = new Rect(new Vector2(view.Center.X - width * 0.5f, cursorY),
             new Vector2(view.Center.X + width * 0.5f, cursorY + height));
-        var hovered = interactive && ImGui.IsMouseHoveringRect(button.Min, button.Max);
+        var hovered = interactive && UiInteract.Hover(button.Min, button.Max);
         Squircle.Fill(drawList, button.Min, button.Max, height * 0.5f,
             ImGui.GetColorU32(Palette.WithAlpha(theme.Accent, hovered ? 1f : 0.9f)));
         Typography.DrawCentered(drawList, button.Center, label, new Vector4(1f, 1f, 1f, 1f),

--- a/src/Aetherphone/Core/Shell/Home/WidgetSizeMenu.cs
+++ b/src/Aetherphone/Core/Shell/Home/WidgetSizeMenu.cs
@@ -127,7 +127,7 @@ internal sealed class WidgetSizeMenu
             new Vector2(panel.Max.X - 4f * scale, top + rowHeight));
         rowIndex++;
         var drawList = ImGui.GetWindowDrawList();
-        var hovered = ImGui.IsMouseHoveringRect(row.Min, row.Max);
+        var hovered = UiInteract.Hover(row.Min, row.Max);
         if (hovered)
         {
             Squircle.Fill(drawList, row.Min, row.Max, 11f * scale,

--- a/src/Aetherphone/Core/Shell/PhoneShell.cs
+++ b/src/Aetherphone/Core/Shell/PhoneShell.cs
@@ -324,7 +324,7 @@ internal sealed class PhoneShell : IDisposable
         UiAnchors.Report("chrome.home", new Rect(min, max));
         var hitMin = new Vector2(min.X - 24f * scale, min.Y - 16f * scale);
         var hitMax = new Vector2(max.X + 24f * scale, max.Y + 16f * scale);
-        var hovered = ImGui.IsMouseHoveringRect(hitMin, hitMax);
+        var hovered = UiInteract.Hover(hitMin, hitMax);
         var usable = !navigation.AtHome && !navigation.IsTransitioning;
         var actionable = usable && (hovered || indicatorPressActive);
         var color = actionable ? theme.TextStrong : Palette.WithAlpha(theme.TextStrong, 0.55f);

--- a/src/Aetherphone/Windows/Components/AppHeader.cs
+++ b/src/Aetherphone/Windows/Components/AppHeader.cs
@@ -19,7 +19,7 @@ internal static class AppHeader
             FontWeight.SemiBold);
         var hitMin = new Vector2(content.Min.X, content.Min.Y);
         var hitMax = new Vector2(content.Min.X + 44f * scale, content.Min.Y + Height * scale);
-        var hovered = ImGui.IsMouseHoveringRect(hitMin, hitMax);
+        var hovered = UiInteract.Hover(hitMin, hitMax);
         var center = new Vector2(content.Min.X + 13f * scale, rowCenterY);
         var clicked = BackButton.Draw("appheader.back", center, 15f * scale, theme.Accent, hovered, scale);
         if (!clicked)

--- a/src/Aetherphone/Windows/Components/AvatarLightbox.cs
+++ b/src/Aetherphone/Windows/Components/AvatarLightbox.cs
@@ -110,7 +110,7 @@ internal sealed class AvatarLightbox
             return;
         }
 
-        if (ImGui.IsMouseHoveringRect(area.Min, area.Max) && ImGui.IsMouseClicked(ImGuiMouseButton.Left))
+        if (UiInteract.Hover(area.Min, area.Max) && ImGui.IsMouseClicked(ImGuiMouseButton.Left))
         {
             Close();
         }

--- a/src/Aetherphone/Windows/Components/ChatBubble.cs
+++ b/src/Aetherphone/Windows/Components/ChatBubble.cs
@@ -56,7 +56,7 @@ internal static class ChatBubble
             var dl = ImGui.GetWindowDrawList();
             var headerLeft = screenOrigin.X + gutter + padding;
             var headerMaxWidth = screenOrigin.X + available - padding - headerLeft;
-            var headerHovering = ImGui.IsMouseHoveringRect(new Vector2(headerLeft, screenOrigin.Y),
+            var headerHovering = UiInteract.Hover(new Vector2(headerLeft, screenOrigin.Y),
                 new Vector2(headerLeft + headerMaxWidth, screenOrigin.Y + headerHeight));
             Marquee.DrawLeft("chatbubble.sender." + senderName, senderName, headerLeft, screenOrigin.Y,
                 headerMaxWidth, TextStyles.Caption1, group.SenderColor, headerHovering);
@@ -77,8 +77,7 @@ internal static class ChatBubble
             ImGui.SetCursorPos(new Vector2(start.X + offsetX, bubbleTop));
             var bubbleScreen = ImGui.GetCursorScreenPos();
             var bubbleEnd = bubbleScreen + new Vector2(bubbleWidth, bubbleHeight);
-            contextRequested = !UiInteract.InputBlocked && ImGui.IsMouseHoveringRect(bubbleScreen, bubbleEnd)
-                && ImGui.IsMouseClicked(ImGuiMouseButton.Right);
+            contextRequested = UiInteract.Hover(bubbleScreen, bubbleEnd) && ImGui.IsMouseClicked(ImGuiMouseButton.Right);
             Squircle.Fill(ImGui.GetWindowDrawList(), bubbleScreen,
                 bubbleScreen + new Vector2(bubbleWidth, bubbleHeight), 13f * scale, ImGui.GetColorU32(fillColor));
             if (linkLayout is null)

--- a/src/Aetherphone/Windows/Components/ChatComposer.cs
+++ b/src/Aetherphone/Windows/Components/ChatComposer.cs
@@ -166,7 +166,7 @@ internal sealed class ChatComposer : IDisposable
         var emojiCenter = new Vector2(pillMin.X + iconRadius + 5f * scale, area.Center.Y);
         var emojiMin = emojiCenter - new Vector2(iconRadius, iconRadius);
         var emojiMax = emojiCenter + new Vector2(iconRadius, iconRadius);
-        var emojiHovered = ImGui.IsMouseHoveringRect(emojiMin, emojiMax);
+        var emojiHovered = UiInteract.Hover(emojiMin, emojiMax);
         var emojiColor = emojiOpen ? ui.Accent : emojiHovered ? theme.TextStrong : ui.MutedInk;
         AppSkin.Icon(emojiCenter, FontAwesomeIcon.Smile.ToIconString(), emojiColor, 0.95f);
         HoverTooltip.Show(new Rect(emojiMin, emojiMax), Loc.T(L.Common.Emoji), HoverLabelSide.Above);
@@ -186,7 +186,7 @@ internal sealed class ChatComposer : IDisposable
             var pictureCenter = new Vector2(trailingIconX, area.Center.Y);
             var pictureMin = pictureCenter - new Vector2(iconRadius, iconRadius);
             var pictureMax = pictureCenter + new Vector2(iconRadius, iconRadius);
-            var pictureHovered = ImGui.IsMouseHoveringRect(pictureMin, pictureMax);
+            var pictureHovered = UiInteract.Hover(pictureMin, pictureMax);
             AppSkin.Icon(pictureCenter, FontAwesomeIcon.Image.ToIconString(),
                 pictureHovered ? theme.TextStrong : ui.MutedInk, 0.95f);
             HoverTooltip.Show(new Rect(pictureMin, pictureMax), Loc.T(L.Velvet.SendPicture), HoverLabelSide.Above);
@@ -208,7 +208,7 @@ internal sealed class ChatComposer : IDisposable
             var locationCenter = new Vector2(trailingIconX, area.Center.Y);
             var locationMin = locationCenter - new Vector2(iconRadius, iconRadius);
             var locationMax = locationCenter + new Vector2(iconRadius, iconRadius);
-            var locationHovered = ImGui.IsMouseHoveringRect(locationMin, locationMax);
+            var locationHovered = UiInteract.Hover(locationMin, locationMax);
             AppSkin.Icon(locationCenter, FontAwesomeIcon.MapMarkerAlt.ToIconString(),
                 locationHovered ? theme.TextStrong : ui.MutedInk, 0.95f);
             HoverTooltip.Show(new Rect(locationMin, locationMax), Loc.T(L.Message.ShareLocation),

--- a/src/Aetherphone/Windows/Components/ChatHeaderControls.cs
+++ b/src/Aetherphone/Windows/Components/ChatHeaderControls.cs
@@ -58,7 +58,7 @@ internal static class ChatHeaderControls
         drawList.AddRectFilled(min, max, ImGui.GetColorU32(Palette.WithAlpha(ui.Accent, 0.14f)));
         Typography.DrawCentered(drawList, new Vector2((min.X + max.X) * 0.5f, (min.Y + max.Y) * 0.5f),
             text, mutedInk, 0.76f, FontWeight.Medium);
-        if (ImGui.IsMouseHoveringRect(min, max) && ImGui.IsMouseClicked(ImGuiMouseButton.Left))
+        if (UiInteract.Hover(min, max) && ImGui.IsMouseClicked(ImGuiMouseButton.Left))
         {
             onDismiss();
         }
@@ -82,11 +82,11 @@ internal static class ChatHeaderControls
             FontAwesomeIcon.Times.ToIconString(), mutedInk, 0.6f);
         if (ImGui.IsMouseClicked(ImGuiMouseButton.Left))
         {
-            if (ImGui.IsMouseHoveringRect(dismissMin, max))
+            if (UiInteract.Hover(dismissMin, max))
             {
                 onDismiss();
             }
-            else if (ImGui.IsMouseHoveringRect(min, max))
+            else if (UiInteract.Hover(min, max))
             {
                 onOpen();
             }

--- a/src/Aetherphone/Windows/Components/ChatMenuController.cs
+++ b/src/Aetherphone/Windows/Components/ChatMenuController.cs
@@ -225,7 +225,7 @@ internal sealed class ChatMenuController
             var center = new Vector2(min.X + padding + slot * (index + 0.5f), (min.Y + max.Y) * 0.5f);
             var hitMin = new Vector2(center.X - slot * 0.5f, min.Y);
             var hitMax = new Vector2(center.X + slot * 0.5f, max.Y);
-            var hovered = UiInteract.Hover(hitMin, hitMax);
+            var hovered = UiInteract.HoverWindowOnly(hitMin, hitMax);
             if (token == myReaction)
             {
                 drawList.AddCircleFilled(center, 14f * scale,

--- a/src/Aetherphone/Windows/Components/ChatMenuController.cs
+++ b/src/Aetherphone/Windows/Components/ChatMenuController.cs
@@ -225,7 +225,7 @@ internal sealed class ChatMenuController
             var center = new Vector2(min.X + padding + slot * (index + 0.5f), (min.Y + max.Y) * 0.5f);
             var hitMin = new Vector2(center.X - slot * 0.5f, min.Y);
             var hitMax = new Vector2(center.X + slot * 0.5f, max.Y);
-            var hovered = ImGui.IsMouseHoveringRect(hitMin, hitMax);
+            var hovered = UiInteract.Hover(hitMin, hitMax);
             if (token == myReaction)
             {
                 drawList.AddCircleFilled(center, 14f * scale,

--- a/src/Aetherphone/Windows/Components/ChatThreadView.cs
+++ b/src/Aetherphone/Windows/Components/ChatThreadView.cs
@@ -938,7 +938,7 @@ internal abstract class ChatThreadView<TMessage, TThread> : IDisposable, IChatTr
             lodestone, 0.85f, 32);
         var textLeft = avatarCenter.X + radius + 12f * scale;
         var labelMaxWidth = MathF.Max(1f, origin.X + width - pad - 40f * scale - textLeft);
-        var rowHovering = ImGui.IsMouseHoveringRect(origin, rowMax);
+        var rowHovering = UiInteract.Hover(origin, rowMax);
         if (mine)
         {
             Marquee.DrawLeft("chatthread.reactor." + reactor.UserId, label, textLeft, origin.Y + 10f * scale,

--- a/src/Aetherphone/Windows/Components/ChatTranscript.cs
+++ b/src/Aetherphone/Windows/Components/ChatTranscript.cs
@@ -459,7 +459,7 @@ internal sealed class ChatTranscript
         var textLeft = origin.X + 4f * scale;
         var maxWidth = ScrollLayout.StableContentWidth() - 4f * scale;
         var rect = new Vector2(textLeft, origin.Y);
-        var hovering = ImGui.IsMouseHoveringRect(rect, new Vector2(rect.X + maxWidth, rect.Y + 16f * scale));
+        var hovering = UiInteract.Hover(rect, new Vector2(rect.X + maxWidth, rect.Y + 16f * scale));
         var name = FirstName(message.SenderName);
         Marquee.DrawLeft("chattranscript.sender." + message.Id, name, textLeft, origin.Y, maxWidth,
             new TextStyle(0.78f, FontWeight.SemiBold), message.SenderTint, hovering);
@@ -1756,8 +1756,7 @@ internal sealed class ChatTranscript
         return space > 0 ? name.Substring(0, space) : name;
     }
 
-    private static bool Hovering(Vector2 min, Vector2 max) =>
-        !UiInteract.InputBlocked && ImGui.IsMouseHoveringRect(min, max);
+    private static bool Hovering(Vector2 min, Vector2 max) => UiInteract.Hover(min, max);
 
     private readonly struct BubbleStamp
     {

--- a/src/Aetherphone/Windows/Components/ChipRail.cs
+++ b/src/Aetherphone/Windows/Components/ChipRail.cs
@@ -102,7 +102,7 @@ internal sealed class ChipRail
 
     private void HandleDrag(Rect row)
     {
-        if (ImGui.IsMouseHoveringRect(row.Min, row.Max) && ImGui.IsMouseClicked(ImGuiMouseButton.Left))
+        if (UiInteract.Hover(row.Min, row.Max) && ImGui.IsMouseClicked(ImGuiMouseButton.Left))
         {
             dragging = true;
             dragTravel = 0f;

--- a/src/Aetherphone/Windows/Components/CoachmarkOverlay.cs
+++ b/src/Aetherphone/Windows/Components/CoachmarkOverlay.cs
@@ -321,7 +321,7 @@ internal sealed class CoachmarkOverlay
         }
 
         dl.PopClipRect();
-        if (isTap && live && hole is { } tapHole && ImGui.IsMouseHoveringRect(tapHole.Min, tapHole.Max))
+        if (isTap && live && hole is { } tapHole && UiInteract.Hover(tapHole.Min, tapHole.Max))
         {
             ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
             if (ImGui.IsMouseClicked(ImGuiMouseButton.Left))
@@ -485,7 +485,7 @@ internal sealed class CoachmarkOverlay
         var min = center - half;
         var max = center + half;
         var radius = size.Y * 0.5f;
-        var hovered = live && ImGui.IsMouseHoveringRect(min, max);
+        var hovered = live && UiInteract.Hover(min, max);
         var fill = hovered ? Palette.Mix(accent, Vector4.One, 0.14f) : accent;
         Squircle.Fill(dl, min, max, radius, ImGui.GetColorU32(fill with { W = fill.W * alpha }));
         Typography.DrawCentered(dl, center, label, Ink with { W = contentAlpha }, TextStyles.Headline);

--- a/src/Aetherphone/Windows/Components/ConfirmDialog.cs
+++ b/src/Aetherphone/Windows/Components/ConfirmDialog.cs
@@ -224,7 +224,7 @@ internal static class ConfirmDialog
         float opacity, ConfirmButtonTone tone = ConfirmButtonTone.Neutral, string? id = null)
     {
         var drawList = ImGui.GetWindowDrawList();
-        var hovered = enabled && ImGui.IsMouseHoveringRect(rect.Min, rect.Max);
+        var hovered = enabled && UiInteract.Hover(rect.Min, rect.Max);
         var radius = rect.Height * 0.5f;
         Vector4 fill;
         Vector4 textColor;

--- a/src/Aetherphone/Windows/Components/ConfirmOverlay.cs
+++ b/src/Aetherphone/Windows/Components/ConfirmOverlay.cs
@@ -73,8 +73,7 @@ internal sealed class ConfirmOverlay
             {
                 service.CancelActive();
             }
-            else if (!service.Busy && ImGui.IsMouseClicked(ImGuiMouseButton.Left) &&
-                     !UiInteract.Hover(cardRect.Min, cardRect.Max))
+            else if (!service.Busy && UiInteract.ClickedOutside(cardRect.Min, cardRect.Max))
             {
                 service.CancelActive();
             }

--- a/src/Aetherphone/Windows/Components/ConfirmOverlay.cs
+++ b/src/Aetherphone/Windows/Components/ConfirmOverlay.cs
@@ -74,7 +74,7 @@ internal sealed class ConfirmOverlay
                 service.CancelActive();
             }
             else if (!service.Busy && ImGui.IsMouseClicked(ImGuiMouseButton.Left) &&
-                     !ImGui.IsMouseHoveringRect(cardRect.Min, cardRect.Max))
+                     !UiInteract.Hover(cardRect.Min, cardRect.Max))
             {
                 service.CancelActive();
             }

--- a/src/Aetherphone/Windows/Components/ContactRow.cs
+++ b/src/Aetherphone/Windows/Components/ContactRow.cs
@@ -13,7 +13,7 @@ internal static class ContactRow
     {
         var scale = ImGuiHelpers.GlobalScale;
         var dl = ImGui.GetWindowDrawList();
-        var hovered = ImGui.IsMouseHoveringRect(row.Min, row.Max);
+        var hovered = UiInteract.Hover(row.Min, row.Max);
         var pressed = hovered && ImGui.IsMouseDown(ImGuiMouseButton.Left);
         if (hovered)
         {
@@ -36,13 +36,13 @@ internal static class ContactRow
         var textMaxWidth = subtitleRight - textLeft;
         var nameY = row.Min.Y + 9f * scale;
         var nameSize = Typography.Measure(friend.Name, TextStyles.Headline);
-        var nameHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, nameY),
+        var nameHovering = UiInteract.Hover(new Vector2(textLeft, nameY),
             new Vector2(textLeft + textMaxWidth, nameY + nameSize.Y));
         Marquee.DrawLeft("contactrow.name." + friend.Name, friend.Name, textLeft, nameY,
             textMaxWidth, TextStyles.Headline, nameColor, nameHovering);
         var subtitleY = row.Min.Y + 30f * scale;
         var subtitleSize = Typography.Measure(subtitle, TextStyles.Subheadline);
-        var subtitleHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, subtitleY),
+        var subtitleHovering = UiInteract.Hover(new Vector2(textLeft, subtitleY),
             new Vector2(textLeft + textMaxWidth, subtitleY + subtitleSize.Y));
         Marquee.DrawLeft("contactrow.subtitle." + friend.Name, subtitle, textLeft, subtitleY,
             textMaxWidth, TextStyles.Subheadline, theme.TextMuted, subtitleHovering);

--- a/src/Aetherphone/Windows/Components/ControlTile.cs
+++ b/src/Aetherphone/Windows/Components/ControlTile.cs
@@ -64,7 +64,7 @@ internal static class ControlTile
         var radius = MathF.Min(rect.Width, rect.Height * 0.5f) * 0.44f;
         var result = Math.Clamp(value, 0f, 1f);
         released = false;
-        var hovered = interactive && ImGui.IsMouseHoveringRect(rect.Min, rect.Max);
+        var hovered = interactive && UiInteract.Hover(rect.Min, rect.Max);
         if (hovered)
         {
             ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
@@ -112,11 +112,11 @@ internal static class ControlTile
 
     private static bool Pressed(Rect rect, bool interactive) =>
         interactive && armed && ImGui.IsMouseDown(ImGuiMouseButton.Left) &&
-        ImGui.IsMouseHoveringRect(rect.Min, rect.Max);
+        UiInteract.Hover(rect.Min, rect.Max);
 
     private static bool Release(Rect rect, bool interactive, out bool hovered)
     {
-        hovered = interactive && ImGui.IsMouseHoveringRect(rect.Min, rect.Max);
+        hovered = interactive && UiInteract.Hover(rect.Min, rect.Max);
         if (!interactive)
         {
             return false;

--- a/src/Aetherphone/Windows/Components/ConversationRow.cs
+++ b/src/Aetherphone/Windows/Components/ConversationRow.cs
@@ -18,7 +18,7 @@ internal static class ConversationRow
         var width = ImGui.GetContentRegionAvail().X;
         var min = origin;
         var max = new Vector2(origin.X + width, origin.Y + Height * scale);
-        var hovered = ImGui.IsMouseHoveringRect(min, max);
+        var hovered = UiInteract.Hover(min, max);
         var pressed = hovered && ImGui.IsMouseDown(ImGuiMouseButton.Left);
         var dl = ImGui.GetWindowDrawList();
         if (hovered)
@@ -43,7 +43,7 @@ internal static class ConversationRow
         var nameMaxWidth = textRight - timeSize.X - 8f * scale - textLeft;
         var nameY = min.Y + 11f * scale;
         var nameSize = Typography.Measure(conversation.Contact, TextStyles.Headline);
-        var nameHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, nameY),
+        var nameHovering = UiInteract.Hover(new Vector2(textLeft, nameY),
             new Vector2(textLeft + nameMaxWidth, nameY + nameSize.Y));
         Marquee.DrawLeft("conversationrow.name." + conversation.Contact, conversation.Contact, textLeft,
             nameY, nameMaxWidth, TextStyles.Headline, theme.TextStrong, nameHovering);
@@ -67,7 +67,7 @@ internal static class ConversationRow
         var previewY = min.Y + 34f * scale;
         var previewMaxWidth = previewRight - textLeft;
         var previewSize = Typography.Measure(preview, TextStyles.Subheadline);
-        var previewHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, previewY),
+        var previewHovering = UiInteract.Hover(new Vector2(textLeft, previewY),
             new Vector2(textLeft + previewMaxWidth, previewY + previewSize.Y));
         Marquee.DrawLeft("conversationrow.preview." + conversation.Contact, preview, textLeft, previewY,
             previewMaxWidth, TextStyles.Subheadline, theme.TextMuted, previewHovering);

--- a/src/Aetherphone/Windows/Components/DropdownMenu.cs
+++ b/src/Aetherphone/Windows/Components/DropdownMenu.cs
@@ -156,8 +156,8 @@ internal sealed class DropdownMenu
                 cursorRight -= actionSlot;
             }
 
-            var rowHovered = ImGui.IsMouseHoveringRect(rowMin, rowMax);
-            var editHovered = item.CanEdit && editRect is { } er && ImGui.IsMouseHoveringRect(er.Min, er.Max);
+            var rowHovered = UiInteract.Hover(rowMin, rowMax);
+            var editHovered = item.CanEdit && editRect is { } er && UiInteract.Hover(er.Min, er.Max);
             if (rowHovered)
             {
                 Squircle.Fill(drawList, rowMin, rowMax, 9f * scale,
@@ -210,7 +210,7 @@ internal sealed class DropdownMenu
             return clicked;
         }
 
-        if (ImGui.IsMouseClicked(ImGuiMouseButton.Left) && !ImGui.IsMouseHoveringRect(min, max, false) &&
+        if (ImGui.IsMouseClicked(ImGuiMouseButton.Left) && !UiInteract.Hover(min, max, false) &&
             ImGui.GetFrameCount() != openedFrame)
         {
             Close();

--- a/src/Aetherphone/Windows/Components/DropdownMenu.cs
+++ b/src/Aetherphone/Windows/Components/DropdownMenu.cs
@@ -156,8 +156,8 @@ internal sealed class DropdownMenu
                 cursorRight -= actionSlot;
             }
 
-            var rowHovered = UiInteract.Hover(rowMin, rowMax);
-            var editHovered = item.CanEdit && editRect is { } er && UiInteract.Hover(er.Min, er.Max);
+            var rowHovered = UiInteract.HoverWindowOnly(rowMin, rowMax);
+            var editHovered = item.CanEdit && editRect is { } er && UiInteract.HoverWindowOnly(er.Min, er.Max);
             if (rowHovered)
             {
                 Squircle.Fill(drawList, rowMin, rowMax, 9f * scale,
@@ -210,7 +210,7 @@ internal sealed class DropdownMenu
             return clicked;
         }
 
-        if (ImGui.IsMouseClicked(ImGuiMouseButton.Left) && !UiInteract.Hover(min, max, false) &&
+        if (ImGui.IsMouseClicked(ImGuiMouseButton.Left) && !UiInteract.HoverWindowOnly(min, max, false) &&
             ImGui.GetFrameCount() != openedFrame)
         {
             Close();

--- a/src/Aetherphone/Windows/Components/EmojiComposer.cs
+++ b/src/Aetherphone/Windows/Components/EmojiComposer.cs
@@ -31,7 +31,7 @@ internal sealed class EmojiComposer
     {
         var min = center - new Vector2(radius, radius);
         var max = center + new Vector2(radius, radius);
-        var hovered = ImGui.IsMouseHoveringRect(min, max);
+        var hovered = UiInteract.Hover(min, max);
         var color = open ? activeColor : hovered ? ui.Theme.TextStrong : idleColor;
         AppSkin.Icon(center, FontAwesomeIcon.Smile.ToIconString(), color, 0.95f);
         HoverTooltip.Show(new Rect(min, max), tooltip, side);

--- a/src/Aetherphone/Windows/Components/HomeTileView.cs
+++ b/src/Aetherphone/Windows/Components/HomeTileView.cs
@@ -120,8 +120,7 @@ internal static class HomeTileView
     {
         var radius = 9f * scale;
         var dl = ImGui.GetWindowDrawList();
-        var hovered =
-            ImGui.IsMouseHoveringRect(center - new Vector2(radius, radius), center + new Vector2(radius, radius));
+        var hovered = UiInteract.Hover(center - new Vector2(radius, radius), center + new Vector2(radius, radius));
         dl.AddCircleFilled(center, radius, ImGui.GetColorU32(Palette.WithAlpha(theme.TextStrong, hovered ? 1f : 0.88f)),
             24);
         var arm = radius * 0.4f;

--- a/src/Aetherphone/Windows/Components/HoverButton.cs
+++ b/src/Aetherphone/Windows/Components/HoverButton.cs
@@ -26,7 +26,7 @@ internal static class HoverButton
         var scale = ImGuiHelpers.GlobalScale;
         var min = new Vector2(center.X - radius, center.Y - radius);
         var max = new Vector2(center.X + radius, center.Y + radius);
-        var hovered = interactive && ImGui.IsMouseHoveringRect(min, max);
+        var hovered = interactive && UiInteract.Hover(min, max);
         var eased = Step(id, hovered, delta);
         var grow = 1f + GrowAmount * eased;
         var scaledRadius = radius * grow;

--- a/src/Aetherphone/Windows/Components/ImagePickCrop.cs
+++ b/src/Aetherphone/Windows/Components/ImagePickCrop.cs
@@ -225,7 +225,7 @@ internal sealed class ImagePickCrop
 
     private void HandleGestures(Rect preview, Vector2 size, Vector2 visible)
     {
-        var hovering = ImGui.IsMouseHoveringRect(preview.Min, preview.Max);
+        var hovering = UiInteract.Hover(preview.Min, preview.Max);
         if (hovering)
         {
             ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
@@ -286,7 +286,7 @@ internal sealed class ImagePickCrop
     private static bool Pill(Rect rect, string label, bool filled, Vector4 accent, PhoneTheme theme)
     {
         var drawList = ImGui.GetWindowDrawList();
-        var hovered = ImGui.IsMouseHoveringRect(rect.Min, rect.Max);
+        var hovered = UiInteract.Hover(rect.Min, rect.Max);
         var radius = rect.Height * 0.5f;
         var fill = filled
             ? (hovered ? Palette.Mix(accent, theme.TextStrong, 0.12f) : accent)

--- a/src/Aetherphone/Windows/Components/IncomingCallOverlay.cs
+++ b/src/Aetherphone/Windows/Components/IncomingCallOverlay.cs
@@ -98,7 +98,7 @@ internal sealed class IncomingCallOverlay
         var dl = ImGui.GetWindowDrawList();
         var scale = ImGuiHelpers.GlobalScale;
         var hovered = live &&
-                      ImGui.IsMouseHoveringRect(center - new Vector2(radius, radius),
+                      UiInteract.Hover(center - new Vector2(radius, radius),
                           center + new Vector2(radius, radius));
         var color = hovered ? Palette.Mix(fill, Ink, 0.14f) : fill;
         dl.AddCircleFilled(center, radius, ImGui.GetColorU32(Palette.WithAlpha(color, alpha)), 40);

--- a/src/Aetherphone/Windows/Components/LinkshellRow.cs
+++ b/src/Aetherphone/Windows/Components/LinkshellRow.cs
@@ -35,7 +35,7 @@ internal static class LinkshellRow
         var bellCenter = new Vector2(max.X - 22f * scale, min.Y + Height * scale * 0.5f);
         var bellMin = bellCenter - new Vector2(bellRadius, bellRadius);
         var bellMax = bellCenter + new Vector2(bellRadius, bellRadius);
-        var bellHovered = ImGui.IsMouseHoveringRect(bellMin, bellMax);
+        var bellHovered = UiInteract.Hover(bellMin, bellMax);
 
         var hovered = UiInteract.Hover(min, max);
         var rowActive = hovered && !bellHovered;
@@ -70,7 +70,7 @@ internal static class LinkshellRow
             ? min.Y + Height * scale * 0.5f - titleSize.Y * 0.5f
             : min.Y + 11f * scale;
         var titleMaxWidth = textRight - 4f * scale - textLeft;
-        var titleHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, titleY),
+        var titleHovering = UiInteract.Hover(new Vector2(textLeft, titleY),
             new Vector2(textLeft + titleMaxWidth, titleY + titleSize.Y));
         Marquee.DrawLeft("linkshellrow.title." + channel.Key, label, textLeft, titleY,
             titleMaxWidth, TextStyles.Headline, theme.TextStrong, titleHovering);
@@ -106,7 +106,7 @@ internal static class LinkshellRow
             var previewY = min.Y + 34f * scale;
             var previewMaxWidth = previewRight - textLeft;
             var previewSize = Typography.Measure(preview, TextStyles.Subheadline);
-            var previewHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, previewY),
+            var previewHovering = UiInteract.Hover(new Vector2(textLeft, previewY),
                 new Vector2(textLeft + previewMaxWidth, previewY + previewSize.Y));
             Marquee.DrawLeft("linkshellrow.preview." + channel.Key, preview, textLeft, previewY,
                 previewMaxWidth, TextStyles.Subheadline, theme.TextMuted, previewHovering);

--- a/src/Aetherphone/Windows/Components/MarketRowViews.cs
+++ b/src/Aetherphone/Windows/Components/MarketRowViews.cs
@@ -28,7 +28,7 @@ internal static class MarketRowViews
         var scale = ImGuiHelpers.GlobalScale;
         var drawList = ImGui.GetWindowDrawList();
         var openRight = row.Max.X - 56f * scale;
-        if (ImGui.IsMouseHoveringRect(row.Min, new Vector2(openRight, row.Max.Y)))
+        if (UiInteract.Hover(row.Min, new Vector2(openRight, row.Max.Y)))
         {
             DrawRowHighlight(drawList, new Rect(row.Min, new Vector2(openRight, row.Max.Y)),
                 ImGui.IsMouseDown(ImGuiMouseButton.Left), scale);
@@ -63,7 +63,7 @@ internal static class MarketRowViews
         var topY = row.Min.Y + 9f * scale;
         var textMaxWidth = MathF.Max(1f, dotCenter.X - 8f * scale - textX);
         var nameSize = Typography.Measure(alert.ItemName, TextStyles.Body);
-        var nameHovered = ImGui.IsMouseHoveringRect(new Vector2(textX, topY),
+        var nameHovered = UiInteract.Hover(new Vector2(textX, topY),
             new Vector2(textX + textMaxWidth, topY + nameSize.Y));
         Marquee.DrawLeft(rowId + ".name", alert.ItemName, textX, topY, textMaxWidth,
             TextStyles.Body, theme.TextStrong, nameHovered);
@@ -72,7 +72,7 @@ internal static class MarketRowViews
             $"{arrow} {MarketFormat.Gil(alert.Threshold)} · {alert.ScopeName}{(alert.HqOnly ? $" · {Loc.T(L.Common.Hq)}" : string.Empty)}";
         var subSize = Typography.Measure(sub, 0.82f);
         var subTop = row.Max.Y - 9f * scale - subSize.Y;
-        var subHovered = ImGui.IsMouseHoveringRect(new Vector2(textX, subTop),
+        var subHovered = UiInteract.Hover(new Vector2(textX, subTop),
             new Vector2(textX + textMaxWidth, subTop + subSize.Y));
         Marquee.DrawLeft(rowId + ".sub", sub, textX, subTop,
             textMaxWidth, new TextStyle(0.82f, FontWeight.Regular), theme.TextMuted, subHovered);

--- a/src/Aetherphone/Windows/Components/Marquee.cs
+++ b/src/Aetherphone/Windows/Components/Marquee.cs
@@ -50,7 +50,7 @@ internal static class Marquee
         float maxWidth, in TextStyle style, Vector4 color)
     {
         var size = Typography.Measure(fullText, style);
-        var hovering = ImGui.IsMouseHoveringRect(new Vector2(boxLeft, y),
+        var hovering = UiInteract.Hover(new Vector2(boxLeft, y),
             new Vector2(boxLeft + MathF.Min(size.X, maxWidth), y + size.Y));
         return DrawLeft(drawList, id, fullText, boxLeft, y, maxWidth, style, color, hovering);
     }
@@ -63,7 +63,7 @@ internal static class Marquee
         float maxWidth, in TextStyle style, Vector4 color)
     {
         var size = Typography.Measure(fullText, style);
-        var hovering = ImGui.IsMouseHoveringRect(new Vector2(boxRight - MathF.Min(size.X, maxWidth), y),
+        var hovering = UiInteract.Hover(new Vector2(boxRight - MathF.Min(size.X, maxWidth), y),
             new Vector2(boxRight, y + size.Y));
         DrawRight(drawList, id, fullText, boxRight, y, maxWidth, style, color, hovering);
     }
@@ -77,7 +77,7 @@ internal static class Marquee
     {
         var size = Typography.Measure(fullText, style);
         var clampedWidth = MathF.Min(size.X, maxWidth);
-        var hovering = ImGui.IsMouseHoveringRect(new Vector2(centerX - clampedWidth * 0.5f, y),
+        var hovering = UiInteract.Hover(new Vector2(centerX - clampedWidth * 0.5f, y),
             new Vector2(centerX + clampedWidth * 0.5f, y + size.Y));
         DrawCentered(drawList, id, fullText, centerX, y, maxWidth, style, color, hovering);
     }

--- a/src/Aetherphone/Windows/Components/MentionPopup.cs
+++ b/src/Aetherphone/Windows/Components/MentionPopup.cs
@@ -67,7 +67,7 @@ internal sealed class MentionPopup
 
         var min = new Vector2(left, top);
         var max = new Vector2(left + width, top + height);
-        autocomplete.PointerOver = ImGui.IsMouseHoveringRect(min, max);
+        autocomplete.PointerOver = UiInteract.Hover(min, max);
         Elevation.Floating(drawList, min, max, 14f * scale, scale);
         Squircle.Fill(drawList, min, max, 14f * scale,
             ImGui.GetColorU32(Palette.WithAlpha(theme.GroupedCard, MathF.Min(0.98f, theme.GroupedCard.W + 0.4f) * alpha)));
@@ -88,7 +88,7 @@ internal sealed class MentionPopup
             var row = rows[index];
             var rowMin = new Vector2(min.X + padY, min.Y + padY + index * rowHeight);
             var rowMax = new Vector2(max.X - padY, rowMin.Y + rowHeight);
-            var hovered = ImGui.IsMouseHoveringRect(rowMin, rowMax);
+            var hovered = UiInteract.Hover(rowMin, rowMax);
             if (hovered || index == autocomplete.SelectedIndex)
             {
                 Squircle.Fill(drawList, rowMin, rowMax, 9f * scale,
@@ -114,14 +114,14 @@ internal sealed class MentionPopup
             var name = SocialIdentity.Name(row.DisplayName, row.Handle);
             var nameY = rowMin.Y + 6f * scale;
             var nameSize = Typography.Measure(name, 0.92f, FontWeight.SemiBold);
-            var nameHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, nameY),
+            var nameHovering = UiInteract.Hover(new Vector2(textLeft, nameY),
                 new Vector2(textLeft + textMaxWidth, nameY + nameSize.Y));
             Marquee.DrawLeft(drawList, "mentionpopup.name." + row.Handle, name, textLeft, nameY, textMaxWidth,
                 new TextStyle(0.92f, FontWeight.SemiBold), Palette.WithAlpha(theme.TextStrong, alpha), nameHovering);
             var handleText = "@" + row.Handle;
             var handleY = nameY + nameSize.Y;
             var handleSize = Typography.Measure(handleText, 0.82f, FontWeight.Regular);
-            var handleHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, handleY),
+            var handleHovering = UiInteract.Hover(new Vector2(textLeft, handleY),
                 new Vector2(textLeft + textMaxWidth, handleY + handleSize.Y));
             Marquee.DrawLeft(drawList, "mentionpopup.handle." + row.Handle, handleText,
                 textLeft, handleY, textMaxWidth, new TextStyle(0.82f, FontWeight.Regular),

--- a/src/Aetherphone/Windows/Components/NavigationBar.cs
+++ b/src/Aetherphone/Windows/Components/NavigationBar.cs
@@ -113,7 +113,7 @@ internal static class NavigationBar
     {
         var hitMin = new Vector2(content.Min.X, content.Min.Y);
         var hitMax = new Vector2(content.Min.X + 44f * scale, barBottom);
-        var hovered = ImGui.IsMouseHoveringRect(hitMin, hitMax);
+        var hovered = UiInteract.Hover(hitMin, hitMax);
         var center = new Vector2(content.Min.X + 13f * scale, (content.Min.Y + barBottom) * 0.5f);
         if (!BackButton.Draw("navbar.back", center, 15f * scale, palette.Chevron, hovered, scale))
         {

--- a/src/Aetherphone/Windows/Components/NotificationBanner.cs
+++ b/src/Aetherphone/Windows/Components/NotificationBanner.cs
@@ -77,7 +77,7 @@ internal sealed class NotificationBanner : IDisposable
         }
 
         var bounds = CurrentBounds(screen, ImGuiHelpers.GlobalScale, out _);
-        return ImGui.IsMouseHoveringRect(bounds.Min, bounds.Max);
+        return UiInteract.Hover(bounds.Min, bounds.Max);
     }
 
     public void Advance(float deltaSeconds)
@@ -151,7 +151,7 @@ internal sealed class NotificationBanner : IDisposable
 
         var scale = ImGuiHelpers.GlobalScale;
         var bounds = CurrentBounds(screen, scale, out var opacity);
-        var hovered = stage != Stage.Exit && ImGui.IsMouseHoveringRect(bounds.Min, bounds.Max);
+        var hovered = stage != Stage.Exit && UiInteract.Hover(bounds.Min, bounds.Max);
         if (hovered || dragging)
         {
             holdPaused = true;

--- a/src/Aetherphone/Windows/Components/NotificationCenter.cs
+++ b/src/Aetherphone/Windows/Components/NotificationCenter.cs
@@ -250,7 +250,7 @@ internal sealed class NotificationCenter
         var pillHeight = 26f * scale;
         var pillMax = new Vector2(bar.Max.X, bar.Center.Y + pillHeight * 0.5f);
         var pillMin = new Vector2(pillMax.X - textSize.X - padX * 2f, bar.Center.Y - pillHeight * 0.5f);
-        var hovered = interactive && ImGui.IsMouseHoveringRect(pillMin, pillMax);
+        var hovered = interactive && UiInteract.Hover(pillMin, pillMax);
         var fill = hovered ? theme.Surface : theme.GroupedCard;
         Squircle.Fill(dl, pillMin, pillMax, pillHeight * 0.5f,
             ImGui.GetColorU32(fill with { W = fill.W * opacity }));
@@ -418,7 +418,7 @@ internal sealed class NotificationCenter
                 new Vector2(blockOrigin.X + width, blockOrigin.Y + HeaderHeight * scale));
             DrawHeader(dl, headerRect, group.Items[0].Title, theme, scale, progress * opacity);
             if (interactive && state.Expanded && progress > 0.5f &&
-                ImGui.IsMouseHoveringRect(headerRect.Min, headerRect.Max))
+                UiInteract.Hover(headerRect.Min, headerRect.Max))
             {
                 ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
                 if (ImGui.IsMouseClicked(ImGuiMouseButton.Left))
@@ -481,12 +481,12 @@ internal sealed class NotificationCenter
         if (!drag.Active && interactive)
         {
             var mouse = ImGui.GetMousePos();
-            if (interactionBounds.Contains(mouse))
+            if (UiInteract.Hover(interactionBounds.Min, interactionBounds.Max))
             {
                 for (var index = 0; index < candidates.Count; index++)
                 {
                     var candidate = candidates[index];
-                    if (!candidate.Rect.Contains(mouse))
+                    if (!UiInteract.Hover(candidate.Rect.Min, candidate.Rect.Max))
                     {
                         continue;
                     }

--- a/src/Aetherphone/Windows/Components/PersonPicker.cs
+++ b/src/Aetherphone/Windows/Components/PersonPicker.cs
@@ -144,14 +144,14 @@ internal sealed class PersonPicker
             var name = SocialIdentity.Name(row.DisplayName, row.Handle);
             var nameY = rowMin.Y + 6f * scale;
             var nameSize = Typography.Measure(name, 0.95f, FontWeight.SemiBold);
-            var nameHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, nameY),
+            var nameHovering = UiInteract.Hover(new Vector2(textLeft, nameY),
                 new Vector2(textLeft + textMaxWidth, nameY + nameSize.Y));
             Marquee.DrawLeft("personpicker.name." + row.Handle, name, textLeft, nameY, textMaxWidth,
                 new TextStyle(0.95f, FontWeight.SemiBold), theme.TextStrong, nameHovering);
             var handleText = "@" + row.Handle;
             var handleY = nameY + nameSize.Y;
             var handleSize = Typography.Measure(handleText, 0.82f, FontWeight.Regular);
-            var handleHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, handleY),
+            var handleHovering = UiInteract.Hover(new Vector2(textLeft, handleY),
                 new Vector2(textLeft + textMaxWidth, handleY + handleSize.Y));
             Marquee.DrawLeft("personpicker.handle." + row.Handle, handleText,
                 textLeft, handleY, textMaxWidth, new TextStyle(0.82f, FontWeight.Regular),
@@ -160,7 +160,7 @@ internal sealed class PersonPicker
 
         if (ImGui.GetFrameCount() > openedFrame + 1
             && ImGui.IsMouseClicked(ImGuiMouseButton.Left)
-            && !ImGui.IsMouseHoveringRect(min, max))
+            && !UiInteract.Hover(min, max))
         {
             Close();
             return null;

--- a/src/Aetherphone/Windows/Components/PersonPicker.cs
+++ b/src/Aetherphone/Windows/Components/PersonPicker.cs
@@ -159,8 +159,7 @@ internal sealed class PersonPicker
         }
 
         if (ImGui.GetFrameCount() > openedFrame + 1
-            && ImGui.IsMouseClicked(ImGuiMouseButton.Left)
-            && !UiInteract.Hover(min, max))
+            && UiInteract.ClickedOutside(min, max))
         {
             Close();
             return null;

--- a/src/Aetherphone/Windows/Components/PhotoComposeSession.cs
+++ b/src/Aetherphone/Windows/Components/PhotoComposeSession.cs
@@ -326,7 +326,7 @@ internal sealed class PhotoComposeSession
 
     private void HandleCropGestures(Rect preview, Vector2 size, Vector2 visible, float aspect)
     {
-        var hovering = ImGui.IsMouseHoveringRect(preview.Min, preview.Max);
+        var hovering = UiInteract.Hover(preview.Min, preview.Max);
         if (hovering)
         {
             ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);

--- a/src/Aetherphone/Windows/Components/PhotoViewerOverlay.cs
+++ b/src/Aetherphone/Windows/Components/PhotoViewerOverlay.cs
@@ -66,7 +66,7 @@ internal sealed class PhotoViewerOverlay
         var rowCenterY = contentTop + AppHeader.Height * scale * 0.5f;
         var hitMin = new Vector2(contentLeft, contentTop);
         var hitMax = new Vector2(contentLeft + 44f * scale, headerBottom);
-        var hovered = ImGui.IsMouseHoveringRect(hitMin, hitMax);
+        var hovered = UiInteract.Hover(hitMin, hitMax);
         var backCenter = new Vector2(contentLeft + 13f * scale, rowCenterY);
         if (BackButton.Draw("photoviewer.back", backCenter, 15f * scale, new Vector4(1f, 1f, 1f, 0.95f), hovered, scale,
                 shadow: true))

--- a/src/Aetherphone/Windows/Components/PhotoZoomView.cs
+++ b/src/Aetherphone/Windows/Components/PhotoZoomView.cs
@@ -67,7 +67,7 @@ internal sealed class PhotoZoomView
     private void HandleInput(Rect stage, Vector2 size)
     {
         var mouse = ImGui.GetMousePos();
-        var hovering = ImGui.IsMouseHoveringRect(stage.Min, stage.Max);
+        var hovering = UiInteract.Hover(stage.Min, stage.Max);
         if (hovering)
         {
             var wheel = ImGui.GetIO().MouseWheel;
@@ -163,7 +163,7 @@ internal sealed class PhotoZoomView
     {
         var drawList = ImGui.GetWindowDrawList();
         var hovered = enabled &&
-                      ImGui.IsMouseHoveringRect(center - new Vector2(radius, radius),
+                      UiInteract.Hover(center - new Vector2(radius, radius),
                           center + new Vector2(radius, radius));
         var alpha = enabled ? hovered ? 0.30f : 0.20f : 0.10f;
         drawList.AddCircleFilled(center, radius, ImGui.GetColorU32(new Vector4(1f, 1f, 1f, alpha)), 32);

--- a/src/Aetherphone/Windows/Components/ProgressRing.cs
+++ b/src/Aetherphone/Windows/Components/ProgressRing.cs
@@ -126,7 +126,7 @@ internal static class ProgressRing
         var dl = ImGui.GetWindowDrawList();
         var min = c - new Vector2(radius, radius);
         var max = c + new Vector2(radius, radius);
-        var hovered = enabled && ImGui.IsMouseHoveringRect(min, max);
+        var hovered = enabled && UiInteract.Hover(min, max);
         var accent = Accent.Violet;
         var thickness = 4.5f * ImGuiHelpers.GlobalScale;
         if (enabled)

--- a/src/Aetherphone/Windows/Components/QuickAction.cs
+++ b/src/Aetherphone/Windows/Components/QuickAction.cs
@@ -20,7 +20,7 @@ internal static class QuickAction
         var labelSize = Typography.Measure(label, TextStyles.Caption1);
         var hitMin = new Vector2(center.X - radius, center.Y - radius);
         var hitMax = new Vector2(center.X + radius, center.Y + radius + LabelGap * scale + labelSize.Y);
-        var hovered = ImGui.IsMouseHoveringRect(hitMin, hitMax);
+        var hovered = UiInteract.Hover(hitMin, hitMax);
         var pressed = hovered && ImGui.IsMouseDown(ImGuiMouseButton.Left);
         var deltaSeconds = MathF.Min(ImGui.GetIO().DeltaTime, 0.1f);
         if (!Scales.TryGetValue(id, out var spring))

--- a/src/Aetherphone/Windows/Components/ReportOverlay.cs
+++ b/src/Aetherphone/Windows/Components/ReportOverlay.cs
@@ -91,7 +91,7 @@ internal sealed class ReportOverlay
             }
 
             if (!service.Busy && ImGui.IsMouseClicked(ImGuiMouseButton.Left) &&
-                !ImGui.IsMouseHoveringRect(cardRect.Min, cardRect.Max))
+                !UiInteract.Hover(cardRect.Min, cardRect.Max))
             {
                 service.Dismiss();
             }
@@ -213,7 +213,7 @@ internal sealed class ReportOverlay
         bool interactive)
     {
         var drawList = ImGui.GetWindowDrawList();
-        var hovered = interactive && ImGui.IsMouseHoveringRect(rect.Min, rect.Max);
+        var hovered = interactive && UiInteract.Hover(rect.Min, rect.Max);
         var fill = hovered ? Palette.Mix(theme.SurfaceMuted, theme.TextStrong, 0.06f) : theme.SurfaceMuted;
         Squircle.Fill(drawList, rect.Min, rect.Max, 12f * s, ImGui.GetColorU32(Palette.WithAlpha(fill, opacity)));
         Squircle.Stroke(drawList, rect.Min, rect.Max, 12f * s,
@@ -255,7 +255,7 @@ internal sealed class ReportOverlay
                 var textSize = Typography.Measure(service.ReasonDraft, FieldTextScale * cardScale);
                 var textLeft = rect.Min.X + 14f * s;
                 var textMaxWidth = rect.Max.X - 14f * s - textLeft;
-                var reasonHovering = ImGui.IsMouseHoveringRect(rect.Min, rect.Max);
+                var reasonHovering = UiInteract.Hover(rect.Min, rect.Max);
                 Marquee.DrawLeft("reportoverlay.reason", service.ReasonDraft, textLeft,
                     rect.Center.Y - textSize.Y * 0.5f, textMaxWidth, new TextStyle(FieldTextScale * cardScale,
                         FontWeight.Regular), Palette.WithAlpha(theme.TextStrong, opacity), reasonHovering);

--- a/src/Aetherphone/Windows/Components/ReportOverlay.cs
+++ b/src/Aetherphone/Windows/Components/ReportOverlay.cs
@@ -90,8 +90,7 @@ internal sealed class ReportOverlay
                 return;
             }
 
-            if (!service.Busy && ImGui.IsMouseClicked(ImGuiMouseButton.Left) &&
-                !UiInteract.Hover(cardRect.Min, cardRect.Max))
+            if (!service.Busy && UiInteract.ClickedOutside(cardRect.Min, cardRect.Max))
             {
                 service.Dismiss();
             }

--- a/src/Aetherphone/Windows/Components/SceneChrome.cs
+++ b/src/Aetherphone/Windows/Components/SceneChrome.cs
@@ -22,7 +22,7 @@ internal static class SceneChrome
         var hitMin = new Vector2(content.Min.X, content.Min.Y);
         var hitMax = new Vector2(content.Min.X + 46f * scale, content.Min.Y + 40f * scale);
         UiAnchors.Report("chrome.back", new Rect(hitMin, hitMax));
-        var hovered = ImGui.IsMouseHoveringRect(hitMin, hitMax);
+        var hovered = UiInteract.Hover(hitMin, hitMax);
         var center = new Vector2(content.Min.X + 15f * scale, rowCenterY);
         if (BackButton.Draw("chrome.back", center, 15f * scale, ink, hovered, scale, shadow: true))
         {

--- a/src/Aetherphone/Windows/Components/Scrubber.cs
+++ b/src/Aetherphone/Windows/Components/Scrubber.cs
@@ -42,6 +42,6 @@ internal static class Scrubber
         var midY = track.Center.Y;
         var hitMin = new Vector2(track.Min.X - 6f * scale, midY - 14f * scale);
         var hitMax = new Vector2(track.Max.X + 6f * scale, midY + 14f * scale);
-        return ImGui.IsMouseHoveringRect(hitMin, hitMax);
+        return UiInteract.Hover(hitMin, hitMax);
     }
 }

--- a/src/Aetherphone/Windows/Components/SearchField.cs
+++ b/src/Aetherphone/Windows/Components/SearchField.cs
@@ -94,7 +94,7 @@ internal static class SearchField
             return;
         }
 
-        var hovered = ImGui.IsMouseHoveringRect(clearCenter - new Vector2(clearRadius, clearRadius),
+        var hovered = UiInteract.Hover(clearCenter - new Vector2(clearRadius, clearRadius),
             clearCenter + new Vector2(clearRadius, clearRadius));
         drawList.AddCircleFilled(clearCenter, clearRadius,
             ImGui.GetColorU32(hovered ? mutedInk : clearFill), 16);

--- a/src/Aetherphone/Windows/Components/SegmentStrip.cs
+++ b/src/Aetherphone/Windows/Components/SegmentStrip.cs
@@ -76,7 +76,7 @@ internal static class SegmentStrip
             var center = new Vector2(trackMin.X + (index + 0.5f) * segmentWidth, row.Center.Y);
             var proximity = 1f - Math.Clamp(MathF.Abs(position - index), 0f, 1f);
             var color = Vector4.Lerp(mutedInk, activeInk, proximity);
-            var hovering = ImGui.IsMouseHoveringRect(segmentMin, segmentMax);
+            var hovering = UiInteract.Hover(segmentMin, segmentMax);
             var labelHeight = Typography.Measure(options[index], textScale, FontWeight.SemiBold).Y;
             Marquee.DrawCentered(id + "." + index, options[index], center.X, center.Y - labelHeight * 0.5f,
                 labelMaxWidth, new TextStyle(textScale, FontWeight.SemiBold), color, hovering);

--- a/src/Aetherphone/Windows/Components/SettingsRow.cs
+++ b/src/Aetherphone/Windows/Components/SettingsRow.cs
@@ -33,14 +33,14 @@ internal static class SettingsRow
         var labelCap = MathF.Max(1f, available - valueFullSize.X);
         var labelSize = Typography.Measure(label, TextStyles.BodyEmphasized);
         var labelY = row.Center.Y - labelSize.Y * 0.5f;
-        var labelHovered = ImGui.IsMouseHoveringRect(new Vector2(row.Min.X, row.Min.Y),
+        var labelHovered = UiInteract.Hover(new Vector2(row.Min.X, row.Min.Y),
             new Vector2(row.Min.X + labelCap, row.Max.Y));
         var rowId = id ?? label;
         var labelWidth = Marquee.DrawLeft(rowId, label, row.Min.X, labelY, labelCap, TextStyles.BodyEmphasized,
             theme.TextStrong, labelHovered);
         var valueMaxWidth = MathF.Max(1f, available - labelWidth);
         var valueY = row.Center.Y - valueFullSize.Y * 0.5f;
-        var valueHovered = ImGui.IsMouseHoveringRect(new Vector2(row.Max.X - valueMaxWidth, row.Min.Y),
+        var valueHovered = UiInteract.Hover(new Vector2(row.Max.X - valueMaxWidth, row.Min.Y),
             new Vector2(row.Max.X, row.Max.Y));
         Marquee.DrawRight(rowId + ":infoValue", value, row.Max.X, valueY, valueMaxWidth, TextStyles.Body,
             theme.TextMuted, valueHovered);
@@ -171,7 +171,7 @@ internal static class SettingsRow
 
         var labelSize = Typography.Measure(label, TextStyles.BodyEmphasized);
         var labelY = row.Center.Y - labelSize.Y * 0.5f;
-        var labelHovered = ImGui.IsMouseHoveringRect(new Vector2(labelStartX, row.Min.Y),
+        var labelHovered = UiInteract.Hover(new Vector2(labelStartX, row.Min.Y),
             new Vector2(labelStartX + labelCap, row.Max.Y));
         var labelWidth = Marquee.DrawLeft(rowId, label, labelStartX, labelY, labelCap, TextStyles.BodyEmphasized,
             theme.TextStrong, labelHovered);
@@ -184,7 +184,7 @@ internal static class SettingsRow
         var valueMaxWidth = MathF.Max(1f, valueBoxRight - labelStartX - labelWidth - midGap);
         var valueSize = Typography.Measure(value, TextStyles.Body);
         var valueY = row.Center.Y - valueSize.Y * 0.5f;
-        var valueHovered = ImGui.IsMouseHoveringRect(new Vector2(valueBoxRight - valueMaxWidth, row.Min.Y),
+        var valueHovered = UiInteract.Hover(new Vector2(valueBoxRight - valueMaxWidth, row.Min.Y),
             new Vector2(valueBoxRight, row.Max.Y));
         Marquee.DrawRight(rowId + ":value", value, valueBoxRight, valueY, valueMaxWidth, TextStyles.Body,
             theme.TextMuted, valueHovered);

--- a/src/Aetherphone/Windows/Components/SetupOverlay.Pages.cs
+++ b/src/Aetherphone/Windows/Components/SetupOverlay.Pages.cs
@@ -515,7 +515,7 @@ internal sealed partial class SetupOverlay
         bool live)
     {
         var scale = ImGuiHelpers.GlobalScale;
-        var hovered = live && ImGui.IsMouseHoveringRect(rect.Min, rect.Max);
+        var hovered = live && UiInteract.Hover(rect.Min, rect.Max);
         var radius = 14f * scale;
         var fill = hovered ? Fade(accent, 0.16f * alpha) : Fade(CardFill, alpha);
         Squircle.Fill(drawList, rect.Min, rect.Max, radius, ImGui.GetColorU32(fill));
@@ -671,7 +671,7 @@ internal sealed partial class SetupOverlay
         bool live, bool enabled = true)
     {
         var scale = ImGuiHelpers.GlobalScale;
-        var hovered = live && enabled && ImGui.IsMouseHoveringRect(rect.Min, rect.Max);
+        var hovered = live && enabled && UiInteract.Hover(rect.Min, rect.Max);
         var fill = hovered ? Palette.Mix(accent, Vector4.One, 0.14f) : accent;
         Squircle.Fill(drawList, rect.Min, rect.Max, 15f * scale,
             ImGui.GetColorU32(Fade(fill, (enabled ? 1f : 0.4f) * alpha)));
@@ -688,7 +688,7 @@ internal sealed partial class SetupOverlay
     private static bool Secondary(ImDrawListPtr drawList, Rect rect, string label, float alpha, bool live)
     {
         var scale = ImGuiHelpers.GlobalScale;
-        var hovered = live && ImGui.IsMouseHoveringRect(rect.Min, rect.Max);
+        var hovered = live && UiInteract.Hover(rect.Min, rect.Max);
         var fill = hovered ? 0.16f : 0.09f;
         Squircle.Fill(drawList, rect.Min, rect.Max, 15f * scale,
             ImGui.GetColorU32(new Vector4(1f, 1f, 1f, fill * alpha)));
@@ -707,7 +707,7 @@ internal sealed partial class SetupOverlay
         var scale = ImGuiHelpers.GlobalScale;
         var size = Typography.Measure(label, TextStyles.SubheadlineEmphasized);
         var padding = new Vector2(10f * scale, 8f * scale);
-        var hovered = live && ImGui.IsMouseHoveringRect(center - size * 0.5f - padding, center + size * 0.5f + padding);
+        var hovered = live && UiInteract.Hover(center - size * 0.5f - padding, center + size * 0.5f + padding);
         var ink = hovered ? Palette.Mix(accent, Vector4.One, 0.25f) : accent;
         Typography.DrawCentered(drawList, center, label, Fade(ink, alpha), TextStyles.SubheadlineEmphasized);
         if (hovered)

--- a/src/Aetherphone/Windows/Components/SetupOverlay.cs
+++ b/src/Aetherphone/Windows/Components/SetupOverlay.cs
@@ -280,7 +280,7 @@ internal sealed partial class SetupOverlay : IDisposable
         var scale = ImGuiHelpers.GlobalScale;
         var center = new Vector2(screen.Min.X + 26f * scale, screen.Min.Y + 30f * scale);
         var half = 16f * scale;
-        var hovered = live && ImGui.IsMouseHoveringRect(center - new Vector2(half, half),
+        var hovered = live && UiInteract.Hover(center - new Vector2(half, half),
             center + new Vector2(half, half));
         var ink = hovered ? InkStrong : InkMuted;
         AppSkin.Icon(drawList, center, FontAwesomeIcon.ChevronLeft.ToIconString(), ink with { W = ink.W * alpha },

--- a/src/Aetherphone/Windows/Components/ShareSheet.cs
+++ b/src/Aetherphone/Windows/Components/ShareSheet.cs
@@ -69,7 +69,7 @@ internal sealed class ShareSheet
                 return;
             }
 
-            if (ImGui.IsMouseClicked(ImGuiMouseButton.Left) && !ImGui.IsMouseHoveringRect(panel.Min, panel.Max))
+            if (ImGui.IsMouseClicked(ImGuiMouseButton.Left) && !UiInteract.Hover(panel.Min, panel.Max))
             {
                 service.Dismiss();
             }
@@ -148,7 +148,7 @@ internal sealed class ShareSheet
         Vector2 cellMin, float cellWidth, float cellHeight, float scale, float opacity, bool interactive)
     {
         var cellMax = cellMin + new Vector2(cellWidth, cellHeight);
-        var hovered = interactive && ImGui.IsMouseHoveringRect(cellMin, cellMax);
+        var hovered = interactive && UiInteract.Hover(cellMin, cellMax);
         var tileSize = TileSize * scale;
         var tileCenter = new Vector2(cellMin.X + cellWidth * 0.5f, cellMin.Y + tileSize * 0.5f);
         var tileMin = new Vector2(tileCenter.X - tileSize * 0.5f, tileCenter.Y - tileSize * 0.5f);

--- a/src/Aetherphone/Windows/Components/ShareSheet.cs
+++ b/src/Aetherphone/Windows/Components/ShareSheet.cs
@@ -69,7 +69,7 @@ internal sealed class ShareSheet
                 return;
             }
 
-            if (ImGui.IsMouseClicked(ImGuiMouseButton.Left) && !UiInteract.Hover(panel.Min, panel.Max))
+            if (UiInteract.ClickedOutside(panel.Min, panel.Max))
             {
                 service.Dismiss();
             }

--- a/src/Aetherphone/Windows/Components/SideButton.cs
+++ b/src/Aetherphone/Windows/Components/SideButton.cs
@@ -25,7 +25,7 @@ internal sealed class SideButton
         var scale = ImGuiHelpers.GlobalScale;
         var hitMin = new Vector2(bounds.Min.X - 8f * scale, bounds.Min.Y - 8f * scale);
         var hitMax = new Vector2(bounds.Max.X + 4f * scale, bounds.Max.Y + 8f * scale);
-        var hovered = ImGui.IsMouseHoveringRect(hitMin, hitMax);
+        var hovered = UiInteract.Hover(hitMin, hitMax);
         var action = SideButtonAction.None;
         if (hovered && ImGui.IsMouseClicked(ImGuiMouseButton.Left))
         {

--- a/src/Aetherphone/Windows/Components/SideToggle.cs
+++ b/src/Aetherphone/Windows/Components/SideToggle.cs
@@ -12,7 +12,7 @@ internal static class SideToggle
         var scale = ImGuiHelpers.GlobalScale;
         var hitMin = new Vector2(bounds.Min.X - 8f * scale, bounds.Min.Y - 6f * scale);
         var hitMax = new Vector2(bounds.Max.X + 4f * scale, bounds.Max.Y + 6f * scale);
-        var hovered = ImGui.IsMouseHoveringRect(hitMin, hitMax);
+        var hovered = UiInteract.Hover(hitMin, hitMax);
         var press = hovered && ImGui.IsMouseDown(ImGuiMouseButton.Left) ? 1f : 0f;
         HardwareButton.Draw(ImGui.GetWindowDrawList(), bounds, theme, RailSide.Left, hovered, press, active ? 1f : 0f);
         if (hovered)

--- a/src/Aetherphone/Windows/Components/SocialActivityList.cs
+++ b/src/Aetherphone/Windows/Components/SocialActivityList.cs
@@ -85,7 +85,7 @@ internal static class SocialActivityList
         DrawTypeBadge(drawList, avatarCenter + new Vector2(radius - 4f * scale, radius - 4f * scale), item.Type,
             theme, scale);
         var textTop = origin.Y + (rowHeight - contentHeight) * 0.5f;
-        var rowHovering = ImGui.IsMouseHoveringRect(origin, rowMax);
+        var rowHovering = UiInteract.Hover(origin, rowMax);
         Marquee.DrawLeft("socialactivity.actor." + item.Id, actorLabel, textLeft, textTop, textWidth,
             new TextStyle(0.95f, FontWeight.SemiBold), theme.TextStrong, rowHovering);
         Typography.Draw(new Vector2(origin.X + width - pad - timeSize.X, textTop + 2f * scale), timeText,

--- a/src/Aetherphone/Windows/Components/SocialProfilePages.cs
+++ b/src/Aetherphone/Windows/Components/SocialProfilePages.cs
@@ -696,7 +696,7 @@ internal sealed class SocialProfilePages
         var textMaxWidth = origin.X + width - pad - buttonWidth - 10f * scale - textLeft;
         var nameY = origin.Y + nameTop * scale;
         var nameSize = Typography.Measure(displayName, 1f, FontWeight.SemiBold);
-        var nameHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, nameY),
+        var nameHovering = UiInteract.Hover(new Vector2(textLeft, nameY),
             new Vector2(textLeft + textMaxWidth, nameY + nameSize.Y));
         Marquee.DrawLeft("socialprofile.row.name." + user.Id, displayName, textLeft, nameY,
             textMaxWidth, new TextStyle(1f, FontWeight.SemiBold), theme.TextStrong, nameHovering);
@@ -706,7 +706,7 @@ internal sealed class SocialProfilePages
         var sub = SocialIdentity.ProfileMeta(user.Handle, regionCode);
         var subY = origin.Y + subTop * scale;
         var subSize = Typography.Measure(sub, 0.85f);
-        var subHovering = ImGui.IsMouseHoveringRect(new Vector2(textLeft, subY),
+        var subHovering = UiInteract.Hover(new Vector2(textLeft, subY),
             new Vector2(textLeft + textMaxWidth, subY + subSize.Y));
         Marquee.DrawLeft("socialprofile.row.sub." + user.Id, sub, textLeft, subY,
             textMaxWidth, new TextStyle(0.85f, FontWeight.Regular), style.Palette.MutedInk, subHovering);

--- a/src/Aetherphone/Windows/Components/StepperField.cs
+++ b/src/Aetherphone/Windows/Components/StepperField.cs
@@ -29,7 +29,7 @@ internal static class StepperField
 
     private static bool DrawChevron(AppSkin ui, ImDrawListPtr drawList, Rect rect, string chevron, float scale)
     {
-        if (ImGui.IsMouseHoveringRect(rect.Min, rect.Max))
+        if (UiInteract.Hover(rect.Min, rect.Max))
         {
             Squircle.Fill(drawList, rect.Min, rect.Max, Metrics.Radius.Sm * scale, ImGui.GetColorU32(ui.HoverTint));
         }

--- a/src/Aetherphone/Windows/Components/StoryTrayRow.cs
+++ b/src/Aetherphone/Windows/Components/StoryTrayRow.cs
@@ -95,7 +95,7 @@ internal sealed class StoryTrayRow
 
     private void HandleDrag(Rect row)
     {
-        var hovering = ImGui.IsMouseHoveringRect(row.Min, row.Max);
+        var hovering = UiInteract.Hover(row.Min, row.Max);
         if (hovering && ImGui.IsMouseClicked(ImGuiMouseButton.Left))
         {
             dragging = true;

--- a/src/Aetherphone/Windows/Components/StoryViewerOverlay.cs
+++ b/src/Aetherphone/Windows/Components/StoryViewerOverlay.cs
@@ -333,7 +333,7 @@ internal sealed class StoryViewerOverlay
         {
             AppSkin.Icon(sendCenter, FontAwesomeIcon.PaperPlane.ToIconString(), new Vector4(1f, 1f, 1f, 0.95f), 1f);
             var hit = new Vector2(14f * scale, 14f * scale);
-            if (ImGui.IsMouseHoveringRect(sendCenter - hit, sendCenter + hit))
+            if (UiInteract.Hover(sendCenter - hit, sendCenter + hit))
             {
                 ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
                 if (ImGui.IsMouseClicked(ImGuiMouseButton.Left))
@@ -377,7 +377,7 @@ internal sealed class StoryViewerOverlay
             var center = new Vector2(barMin.X + slot * (emojiIndex + 0.5f), rowCenterY);
             var half = side * 0.5f;
             var hovered = eased > 0.5f
-                && ImGui.IsMouseHoveringRect(center - new Vector2(half, half), center + new Vector2(half, half));
+                && UiInteract.Hover(center - new Vector2(half, half), center + new Vector2(half, half));
             var drawHalf = hovered ? half * 1.15f : half;
             EmojiImages.TryDraw(drawList, QuickEmojiFiles[emojiIndex], center - new Vector2(drawHalf, drawHalf),
                 center + new Vector2(drawHalf, drawHalf), tint);
@@ -520,7 +520,7 @@ internal sealed class StoryViewerOverlay
         var stamp = TimeText.Short(viewer.ViewedAtUnix);
         var stampSize = Typography.Measure(stamp, TextStyles.Caption1);
         var nameMaxWidth = MathF.Max(1f, origin.X + width - stampSize.X - 16f * scale - left);
-        var rowHovering = ImGui.IsMouseHoveringRect(origin, new Vector2(origin.X + width, origin.Y + height));
+        var rowHovering = UiInteract.Hover(origin, new Vector2(origin.X + width, origin.Y + height));
         var nameSize = Typography.Measure(name, TextStyles.Subheadline);
         Marquee.DrawLeft("storyviewer.name." + viewer.Handle, name, left, center.Y - nameSize.Y * 0.5f,
             nameMaxWidth, TextStyles.Subheadline, theme.TextStrong, rowHovering);
@@ -532,13 +532,13 @@ internal sealed class StoryViewerOverlay
 
     private void HandleInput(Rect area, float delta, bool imageReady, Rect replyZone)
     {
-        var hovering = ImGui.IsMouseHoveringRect(area.Min, area.Max);
+        var hovering = UiInteract.Hover(area.Min, area.Max);
         if (hovering && ImGui.IsMouseClicked(ImGuiMouseButton.Left))
         {
             pressStartedAt = ImGui.GetTime();
             pressOrigin = ImGui.GetIO().MousePos;
             pressInReplyZone = replyPrompt is not null
-                && ImGui.IsMouseHoveringRect(replyZone.Min, replyZone.Max);
+                && UiInteract.Hover(replyZone.Min, replyZone.Max);
         }
 
         var down = ImGui.IsMouseDown(ImGuiMouseButton.Left);
@@ -716,7 +716,7 @@ internal sealed class StoryViewerOverlay
         var stamp = TimeText.Short(story.CreatedAtUnix);
         var stampWidth = Typography.Measure(stamp, TextStyles.Footnote).X;
         var nameMaxWidth = MathF.Max(1f, row.Max.X - closeReserve - stampWidth - 8f * scale - left);
-        var headerHovering = ImGui.IsMouseHoveringRect(row.Min, row.Max);
+        var headerHovering = UiInteract.Hover(row.Min, row.Max);
         var nameSize = Typography.Measure(authorLabel, TextStyles.SubheadlineEmphasized);
         var nameWidth = Marquee.DrawLeft("storyviewer.header.author." + authorLabel, authorLabel, left,
             row.Center.Y - nameSize.Y * 0.5f, nameMaxWidth, TextStyles.SubheadlineEmphasized,

--- a/src/Aetherphone/Windows/Components/SubmitField.cs
+++ b/src/Aetherphone/Windows/Components/SubmitField.cs
@@ -54,7 +54,7 @@ internal static class SubmitField
             return submitted;
         }
 
-        var hovered = ImGui.IsMouseHoveringRect(clearCenter - new Vector2(clearRadius, clearRadius),
+        var hovered = UiInteract.Hover(clearCenter - new Vector2(clearRadius, clearRadius),
             clearCenter + new Vector2(clearRadius, clearRadius));
         drawList.AddCircleFilled(clearCenter, clearRadius,
             ImGui.GetColorU32(hovered ? theme.TextMuted : theme.SurfaceMuted), 16);

--- a/src/Aetherphone/Windows/Components/SwatchStrip.cs
+++ b/src/Aetherphone/Windows/Components/SwatchStrip.cs
@@ -53,7 +53,7 @@ internal static class SwatchStrip
 
             var min = center - new Vector2(radius, radius);
             var max = center + new Vector2(radius, radius);
-            if (!ImGui.IsMouseHoveringRect(min, max))
+            if (!UiInteract.Hover(min, max))
             {
                 continue;
             }

--- a/src/Aetherphone/Windows/Components/TransportButton.cs
+++ b/src/Aetherphone/Windows/Components/TransportButton.cs
@@ -19,7 +19,7 @@ internal static class TransportButton
     {
         var drawList = drawListOverride ?? ImGui.GetWindowDrawList();
         var hovered = active &&
-                      ImGui.IsMouseHoveringRect(center - new Vector2(radius, radius),
+                      UiInteract.Hover(center - new Vector2(radius, radius),
                           center + new Vector2(radius, radius));
         if (hovered)
         {

--- a/src/Aetherphone/Windows/Components/UiInteract.cs
+++ b/src/Aetherphone/Windows/Components/UiInteract.cs
@@ -47,6 +47,27 @@ internal static class UiInteract
     public static bool Hover(Vector2 min, Vector2 max) =>
         !InputBlocked && !MouseOverOverlay && WindowHovered && ImGui.IsMouseHoveringRect(min, max);
 
+    /// <summary>
+    /// <see cref="Hover(Vector2, Vector2)"/> without the <see cref="InputBlocked"/> or
+    /// <see cref="MouseOverOverlay"/> gates, for content that is itself the reason those gates are set
+    /// this frame: a dropdown/picker drawn while its host calls <see cref="BlockThisFrame"/>, or a drag
+    /// start zone that must stay live independent of another overlay's reservation.
+    /// </summary>
+    public static bool HoverWindowOnly(Vector2 min, Vector2 max) => WindowHovered && ImGui.IsMouseHoveringRect(min, max);
+
+    public static bool HoverWindowOnly(Vector2 min, Vector2 max, bool clip) =>
+        WindowHovered && ImGui.IsMouseHoveringRect(min, max, clip);
+
+    /// <summary>
+    /// True when the left mouse button was just clicked inside this phone window but outside
+    /// <paramref name="min"/>/<paramref name="max"/> — the standard "tap outside to dismiss" test.
+    /// Unlike a negated <see cref="Hover"/>, requiring <see cref="WindowHovered"/> directly means a
+    /// click that lands in an unrelated window (where <see cref="WindowHovered"/> is false) can't be
+    /// mistaken for an outside-click on an overlay it never touched.
+    /// </summary>
+    public static bool ClickedOutside(Vector2 min, Vector2 max) =>
+        WindowHovered && ImGui.IsMouseClicked(ImGuiMouseButton.Left) && !ImGui.IsMouseHoveringRect(min, max);
+
     public static bool Hover(Vector2 min, Vector2 max, bool clip) =>
         !InputBlocked && !MouseOverOverlay && WindowHovered && ImGui.IsMouseHoveringRect(min, max, clip);
 

--- a/src/Aetherphone/Windows/Components/UiInteract.cs
+++ b/src/Aetherphone/Windows/Components/UiInteract.cs
@@ -15,10 +15,20 @@ internal static class UiInteract
     private static Vector2 pendingTapMax;
     private static Vector2 pendingTapWindowPos;
     private static bool hasPendingTap;
+    private static bool windowHovered = true;
+    private static int windowHoveredFrame = -1;
 
     public static void BlockThisFrame() => blockedFrame = ImGui.GetFrameCount();
 
     public static bool InputBlocked => blockedFrame == ImGui.GetFrameCount();
+
+    public static void SetWindowHovered(bool hovered)
+    {
+        windowHovered = hovered;
+        windowHoveredFrame = ImGui.GetFrameCount();
+    }
+
+    private static bool WindowHovered => windowHoveredFrame != ImGui.GetFrameCount() || windowHovered;
 
     /// <summary>Discards the in-flight tap without activating it (called when a drag starts).</summary>
     public static void CancelPendingTap() => hasPendingTap = false;
@@ -27,7 +37,7 @@ internal static class UiInteract
     {
         overlayRect = rect;
         overlayFrame = ImGui.GetFrameCount();
-        return !InputBlocked && ImGui.IsMouseHoveringRect(rect.Min, rect.Max);
+        return !InputBlocked && WindowHovered && ImGui.IsMouseHoveringRect(rect.Min, rect.Max);
     }
 
     private static bool MouseOverOverlay =>
@@ -35,7 +45,10 @@ internal static class UiInteract
         ImGui.IsMouseHoveringRect(overlayRect.Min, overlayRect.Max, false);
 
     public static bool Hover(Vector2 min, Vector2 max) =>
-        !InputBlocked && !MouseOverOverlay && ImGui.IsMouseHoveringRect(min, max);
+        !InputBlocked && !MouseOverOverlay && WindowHovered && ImGui.IsMouseHoveringRect(min, max);
+
+    public static bool Hover(Vector2 min, Vector2 max, bool clip) =>
+        !InputBlocked && !MouseOverOverlay && WindowHovered && ImGui.IsMouseHoveringRect(min, max, clip);
 
     /// <summary>
     /// Release-triggered activation for a rect the caller has already hover-tested, so a drag can
@@ -51,6 +64,7 @@ internal static class UiInteract
     /// </remarks>
     public static bool Click(Vector2 min, Vector2 max, bool hovered)
     {
+        hovered = hovered && WindowHovered;
         if (!ImGui.IsMouseDown(ImGuiMouseButton.Left) && !ImGui.IsMouseReleased(ImGuiMouseButton.Left))
         {
             hasPendingTap = false;

--- a/src/Aetherphone/Windows/PhoneWindow.cs
+++ b/src/Aetherphone/Windows/PhoneWindow.cs
@@ -202,7 +202,8 @@ internal sealed class PhoneWindow : Window
     {
         LastPosition = ImGui.GetWindowPos();
         LastSize = ImGui.GetWindowSize();
-        Components.UiInteract.SetWindowHovered(ImGui.IsWindowHovered(ImGuiHoveredFlags.ChildWindows));
+        Components.UiInteract.SetWindowHovered(ImGui.IsWindowHovered(
+            ImGuiHoveredFlags.ChildWindows | ImGuiHoveredFlags.AllowWhenBlockedByActiveItem));
         Plugin.Updates.Poll();
         using (Plugin.Fonts.Push(1f))
         {

--- a/src/Aetherphone/Windows/PhoneWindow.cs
+++ b/src/Aetherphone/Windows/PhoneWindow.cs
@@ -202,6 +202,7 @@ internal sealed class PhoneWindow : Window
     {
         LastPosition = ImGui.GetWindowPos();
         LastSize = ImGui.GetWindowSize();
+        Components.UiInteract.SetWindowHovered(ImGui.IsWindowHovered(ImGuiHoveredFlags.ChildWindows));
         Plugin.Updates.Poll();
         using (Plugin.Fonts.Push(1f))
         {


### PR DESCRIPTION
## Summary

The phone accepted clicks and hovers even when a different Dalamud window sat on top of it. Every row, button, and gesture used raw ImGui rect checks that never asked which window ImGui considers hovered this frame, so clicks passed straight through a plugin window drawn on top.

## Root cause

`UiInteract.Hover()` already existed as the shared hit-test primitive most of the app calls through, but it never checked window ownership. `PhoneWindow.Draw()` now records `ImGui.IsWindowHovered(ImGuiHoveredFlags.ChildWindows)` once per frame; `Hover()` and `Click()` both gate on that. `Click()` also re-checks it directly, so a call site with its own hover test still can't fire an action while another window occludes the phone.

The same gap showed up outside `UiInteract` in a few shared components that predate it or duplicate its logic locally: `Marquee`'s auto-hover variants, `DragTracker.Begin` (Control Center's swipe, Notification Center's swipe-to-dismiss), `HomeInteractionController`'s tap and magnify hover, and the Games framework's `RestartButton`/`Button`. Fixed once in each, which covers every caller.

## Per-area

- `UiInteract`: window-hover gate, a 3-arg `Hover` overload for the existing `clip` parameter, and `Click()` hardened as a backstop for callers with a raw hover test.
- `PhoneWindow`: records window-hover state once per frame before any hit test runs.
- Home screen: tile taps, magnify hover, page dots/arrows, edit-mode Add/Done, folder contents, widget gallery and size menu.
- Control Center: tile press/drag-start, swipe-open/dismiss, top-band cursor.
- Dynamic Island, camera controls, notification center and banners, chat bubbles/transcript/menu, roughly twenty mini-games' board input, and every remaining `Marquee`/hover call site in the app. Same pattern each time.
- `Games/Flow`: kept a plain bounds check for the in-progress drag path. Routing it through `UiInteract.Hover` let `DragScrollHost`'s scroll-vs-tap heuristic set `InputBlocked` mid-drag and freeze the pipe being drawn. Only the initiating press is gated now, matching the pattern already used for the home screen's drag continuation and Solitaire's card grab.

## Test plan

- `dotnet build` clean after each change
- Verified in-game via full plugin reload across Home, Control Center, Dynamic Island, Camera, Notifications, Message/social apps, and the affected mini-games, with a Dalamud window held on top