### PR TITLE
feat(jobs): drag to reorder custom job categories and their gearsets

### DIFF
--- a/src/Aetherphone/Apps/Jobs/JobsApp.Categories.cs
+++ b/src/Aetherphone/Apps/Jobs/JobsApp.Categories.cs
@@ -16,6 +16,13 @@ internal sealed partial class JobsApp
     private const float EditorTitleHeight = 18f;
     private const float EditorFieldHeight = 30f;
     private const int CategoryNameMaxLength = 24;
+    private const float CategoryDragHandleRadius = 9f;
+
+    // Matches AetherStreamQueue's own reorder drag threshold - the phone-appears-to-move bug
+    // turned out to be DragScrollHost racing the handle for the same press (fixed via
+    // surface.CancelDrag() in JobsApp.cs), not a timing race with the window lock, so there's no
+    // need for a long-press dead zone here after all.
+    private const float DragThreshold = 7f;
 
     private static readonly List<JobsCategory> NoCategories = new();
 
@@ -25,6 +32,27 @@ internal sealed partial class JobsApp
     private int categoryEditorOpenedFrame;
     private string categoryEditorName = string.Empty;
     private bool focusCategoryField;
+
+    // Rebuilt every frame from the on-screen custom section headers (see JobsApp.cs's main draw
+    // loop) - used both to place each header's drag handle and, once a drag is active, to find
+    // the nearest header to the cursor as the drop target. Header heights are fixed but section
+    // card heights vary with gearset count, so target detection compares against real header
+    // positions rather than assuming a uniform row height (contrast AetherStreamQueue.Reorder's
+    // drag, where every row is the same height).
+    private readonly List<(int CategoryIndex, Rect Rect)> categoryHeaderRects = new();
+    private int categoryDragIndex = -1;
+    private Vector2 categoryDragPressPos;
+    private bool categoryDragActive;
+
+    // Reordering the jobs/gearsets *within* one custom category - separate from the header drag
+    // above, which reorders the categories themselves. Rows inside a section are uniform height
+    // (RowHeight), so this can use AetherStreamQueue's simpler displaced-row drag math instead of
+    // the nearest-header search the variable-height category headers need.
+    private int jobDragCategoryIndex = -1;
+    private int jobDragIndex = -1;
+    private Vector2 jobDragStart;
+    private float jobDragY;
+    private bool jobDragActive;
 
     private List<JobsCategory> CurrentCategories()
     {
@@ -87,6 +115,244 @@ internal sealed partial class JobsApp
         }
 
         OpenCategoryEditor(picked, -1);
+    }
+
+    // Grip handle on a custom section's header - press-and-hold past the threshold starts a
+    // drag, mirroring AetherStreamQueue's own reorder gesture. Also registers this header's rect
+    // for this frame's drop-target search, so callers must invoke this for every custom section
+    // before UpdateCategoryDrag runs.
+    //
+    // A real InvisibleButton, not just UiInteract.Hover's raw mouse-position check: Dear ImGui
+    // starts its own native window-drag whenever a press lands on the window background with no
+    // item active, regardless of LockPosition (that only adds NoMove). Without an actual active
+    // item here, pressing the handle on an unlocked phone would drag the whole phone instead of
+    // starting a reorder.
+    private void DrawCategoryDragHandle(Rect headerRect, int categoryIndex, float scale)
+    {
+        categoryHeaderRects.Add((categoryIndex, headerRect));
+
+        var drawList = ImGui.GetWindowDrawList();
+        var radius = CategoryDragHandleRadius * scale;
+        var center = new Vector2(headerRect.Max.X - radius - 2f * scale, headerRect.Center.Y);
+        ImGui.SetCursorScreenPos(center - new Vector2(radius));
+        ImGui.InvisibleButton($"##categoryDragHandle{categoryIndex}", new Vector2(radius * 2f));
+        var hovered = ImGui.IsItemHovered();
+        var activated = ImGui.IsItemActivated();
+        var dragging = categoryDragIndex == categoryIndex;
+        var tint = dragging || hovered
+            ? ui.Accent
+            : Palette.WithAlpha(ui.MutedInk, ui.MutedInk.W * 0.6f);
+        AppSkin.Icon(drawList, center, FontAwesomeIcon.GripLinesVertical.ToIconString(), tint, 0.6f);
+
+        if (hovered)
+        {
+            ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
+        }
+
+        if (categoryDragIndex < 0 && activated)
+        {
+            categoryDragIndex = categoryIndex;
+            categoryDragPressPos = ImGui.GetMousePos();
+            categoryDragActive = false;
+        }
+    }
+
+    // Drives the drag state machine once per frame, after every custom header has registered
+    // itself this frame via DrawCategoryDragHandle. Deliberately runs outside the section loop
+    // (rather than inline per-row) since the drop-target search needs every header's rect, not
+    // just the ones drawn so far this frame.
+    private void UpdateCategoryDrag(float scale)
+    {
+        if (categoryDragIndex < 0)
+        {
+            return;
+        }
+
+        if (!ImGui.IsMouseDown(ImGuiMouseButton.Left))
+        {
+            if (categoryDragActive)
+            {
+                var targetIndex = ClosestCategoryHeader(ImGui.GetMousePos().Y);
+                if (targetIndex >= 0)
+                {
+                    ReorderCategory(categoryDragIndex, targetIndex);
+                }
+            }
+
+            categoryDragIndex = -1;
+            categoryDragActive = false;
+            return;
+        }
+
+        if (!categoryDragActive && Vector2.Distance(ImGui.GetMousePos(), categoryDragPressPos) >
+            DragThreshold * scale)
+        {
+            categoryDragActive = true;
+        }
+
+        if (!categoryDragActive)
+        {
+            return;
+        }
+
+        var hoverIndex = ClosestCategoryHeader(ImGui.GetMousePos().Y);
+        if (hoverIndex >= 0)
+        {
+            DrawCategoryDropHighlight(hoverIndex, scale);
+        }
+    }
+
+    private int ClosestCategoryHeader(float mouseY)
+    {
+        var best = -1;
+        var bestDistance = float.MaxValue;
+        for (var index = 0; index < categoryHeaderRects.Count; index++)
+        {
+            var distance = MathF.Abs(categoryHeaderRects[index].Rect.Center.Y - mouseY);
+            if (distance < bestDistance)
+            {
+                bestDistance = distance;
+                best = categoryHeaderRects[index].CategoryIndex;
+            }
+        }
+
+        return best;
+    }
+
+    private void DrawCategoryDropHighlight(int categoryIndex, float scale)
+    {
+        for (var index = 0; index < categoryHeaderRects.Count; index++)
+        {
+            if (categoryHeaderRects[index].CategoryIndex != categoryIndex)
+            {
+                continue;
+            }
+
+            var rect = categoryHeaderRects[index].Rect;
+            var drawList = ImGui.GetForegroundDrawList();
+            drawList.AddRectFilled(rect.Min, rect.Max, ImGui.GetColorU32(Palette.WithAlpha(ui.Accent, 0.16f)),
+                6f * scale);
+            return;
+        }
+    }
+
+    // A true move (remove then re-insert), not a plain adjacent swap - a single drag gesture can
+    // cross several other categories at once, unlike the old up/down-arrow version this replaced.
+    private void ReorderCategory(int fromIndex, int toIndex)
+    {
+        var categories = CurrentCategories();
+        if (fromIndex < 0 || fromIndex >= categories.Count || toIndex < 0 || toIndex >= categories.Count ||
+            fromIndex == toIndex)
+        {
+            return;
+        }
+
+        var item = categories[fromIndex];
+        categories.RemoveAt(fromIndex);
+        categories.Insert(toIndex, item);
+        configuration.Save();
+        Rebuild();
+    }
+
+    // Grip handle on a job row inside a custom category's card - same long-press-and-hold-still
+    // start as DrawCategoryDragHandle, but only one row (identified by categoryIndex+rowIndex) can
+    // claim the drag.
+    //
+    // A real InvisibleButton for the same reason as DrawCategoryDragHandle - without an active
+    // ImGui item under the press, Dear ImGui's own window-drag takes over instead, dragging the
+    // whole phone rather than starting a reorder. Returns whether the handle is hovered, so
+    // DrawJobRow can exclude that area from the row's own hover/equip-click handling.
+    private bool DrawJobDragHandle(ImDrawListPtr drawList, Vector2 center, float radius, int categoryIndex,
+        int rowIndex, float scale)
+    {
+        ImGui.SetCursorScreenPos(center - new Vector2(radius));
+        ImGui.InvisibleButton($"##jobDragHandle{categoryIndex}_{rowIndex}", new Vector2(radius * 2f));
+        var hovered = ImGui.IsItemHovered();
+        var activated = ImGui.IsItemActivated();
+
+        var dragging = jobDragCategoryIndex == categoryIndex && jobDragIndex == rowIndex;
+        var tint = dragging || hovered ? ui.Accent : Palette.WithAlpha(ui.MutedInk, ui.MutedInk.W * 0.6f);
+        AppSkin.Icon(drawList, center, FontAwesomeIcon.GripLines.ToIconString(), tint, 0.55f);
+
+        if (hovered)
+        {
+            ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
+        }
+
+        if (jobDragIndex < 0 && activated)
+        {
+            jobDragCategoryIndex = categoryIndex;
+            jobDragIndex = rowIndex;
+            jobDragStart = ImGui.GetMousePos();
+            jobDragY = 0f;
+            jobDragActive = false;
+        }
+
+        return hovered;
+    }
+
+    // Called once per custom section's card, before its rows are drawn - a no-op unless this is
+    // the specific category currently being dragged in.
+    private void UpdateJobDrag(int categoryIndex, JobEntry[] entries, float rowHeight, float scale)
+    {
+        if (jobDragCategoryIndex != categoryIndex || jobDragIndex < 0)
+        {
+            return;
+        }
+
+        if (!ImGui.IsMouseDown(ImGuiMouseButton.Left))
+        {
+            if (jobDragActive && jobDragIndex < entries.Length)
+            {
+                var targetIndex = Math.Clamp(jobDragIndex + (int)MathF.Round(jobDragY / rowHeight), 0,
+                    entries.Length - 1);
+                if (targetIndex != jobDragIndex)
+                {
+                    ReorderGearsetInCategory(categoryIndex, entries[jobDragIndex].GearsetId,
+                        entries[targetIndex].GearsetId);
+                }
+            }
+
+            jobDragCategoryIndex = -1;
+            jobDragIndex = -1;
+            jobDragActive = false;
+            return;
+        }
+
+        if (!jobDragActive && Vector2.Distance(ImGui.GetMousePos(), jobDragStart) > DragThreshold * scale)
+        {
+            jobDragActive = true;
+        }
+
+        if (jobDragActive)
+        {
+            jobDragY = ImGui.GetMousePos().Y - jobDragStart.Y;
+        }
+    }
+
+    // Moves fromGearsetId to sit where toGearsetId currently is, within one category's own
+    // GearsetIds list - matched by id rather than raw index so a stale id (a gearset removed from
+    // the game but not yet cleaned out of GearsetIds) can't desync the drag from the display.
+    private void ReorderGearsetInCategory(int categoryIndex, int fromGearsetId, int toGearsetId)
+    {
+        var categories = CurrentCategories();
+        if (categoryIndex < 0 || categoryIndex >= categories.Count)
+        {
+            return;
+        }
+
+        var gearsetIds = categories[categoryIndex].GearsetIds;
+        var fromIndex = gearsetIds.IndexOf(fromGearsetId);
+        var toIndex = gearsetIds.IndexOf(toGearsetId);
+        if (fromIndex < 0 || toIndex < 0 || fromIndex == toIndex)
+        {
+            return;
+        }
+
+        gearsetIds.RemoveAt(fromIndex);
+        gearsetIds.Insert(toIndex, fromGearsetId);
+        configuration.Save();
+        Rebuild();
     }
 
     private void DrawRowMenu(Rect content, PhoneTheme theme)

--- a/src/Aetherphone/Apps/Jobs/JobsApp.cs
+++ b/src/Aetherphone/Apps/Jobs/JobsApp.cs
@@ -170,7 +170,7 @@ internal sealed partial class JobsApp : IPhoneApp
                 Rebuild();
             }
 
-            using (AppSurface.Begin(body))
+            using (var surface = AppSurface.Begin(body))
             {
                 if (sections.Length == 0)
                 {
@@ -178,19 +178,43 @@ internal sealed partial class JobsApp : IPhoneApp
                 }
                 else
                 {
+                    categoryHeaderRects.Clear();
                     for (var index = 0; index < sections.Length; index++)
                     {
                         var section = sections[index];
                         var title = section.IsCustom ? section.CustomTitle : Loc.T(section.RoleTitle);
+                        var headerTop = ImGui.GetCursorScreenPos();
+                        var headerWidth = ImGui.GetContentRegionAvail().X;
                         ui.SectionHeading(title, index == 0 ? 8f : 4f);
+                        if (section.IsCustom)
+                        {
+                            var headerRect = new Rect(headerTop,
+                                new Vector2(headerTop.X + headerWidth, ImGui.GetCursorScreenPos().Y));
+                            DrawCategoryDragHandle(headerRect, section.CategoryIndex, scale);
+                        }
+
                         DrawSectionCard(section, scale);
                         ImGui.Dummy(new Vector2(0f, SectionGap * scale));
                     }
 
                     ImGui.Dummy(new Vector2(0f, 8f * scale));
                 }
+
+                // Fixes the phone appearing to move during a category/row drag: it was never the
+                // window's own position, it was DragScrollHost's kinetic scroll racing the drag
+                // handle for the exact same press. DragScrollHost.Begin runs before any row/handle
+                // this frame, so on the press's first frame it sees "no widget active yet" and
+                // happily starts its own scroll gesture on the same touch. Handing it back once a
+                // Jobs drag has been picked up (same pattern as SkywatcherApp's scrubber) stops
+                // that race outright.
+                if (categoryDragIndex >= 0 || jobDragIndex >= 0)
+                {
+                    surface.CancelDrag();
+                }
             }
         }
+
+        UpdateCategoryDrag(scale);
 
         DrawColorMenu(content, theme);
         DrawCategoriesMenu(content, theme);
@@ -325,19 +349,30 @@ internal sealed partial class JobsApp : IPhoneApp
                 Loc.T(L.Jobs.EmptyCategory), ui.MutedInk, TextStyles.Footnote, width - padding * 2f);
         }
 
+        if (section.IsCustom)
+        {
+            UpdateJobDrag(section.CategoryIndex, section.Entries, rowHeight, scale);
+        }
+
         var separator = ImGui.GetColorU32(new Vector4(1f, 1f, 1f, 0.06f));
         for (var index = 0; index < section.Entries.Length; index++)
         {
             var rowTop = min.Y + index * rowHeight;
-            var rowRect = new Rect(new Vector2(min.X, rowTop), new Vector2(max.X, rowTop + rowHeight));
-            var contentRect = new Rect(new Vector2(min.X + padding, rowTop), new Vector2(max.X - padding, rowTop + rowHeight));
+            var dragOffset = section.IsCustom && jobDragActive && jobDragCategoryIndex == section.CategoryIndex &&
+                jobDragIndex == index
+                ? jobDragY
+                : 0f;
+            var rowRect = new Rect(new Vector2(min.X, rowTop + dragOffset), new Vector2(max.X, rowTop + rowHeight + dragOffset));
+            var contentRect = new Rect(new Vector2(min.X + padding, rowTop + dragOffset),
+                new Vector2(max.X - padding, rowTop + rowHeight + dragOffset));
             if (!rowAnchorTaken)
             {
                 rowAnchorTaken = true;
                 UiAnchors.Report("jobs.row", rowRect);
             }
 
-            DrawJobRow(drawList, rowRect, contentRect, section.Entries[index], scale);
+            DrawJobRow(drawList, rowRect, contentRect, section.Entries[index], scale, section.IsCustom,
+                section.CategoryIndex, index);
             if (index > 0)
             {
                 drawList.AddLine(new Vector2(min.X + padding, rowTop), new Vector2(max.X - padding, rowTop), separator,
@@ -349,15 +384,25 @@ internal sealed partial class JobsApp : IPhoneApp
         ImGui.Dummy(new Vector2(width, rowCount * rowHeight));
     }
 
-    private void DrawJobRow(ImDrawListPtr drawList, Rect rowRect, Rect contentRect, JobEntry job, float scale)
+    private void DrawJobRow(ImDrawListPtr drawList, Rect rowRect, Rect contentRect, JobEntry job, float scale,
+        bool draggable, int categoryIndex, int rowIndex)
     {
         var hasMenu = job.Kind == JobEntryKind.Gearset;
         var menuRadius = 13f * scale;
         var menuCenter = new Vector2(contentRect.Max.X - menuRadius, contentRect.Center.Y);
         var menuHalf = new Vector2(menuRadius, menuRadius);
         var overMenu = hasMenu && UiInteract.Hover(menuCenter - menuHalf, menuCenter + menuHalf);
+
+        var handleRadius = 12f * scale;
+        var handleCenter = new Vector2(menuCenter.X - menuRadius - 20f * scale, contentRect.Center.Y);
+        var overHandle = false;
+        if (draggable)
+        {
+            overHandle = DrawJobDragHandle(drawList, handleCenter, handleRadius, categoryIndex, rowIndex, scale);
+        }
+
         var equippable = job.Kind == JobEntryKind.Gearset && !job.IsActive;
-        var hovered = equippable && !overMenu && UiInteract.Hover(rowRect.Min, rowRect.Max);
+        var hovered = equippable && !overMenu && !overHandle && UiInteract.Hover(rowRect.Min, rowRect.Max);
         if (hovered)
         {
             var alpha = ImGui.IsMouseDown(ImGuiMouseButton.Left) ? 0.14f : 0.07f;
@@ -381,6 +426,10 @@ internal sealed partial class JobsApp : IPhoneApp
             : string.Empty;
         var textLeft = iconMax.X + 14f * scale;
         var noteRight = hasMenu ? menuCenter.X - menuRadius - 8f * scale : contentRect.Max.X;
+        if (draggable)
+        {
+            noteRight -= handleRadius * 2f + 8f * scale;
+        }
         var textRight = noteRight -
                         (note.Length == 0 ? 0f : Typography.Measure(note, TextStyles.Caption2).X + 28f * scale);
         var maxTextWidth = MathF.Max(1f, textRight - textLeft);

--- a/src/Aetherphone/Core/Jobs/JobsReader.cs
+++ b/src/Aetherphone/Core/Jobs/JobsReader.cs
@@ -53,7 +53,7 @@ internal static unsafe class JobsReader
         for (var categoryIndex = 0; categoryIndex < customBuckets.Length; categoryIndex++)
         {
             sections.Add(new JobSection(categoryIndex, categories[categoryIndex].Name,
-                SortedEntries(customBuckets[categoryIndex])));
+                CustomOrderedEntries(customBuckets[categoryIndex], categories[categoryIndex].GearsetIds)));
         }
 
         for (var bucketIndex = 0; bucketIndex < buckets.Length; bucketIndex++)
@@ -68,6 +68,32 @@ internal static unsafe class JobsReader
         }
 
         return sections.ToArray();
+    }
+
+    // Custom categories are user-curated, so their display order follows GearsetIds' own list
+    // order (whatever JobsApp's drag-to-reorder last left it in) instead of UiPriority - unlike
+    // the built-in role sections below, which still fall back to SortedEntries. A gearset id with
+    // no live entry this cycle (deleted, or the bucket simply hasn't caught up yet) is skipped
+    // rather than left as a gap.
+    private static JobEntry[] CustomOrderedEntries(List<(JobEntry Entry, byte UiPriority)> bucket,
+        List<int> gearsetIds)
+    {
+        var byGearsetId = new Dictionary<int, JobEntry>(bucket.Count);
+        for (var index = 0; index < bucket.Count; index++)
+        {
+            byGearsetId[bucket[index].Entry.GearsetId] = bucket[index].Entry;
+        }
+
+        var ordered = new List<JobEntry>(bucket.Count);
+        for (var index = 0; index < gearsetIds.Count; index++)
+        {
+            if (byGearsetId.TryGetValue(gearsetIds[index], out var entry))
+            {
+                ordered.Add(entry);
+            }
+        }
+
+        return ordered.ToArray();
     }
 
     private static JobEntry[] SortedEntries(List<(JobEntry Entry, byte UiPriority)> bucket)

--- a/src/Aetherphone/Windows/Components/AppSurface.cs
+++ b/src/Aetherphone/Windows/Components/AppSurface.cs
@@ -37,6 +37,10 @@ internal static class AppSurface
 
         public readonly void JumpToTop() => surface.JumpToTop();
 
+        /// <summary>Hands an in-progress gesture to a widget inside this surface (see SkywatcherApp's
+        /// scrubber), leaving the scroll offset alone instead of letting it also become a scroll.</summary>
+        public readonly void CancelDrag() => surface.CancelDrag();
+
         public void Dispose()
         {
             child.Dispose();


### PR DESCRIPTION
## Summary
- Custom job categories had no way to reorder at all, and a naive reorder UI couldn't have worked anyway: `JobsReader.Build` always re-sorted every category's entries by game-defined priority/abbreviation on every rebuild (every 2 seconds, plus after any edit), discarding any manual order. Custom categories now display in `GearsetIds`' own list order instead.
- Drag-and-drop to reorder categories themselves, via a grip handle on each custom section's header.
- Drag-and-drop to reorder the gearsets within one category, via a grip handle on each row.
- Along the way, fixed the phone appearing to move during either drag: `DragScrollHost`'s kinetic scroll was racing the drag handle for the same press (it checks for a new scroll gesture before the handle gets a chance to claim it). Fixed by handing the gesture back via a new `AppSurface.SurfaceScope.CancelDrag()`, the same escape hatch `SkywatcherApp`'s scrubber already used for the identical problem.

## Test plan
- [ ] Build succeeds (`dotnet build Aetherphone.sln -c Release`)
- [ ] Create 2+ custom job categories, each with 2+ gearsets
- [ ] Drag a category header up/down and confirm the section order updates and persists across a Jobs tab close/reopen
- [ ] Drag a gearset row within a category and confirm the row order updates and persists
- [ ] Confirm the phone window and list scroll position stay put during both drags