### PR TITLE
fix(emote): stop the idle scroll firing while an event window is open

### DIFF
--- a/src/Aetherphone/Core/Emote/PhoneEmoteController.cs
+++ b/src/Aetherphone/Core/Emote/PhoneEmoteController.cs
@@ -20,7 +20,16 @@ internal sealed class PhoneEmoteController : IDisposable
     {
         ConditionFlag.InCombat, ConditionFlag.BetweenAreas, ConditionFlag.BetweenAreas51,
         ConditionFlag.OccupiedInCutSceneEvent, ConditionFlag.WatchingCutscene, ConditionFlag.WatchingCutscene78,
-        ConditionFlag.OccupiedInQuestEvent, ConditionFlag.Casting,
+        ConditionFlag.OccupiedInQuestEvent, ConditionFlag.Casting, ConditionFlag.OccupiedInEvent,
+        ConditionFlag.Gathering, ConditionFlag.Crafting, ConditionFlag.TradeOpen, ConditionFlag.ExecutingCraftingAction,
+        ConditionFlag.Unconscious, ConditionFlag.MeldingMateria, ConditionFlag.OperatingSiegeMachine,
+        ConditionFlag.CarryingItem, ConditionFlag.CarryingObject, ConditionFlag.Mounting, ConditionFlag.Mounting71,
+        ConditionFlag.ParticipatingInCustomMatch, ConditionFlag.PlayingLordOfVerminion, ConditionFlag.ChocoboRacing,
+        ConditionFlag.PlayingMiniGame, ConditionFlag.Performing, ConditionFlag.Transformed,
+        ConditionFlag.UsingHousingFunctions, ConditionFlag.Occupied, ConditionFlag.Occupied30, ConditionFlag.Occupied33,
+        ConditionFlag.Occupied38, ConditionFlag.Occupied39, ConditionFlag.OccupiedSummoningBell,
+        ConditionFlag.ExecutingGatheringAction, ConditionFlag.PreparingToCraft, ConditionFlag.BeingMoved,
+        ConditionFlag.LoggingOut, ConditionFlag.Fishing,
     };
 
     private readonly Configuration configuration;

--- a/src/Aetherphone/Core/Emote/PhoneEmoteController.cs
+++ b/src/Aetherphone/Core/Emote/PhoneEmoteController.cs
@@ -23,7 +23,7 @@ internal sealed class PhoneEmoteController : IDisposable
         ConditionFlag.OccupiedInQuestEvent, ConditionFlag.Casting, ConditionFlag.OccupiedInEvent,
         ConditionFlag.Gathering, ConditionFlag.Crafting, ConditionFlag.TradeOpen, ConditionFlag.ExecutingCraftingAction,
         ConditionFlag.Unconscious, ConditionFlag.MeldingMateria, ConditionFlag.OperatingSiegeMachine,
-        ConditionFlag.CarryingItem, ConditionFlag.CarryingObject, ConditionFlag.Mounting, ConditionFlag.Mounting71,
+        ConditionFlag.CarryingItem, ConditionFlag.CarryingObject, ConditionFlag.EditingPortrait,
         ConditionFlag.ParticipatingInCustomMatch, ConditionFlag.PlayingLordOfVerminion, ConditionFlag.ChocoboRacing,
         ConditionFlag.PlayingMiniGame, ConditionFlag.Performing, ConditionFlag.Transformed,
         ConditionFlag.UsingHousingFunctions, ConditionFlag.Occupied, ConditionFlag.Occupied30, ConditionFlag.Occupied33,
@@ -72,14 +72,15 @@ internal sealed class PhoneEmoteController : IDisposable
             return;
         }
 
+        var now = Environment.TickCount64;
         var player = objectTable.LocalPlayer;
         if (player is null || IsBlocked())
         {
             hasSample = false;
+            lastCastMilliseconds = now;
             return;
         }
 
-        var now = Environment.TickCount64;
         if (IsBusy(player.Address))
         {
             lastCastMilliseconds = now;


### PR DESCRIPTION
## What

`PhoneEmoteController.BlockingConditions` now covers the occupied and event condition flags. It previously held eight flags, all of them combat, zoning, or cutscene states. It now holds thirty eight, adding the full `Occupied` family, gathering, crafting, fishing, the retainer summoning bell, trade, materia melding, housing functions, and the various mini-game and transport states.

No other behaviour changes. The gate is still the same linear check in `IsBlocked()`.

## Why

Bug report: a user opened a gathering node, the idle scroll animation fired, and they ended up in a broken state. They stayed in the gather window but could run around. Closing the window by hand left them unable to move or log out, and only a force close of the game recovered it.

`PhoneEmoteController` sends an emote chat command whenever the phone is visible and the player has held still for 400ms. The only things that suppressed it were `InCombat`, the two `BetweenAreas` flags, the cutscene flags, `OccupiedInQuestEvent`, and `Casting`. Nothing stopped it firing into a live gathering event, so the plugin issued a command while the client was mid event and the client's event state came out desynced. The stuck movement and the refused logout are both consistent with the client still believing it is in that event.

Two things make this worth fixing ahead of other open reports:

- `ScrollWhileIdle` defaults to `true` in `Configuration.cs`, so this is on for every user who has not turned it off.
- "Phone open while standing still" is the plugin's main use case, not an edge case.

The reporter guessed that retainers and the market board would have the same problem, and they were right. Those are the same class of modal event window, so this fixes the class rather than just the gathering node.

Known tradeoff: this is a denylist that has to enumerate every occupied state the game has. A future patch that adds a new event window will reopen the same hole. The alternative, gating on whether any game addon holds focus, is harder to leave a gap in but a much larger change, and not worth bundling into a bug fix.

## How to test

The emote fires after 400ms of stillness with the phone visible, so the test is to stand still rather than to race anything.

1. `dotnet build Aetherphone.sln -c Release`
2. Confirm `ScrollWhileIdle` is on (Settings, Immersion, or the idle tile in Control Center).
3. Open the phone, walk to a gathering node, open it, and stand still for several seconds. No emote should fire. Close the window and confirm you can move and log out normally.
4. Repeat at a retainer summoning bell, a market board, a crafting log, and while fishing.
5. Regression, since this gate covers every idle scroll: stand still in a town with nothing open and confirm the scroll still plays, both the loop and the one-shot variant.
6. Regression on the states deliberately left unblocked: sitting on furniture and riding a mount should both still scroll, since neither is an event window and both are normal phone use.

## Checklist

- [x] `dotnet build -c Release` passes
- [ ] Verified in-game: opened the phone and exercised the affected app/screen
- [ ] Condition flags confirmed live via `/xldata` at a gathering node, retainer bell, and market board
- [x] If this changes user-visible behavior, README is updated (n/a, bug fix only)
- [x] Matches existing style: no `what` comments, no new user-visible strings
