### PR TITLE
refactor(velvet): moved photo gallery below profile details

### DIFF
--- a/src/Aetherphone/Apps/Velvet/VelvetShell.Profile.cs
+++ b/src/Aetherphone/Apps/Velvet/VelvetShell.Profile.cs
@@ -137,10 +137,15 @@ internal sealed partial class VelvetShell
                 }
             }
 
-            Gap(24f);
-            DrawGallery(user, isMe, connected);
+             if (user.Intro.Length > 0)
+            {
+                Gap(20f);
+                VSectionHeader.Bar(Loc.T(L.Velvet.CardAbout));
+                Gap(4f);
+                WrapText(user.Intro, VelvetTheme.BodyInk, TextStyles.Body);
+            }
 
-            var genderLabels = VelvetGender.Labels(user.Gender);
+                        var genderLabels = VelvetGender.Labels(user.Gender);
             if (genderLabels.Length > 0)
             {
                 Gap(20f);
@@ -156,14 +161,6 @@ internal sealed partial class VelvetShell
                 VSectionHeader.Bar(Loc.T(L.Velvet.CardSexuality));
                 Gap(4f);
                 DrawDisplayTokens(sexualityLabels, VChipStyle.Tint, VelvetTheme.Rose);
-            }
-
-            if (user.Intro.Length > 0)
-            {
-                Gap(20f);
-                VSectionHeader.Bar(Loc.T(L.Velvet.CardAbout));
-                Gap(4f);
-                WrapText(user.Intro, VelvetTheme.BodyInk, TextStyles.Body);
             }
 
             if (VelvetIntent.IncludesErp(user.LookingFor) && user.Dynamic.Length > 0)
@@ -198,6 +195,9 @@ internal sealed partial class VelvetShell
                 Gap(4f);
                 DrawDisplayTokens(user.Limits, VChipStyle.Outline, VelvetTheme.Gold);
             }
+
+            Gap(24f);
+            DrawGallery(user, isMe, connected);
 
             if (!isMe)
             {

--- a/src/Aetherphone/Apps/Velvet/VelvetShell.Profile.cs
+++ b/src/Aetherphone/Apps/Velvet/VelvetShell.Profile.cs
@@ -137,9 +137,9 @@ internal sealed partial class VelvetShell
                 }
             }
 
-             if (user.Intro.Length > 0)
+            if (user.Intro.Length > 0)
             {
-                Gap(20f);
+                Gap(18f);
                 VSectionHeader.Bar(Loc.T(L.Velvet.CardAbout));
                 Gap(4f);
                 WrapText(user.Intro, VelvetTheme.BodyInk, TextStyles.Body);

--- a/src/Aetherphone/Apps/Velvet/VelvetShell.Profile.cs
+++ b/src/Aetherphone/Apps/Velvet/VelvetShell.Profile.cs
@@ -145,7 +145,7 @@ internal sealed partial class VelvetShell
                 WrapText(user.Intro, VelvetTheme.BodyInk, TextStyles.Body);
             }
 
-                        var genderLabels = VelvetGender.Labels(user.Gender);
+            var genderLabels = VelvetGender.Labels(user.Gender);
             if (genderLabels.Length > 0)
             {
                 Gap(20f);

--- a/src/Aetherphone/Apps/Velvet/VelvetShell.Profile.cs
+++ b/src/Aetherphone/Apps/Velvet/VelvetShell.Profile.cs
@@ -139,7 +139,7 @@ internal sealed partial class VelvetShell
 
             if (user.Intro.Length > 0)
             {
-                Gap(18f);
+                Gap(20f);
                 VSectionHeader.Bar(Loc.T(L.Velvet.CardAbout));
                 Gap(4f);
                 WrapText(user.Intro, VelvetTheme.BodyInk, TextStyles.Body);
@@ -148,7 +148,7 @@ internal sealed partial class VelvetShell
             var genderLabels = VelvetGender.Labels(user.Gender);
             if (genderLabels.Length > 0)
             {
-                Gap(20f);
+                Gap(18f);
                 VSectionHeader.Bar(Loc.T(L.Velvet.CardGender));
                 Gap(4f);
                 DrawDisplayTokens(genderLabels, VChipStyle.Tint, VelvetTheme.Rose);


### PR DESCRIPTION
## What

Re-arranges the Velvet profile screen.

## Why

Currently the big photo galleries create a poor UX by drowning out Info and Tags within the profile screen. This change loads the photo gallery last so other information bubbles up.

Closes #

## How to test

<!--
Minimum steps a reviewer can run to verify the change. Testing usually means opening the phone with `/phone`, navigating to the app or screen you touched, and confirming it behaves. If you changed messaging, send yourself a /tell and watch it land. For UI-only changes, describe what to click and attach a before/after screenshot.
-->

Before: (Photos omitted due the nature of velvet. 
<img width="389" height="619" alt="image" src="https://github.com/user-attachments/assets/863ed2c8-780a-4b3f-a31e-7560dae7eb92" />


After:
<img width="440" height="903" alt="image" src="https://github.com/user-attachments/assets/af021e17-45c5-4a45-b676-afbcdc0bc59d" />


## Checklist

- [*] `dotnet build -c Release` passes
- [*] Verified in-game: opened the phone and exercised the affected app/screen
- [*] If this changes user-visible behavior, README is updated
- [*] Matches existing style: uses the shared `Windows/Components/` widgets, no `what` comments
