### PR TITLE
fix(housing): stop chip labels wrapping and tidy the filter drawer rows

### DIFF
--- a/src/Aetherphone/Apps/Housing/HousingApp.Filters.cs
+++ b/src/Aetherphone/Apps/Housing/HousingApp.Filters.cs
@@ -28,7 +28,7 @@ internal sealed partial class HousingApp
     private readonly bool[] reminderActive = new bool[HousingDefaults.ReminderChoices.Length];
 
     private static float FilterSectionHeight(float scale) =>
-        Typography.LineHeight(TextStyles.Caption1) + (ChipRail.RowHeight + 12f) * scale;
+        Typography.LineHeight(TextStyles.Caption1) + (ChipRail.RowHeight + Metrics.Space.Sm * 2f) * scale;
 
     private static float FilterDrawerHeightFor(float scale)
     {
@@ -237,10 +237,10 @@ internal sealed partial class HousingApp
         string label, float scale, ReadOnlySpan<string> labels, ReadOnlySpan<bool> active, out int tapped)
     {
         HousingChrome.SectionLabel(drawList, new Vector2(left, y), right - left, label, ui);
-        var top = y + Typography.LineHeight(TextStyles.Caption1) + 4f * scale;
+        var top = y + Typography.LineHeight(TextStyles.Caption1) + Metrics.Space.Sm * scale;
         var row = new Rect(new Vector2(left, top), new Vector2(right, top + ChipRail.RowHeight * scale));
         tapped = rail.Draw(row, ui, labels, active, true);
-        return row.Max.Y + 8f * scale;
+        return row.Max.Y + Metrics.Space.Sm * scale;
     }
 
     private void ResetFilterRails()

--- a/src/Aetherphone/Core/Localization/L.cs
+++ b/src/Aetherphone/Core/Localization/L.cs
@@ -973,7 +973,7 @@ internal static class L
         public static readonly LocString FilterEligibility = new("housing.filterEligibility", "Who can buy");
         public static readonly LocString FilterDivision = new("housing.filterDivision", "Division");
         public static readonly LocString FilterData = new("housing.filterData", "Data");
-        public static readonly LocString FilterOtherPhases = new("housing.filterOtherPhases", "Other phases");
+        public static readonly LocString FilterOtherPhases = new("housing.filterOtherPhases", "Other");
         public static readonly LocString FilterFreshOnly = new("housing.filterFreshOnly", "Fresh scans only");
         public static readonly LocString FilterWatchedOnly = new("housing.filterWatchedOnly", "Watched plots only");
         public static readonly LocString FilterMaxEntries = new("housing.filterMaxEntries", "Max reported entries");

--- a/src/Aetherphone/Localization/de.json
+++ b/src/Aetherphone/Localization/de.json
@@ -3681,7 +3681,7 @@
   "housing.filterEligibility": "Wer kaufen darf",
   "housing.filterDivision": "Bereich",
   "housing.filterData": "Daten",
-  "housing.filterOtherPhases": "Andere Phasen",
+  "housing.filterOtherPhases": "Andere",
   "housing.filterFreshOnly": "Nur frische Scans",
   "housing.filterWatchedOnly": "Nur gemerkte Grundstücke",
   "housing.filterMaxEntries": "Max. gemeldete Bewerber",

--- a/src/Aetherphone/Localization/en.json
+++ b/src/Aetherphone/Localization/en.json
@@ -3681,7 +3681,7 @@
   "housing.filterEligibility": "Who can buy",
   "housing.filterDivision": "Division",
   "housing.filterData": "Data",
-  "housing.filterOtherPhases": "Other phases",
+  "housing.filterOtherPhases": "Other",
   "housing.filterFreshOnly": "Fresh scans only",
   "housing.filterWatchedOnly": "Watched plots only",
   "housing.filterMaxEntries": "Max reported entries",

--- a/src/Aetherphone/Localization/es.json
+++ b/src/Aetherphone/Localization/es.json
@@ -3681,7 +3681,7 @@
   "housing.filterEligibility": "Quién puede comprar",
   "housing.filterDivision": "División",
   "housing.filterData": "Datos",
-  "housing.filterOtherPhases": "Otras fases",
+  "housing.filterOtherPhases": "Otras",
   "housing.filterFreshOnly": "Solo escaneos recientes",
   "housing.filterWatchedOnly": "Solo parcelas seguidas",
   "housing.filterMaxEntries": "Máx. inscripciones",

--- a/src/Aetherphone/Localization/fr.json
+++ b/src/Aetherphone/Localization/fr.json
@@ -3681,7 +3681,7 @@
   "housing.filterEligibility": "Qui peut acheter",
   "housing.filterDivision": "Division",
   "housing.filterData": "Données",
-  "housing.filterOtherPhases": "Autres phases",
+  "housing.filterOtherPhases": "Autres",
   "housing.filterFreshOnly": "Relevés récents uniquement",
   "housing.filterWatchedOnly": "Parcelles suivies uniquement",
   "housing.filterMaxEntries": "Nombre maximal d'inscriptions",

--- a/src/Aetherphone/Localization/ja.json
+++ b/src/Aetherphone/Localization/ja.json
@@ -3681,7 +3681,7 @@
   "housing.filterEligibility": "購入対象",
   "housing.filterDivision": "区分",
   "housing.filterData": "データ",
-  "housing.filterOtherPhases": "その他の期間",
+  "housing.filterOtherPhases": "その他",
   "housing.filterFreshOnly": "新しいスキャンのみ",
   "housing.filterWatchedOnly": "ウォッチ中のみ",
   "housing.filterMaxEntries": "応募数の上限",

--- a/src/Aetherphone/Localization/pt.json
+++ b/src/Aetherphone/Localization/pt.json
@@ -3681,7 +3681,7 @@
   "housing.filterEligibility": "Quem pode comprar",
   "housing.filterDivision": "Divisão",
   "housing.filterData": "Dados",
-  "housing.filterOtherPhases": "Outras fases",
+  "housing.filterOtherPhases": "Outras",
   "housing.filterFreshOnly": "Só scans recentes",
   "housing.filterWatchedOnly": "Só acompanhados",
   "housing.filterMaxEntries": "Máximo de inscritos",

--- a/src/Aetherphone/Localization/ru.json
+++ b/src/Aetherphone/Localization/ru.json
@@ -3681,7 +3681,7 @@
   "housing.filterEligibility": "Кто может купить",
   "housing.filterDivision": "Часть варда",
   "housing.filterData": "Данные",
-  "housing.filterOtherPhases": "Другие этапы",
+  "housing.filterOtherPhases": "Другие",
   "housing.filterFreshOnly": "Только свежие сканы",
   "housing.filterWatchedOnly": "Только отслеживаемые",
   "housing.filterMaxEntries": "Максимум заявок",

--- a/src/Aetherphone/Localization/tr.json
+++ b/src/Aetherphone/Localization/tr.json
@@ -3681,7 +3681,7 @@
   "housing.filterEligibility": "Kim alabilir",
   "housing.filterDivision": "Bölüm",
   "housing.filterData": "Veri",
-  "housing.filterOtherPhases": "Diğer dönemler",
+  "housing.filterOtherPhases": "Diğer",
   "housing.filterFreshOnly": "Yalnızca yeni taramalar",
   "housing.filterWatchedOnly": "Yalnızca takiptekiler",
   "housing.filterMaxEntries": "En fazla başvuru",

--- a/src/Aetherphone/Localization/zh.json
+++ b/src/Aetherphone/Localization/zh.json
@@ -3681,7 +3681,7 @@
   "housing.filterEligibility": "购买资格",
   "housing.filterDivision": "分区",
   "housing.filterData": "数据",
-  "housing.filterOtherPhases": "其他阶段",
+  "housing.filterOtherPhases": "其他",
   "housing.filterFreshOnly": "仅最新扫描",
   "housing.filterWatchedOnly": "仅已关注地块",
   "housing.filterMaxEntries": "申请数上限",

--- a/src/Aetherphone/Windows/Components/ChipRail.cs
+++ b/src/Aetherphone/Windows/Components/ChipRail.cs
@@ -83,8 +83,9 @@ internal sealed class ChipRail
             : highlighted ? ui.HoverTint : ui.FieldSurface;
         Squircle.Fill(drawList, min, max, radius, ImGui.GetColorU32(fill));
         var ink = active ? new Vector4(0.11f, 0.08f, 0.02f, 1f) : ui.BodyInk;
-        Typography.DrawCentered(drawList, new Vector2((min.X + max.X) * 0.5f, (min.Y + max.Y) * 0.5f), label, ink,
-            TextStyles.SubheadlineEmphasized);
+        var labelSize = Typography.Measure(label, TextStyles.SubheadlineEmphasized);
+        var labelOrigin = new Vector2((min.X + max.X - labelSize.X) * 0.5f, (min.Y + max.Y - labelSize.Y) * 0.5f);
+        Typography.Draw(drawList, labelOrigin, label, ink, TextStyles.SubheadlineEmphasized);
         if (highlighted)
         {
             ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);


### PR DESCRIPTION
## What

Fixes chip labels wrapping inside their own pill in the Housing filter drawer, lifts the chip rows off the section rule they were sitting on, and shortens "Other phases" to "Other".

## Why

`Typography.DrawCentered` applies `AutoWrapWidth`, which measures from the text centre to the nearer window content edge and wraps if the string is wider than double that. For the last chip in a rail that budget collapses, so a single line label wrapped to two lines inside a pill that `ChipWidth` had already sized for one line. "Other phases" rendered as two lines spilling out of its own chip. `ChipRail` knows its own chip bounds, so the window relative heuristic is wrong for it.

Separately, `SectionLabel` draws its hairline at `LineHeight(Caption1) + 3f * scale` and `DrawChipSection` started the chip row at `+ 4f * scale`, one pixel below it, so every row looked welded to the rule above it.

With the wrapping fixed the phase row still overflowed, so the third chip is now "Other". The section header already reads LOTTERY PHASE, so the noun is redundant. The shortened forms keep agreement with the noun they drop, so `Otras` and `Outras` stay feminine plural.

## How to test

1. `/phone`, open Housing, tap the filter button to open the drawer.
2. Check the Lottery phase row: all three chips should sit on one line each, fully inside their pills, with no text spilling past a chip edge.
3. Check every section: the chips should sit clear of the rule under the section label, not touching it.
4. Switch to German in Settings and reopen the drawer. Long phase labels may still pan the row, which is the intended `ChipRail` behaviour, but nothing should render as a two line chip.

## Checklist

- [x] `dotnet build -c Release` passes
- [x] Verified in-game: opened the phone and exercised the affected app/screen
- [x] Matches existing style: uses the shared `Windows/Components/` widgets, no `what` comments

## Note on shared code

One change outside the app: `ChipRail.DrawChip` swaps `Typography.DrawCentered` for `Typography.Measure` plus `Typography.Draw`. No signature changes. This also affects the YellowPages, Muster and Housing reminder rails, which had the same latent wrapping bug and none of which relied on wrapping.

Localization is in lockstep: `housing.filterOtherPhases` is updated in `L.cs` and all nine catalogs in this commit.