### PR TITLE
feat: debug specific release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,8 @@ You need the .NET 10 SDK. The plugin requires Dalamud at runtime; CI pulls a Dal
 
 Load the built plugin via `/xlsettings` -> **Experimental** -> **Dev Plugin Locations**, pointing at `src/Aetherphone/bin/Release/Aetherphone.dll`.
 
+A `Debug` build produces a separate side-by-side plugin instead: `src/Aetherphone/bin/Debug/AetherphoneDev.dll`, loaded as `AetherphoneDev`, opened with `/phonedev`, with its own config and pointed at the development Aethernet instance. Register whichever path you build.
+
 ## Project layout
 
 - `src/Aetherphone/Core/`: the device platform: app framework and navigation, theming, messaging, notifications, character/contacts, game data readers, and the shared services (networking, crypto, media, localization) the apps build on.

--- a/docs/README.md
+++ b/docs/README.md
@@ -112,7 +112,7 @@ Read [CONTRIBUTING.md](../CONTRIBUTING.md) at the repo root for the pull request
 
 ## Gotchas
 
-- Dev plugin loading points at a fixed dll path. If you registered `src/Aetherphone/bin/Release/Aetherphone.dll` in Dalamud and then build with `-c Debug`, the output goes to `bin/Debug/` and the game silently keeps loading your previous Release build.
+- Dev plugin loading points at a fixed dll path. Release builds `bin/Release/Aetherphone.dll`, Debug builds the side-by-side `bin/Debug/AetherphoneDev.dll` (`/phonedev`, its own config, development Aethernet instance). Build the configuration you did not register and the game silently keeps loading your previous plugin.
 - Bundled asset folders (Fonts, Emoji, Icons, Images, Sounds, Wallpapers, Cases, Localization) are copied to the build output by `<Content>` items in src/Aetherphone/Aetherphone.csproj. Editing an asset file does nothing in game until you rebuild.
 - These docs cover the client only. The Aethernet backend lives in a separate repository, so server behavior can change without any commit here; where a doc and the code disagree, the code wins.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -58,18 +58,22 @@ The build needs the Dalamud assemblies described above. If XIVLauncher has run o
 
 The output lands in `src/Aetherphone/bin/Release/`: the loadable `Aetherphone.dll` plus a packaged `Aetherphone/latest.zip` that the release pipeline ships. Asset folders (`Fonts`, `Icons`, `Emoji`, `Cases`, `Localization`, `Wallpapers`, `Sounds`) are copied next to the dll by the `<Content>` items in `src/Aetherphone/Aetherphone.csproj`.
 
-### Why Release, not Debug?
+### Release or Debug?
 
-Build `Release`. It is the configuration that CONTRIBUTING.md, CI, and the release workflow all use, and (next section) it is the path you register with Dalamud. The dev plugin location is a fixed file path: if you later run a `Debug` build, the output goes to `bin/Debug/` instead, the file at the registered `bin/Release/` path never changes, and the game silently keeps loading your previous build. Sticking to `-c Release` for the whole dev loop avoids that trap.
+Build `Release` for the plugin end users get. It is the configuration that CONTRIBUTING.md, CI, and the release workflow all use, and (next section) it is the path you register with Dalamud.
+
+`Debug` builds a second plugin that installs alongside it. The output is `src/Aetherphone/bin/Debug/AetherphoneDev.dll`, Dalamud sees it as the separate plugin `AetherphoneDev`, it answers `/phonedev` and `/aetherphonedev`, and it keeps its own Dalamud config, so it never touches the settings of your normal install. It also talks to the development Aethernet instance instead of production.
+
+Either way the dev plugin location is a fixed file path, so register the configuration you actually build. Build the other one and the game silently keeps loading your previous plugin.
 
 ## Load it in the game
 
 1. Launch the game through XIVLauncher.
 2. Type `/xlsettings` in chat to open Dalamud's settings.
 3. Open the **Experimental** tab and find **Dev Plugin Locations**.
-4. Add the full path to your built dll, ending in `src/Aetherphone/bin/Release/Aetherphone.dll`, and save.
+4. Add the full path to your built dll, ending in `src/Aetherphone/bin/Release/Aetherphone.dll`, and save. For a Debug build, use `src/Aetherphone/bin/Debug/AetherphoneDev.dll` instead; both paths can be registered at once.
 5. Open the plugin installer with `/xlplugins`. Aetherphone now appears as a dev plugin; enable it.
-6. Type `/phone`. The phone opens.
+6. Type `/phone`. The phone opens. A Debug build answers `/phonedev` instead.
 
 ## Chat commands
 
@@ -147,7 +151,7 @@ So CI is your local build with the Dalamud dependency fetched explicitly. If `do
 
 ## Gotchas
 
-- **A Debug build never reaches the game.** The dev plugin location points at `bin/Release/Aetherphone.dll`; `dotnet build` without `-c Release` writes to `bin/Debug/` and Dalamud keeps loading your stale Release dll with no error anywhere.
+- **Debug and Release are two different plugins.** Release writes `bin/Release/Aetherphone.dll`, Debug writes `bin/Debug/AetherphoneDev.dll`. Dalamud loads whichever path you registered, so building the other configuration leaves the game on your previous build with no error anywhere.
 - **NuGet restore is locked.** `Directory.Build.props` sets `RestorePackagesWithLockFile`, and CI restores with `--locked-mode`. If you add or bump a `PackageReference`, run `dotnet restore` locally so `packages.lock.json` updates and gets committed, or CI fails at the restore step.
 - **Version lives in three places.** Bumping `<Version>` in `Directory.Build.props` without updating `AssemblyVersion` and `TestingAssemblyVersion` in `repo.json` fails the CI guards job before the build even starts.
 - **Unknown command arguments are silent.** `OnCommand` in `Plugin.cs` treats anything that is not `test`, `reset`, or `market` as a plain toggle, so a typo like `/phone rset` opens or closes the phone instead of erroring.

--- a/src/Aetherphone/Aetherphone.csproj
+++ b/src/Aetherphone/Aetherphone.csproj
@@ -10,17 +10,11 @@
   <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))'">
     <DalamudLibPath>$(DALAMUD_HOME)/</DalamudLibPath>
   </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-    <AssemblyName>AetherphoneDev</AssemblyName>
+    <TargetName>AetherphoneDev</TargetName>
+    <ProjectDepsFileName>AetherphoneDev.deps.json</ProjectDepsFileName>
   </PropertyGroup>
-  
-  <Target Name="PackagePluginDebug" AfterTargets="Build" Condition="'$(Configuration)' == 'Debug'">
-    <DalamudPackager
-      ProjectDir="$(ProjectDir)"
-      OutputPath="$(OutputPath)"
-      AssemblyName="$(AssemblyName)"
-      MakeZip="true" />
-  </Target>
 
   <ItemGroup>
     <Content Include="Images\Icon.png" Condition="Exists('Images\Icon.png')">

--- a/src/Aetherphone/Aetherphone.csproj
+++ b/src/Aetherphone/Aetherphone.csproj
@@ -10,6 +10,17 @@
   <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))'">
     <DalamudLibPath>$(DALAMUD_HOME)/</DalamudLibPath>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <AssemblyName>AetherphoneDev</AssemblyName>
+  </PropertyGroup>
+  
+  <Target Name="PackagePluginDebug" AfterTargets="Build" Condition="'$(Configuration)' == 'Debug'">
+    <DalamudPackager
+      ProjectDir="$(ProjectDir)"
+      OutputPath="$(OutputPath)"
+      AssemblyName="$(AssemblyName)"
+      MakeZip="true" />
+  </Target>
 
   <ItemGroup>
     <Content Include="Images\Icon.png" Condition="Exists('Images\Icon.png')">

--- a/src/Aetherphone/AetherphoneDev.json
+++ b/src/Aetherphone/AetherphoneDev.json
@@ -1,0 +1,21 @@
+{
+    "Author": "XeldarAlz",
+    "Name": "Aetherphone Development",
+    "InternalName": "AetherphoneDev",
+    "Punchline": "A smartphone, built for you.",
+    "Description": "An in-game smartphone that puts everything you do into a single window: one device, endless things to do.",
+    "ApplicableVersion": "any",
+    "RepoUrl": "https://github.com/XeldarAlz/FFXIV-Aetherphone",
+    "IconUrl": "https://raw.githubusercontent.com/XeldarAlz/FFXIV-Aetherphone/master/src/Aetherphone/Images/Icon.png",
+    "Tags": [
+        "phone",
+        "aether",
+	    "aetherphone",
+        "messages",
+        "social",
+        "ui",
+        "quality of life",
+        "device",
+	    "call"
+    ]
+}

--- a/src/Aetherphone/Configuration.cs
+++ b/src/Aetherphone/Configuration.cs
@@ -84,7 +84,11 @@ internal sealed class Configuration : IPluginConfiguration, IHomeConfiguration, 
     public float MusicVolume { get; set; } = 0.6f;
     public int MusicRepeat { get; set; }
     public bool GameSoundsCleared { get; set; }
+    #if DEBUG
+    public const string DefaultAethernetBaseUrl = "https://aethernet-dev-production.up.railway.app";
+    #else
     public const string DefaultAethernetBaseUrl = "https://api.aetherphone.net";
+    #endif
     private const string LegacyAethernetHost = "ffxiv-aethernet-production.up.railway.app";
     public string AethernetBaseUrl { get; set; } = DefaultAethernetBaseUrl;
     public string AethernetToken { get; set; } = string.Empty;

--- a/src/Aetherphone/Core/AepConstants.cs
+++ b/src/Aetherphone/Core/AepConstants.cs
@@ -4,11 +4,13 @@ internal static class AepConstants
 {
     #if DEBUG
     public const string Name = "AetherphoneDev";
+    public const string PrimaryCommand = "/phonedev";
+    public const string AliasCommand = "/aetherphonedev";
     #else
     public const string Name = "Aetherphone";
-    #endif
     public const string PrimaryCommand = "/phone";
     public const string AliasCommand = "/aetherphone";
+    #endif
     public const string DiscordUrl = "https://discord.gg/3HbJCscMyS";
     public const string WebsiteUrl = "https://www.aetherphone.net";
     public const string PatreonUrl = "https://www.patreon.com/XeldarAlz";

--- a/src/Aetherphone/Core/AepConstants.cs
+++ b/src/Aetherphone/Core/AepConstants.cs
@@ -2,7 +2,11 @@ namespace Aetherphone.Core;
 
 internal static class AepConstants
 {
+    #if DEBUG
+    public const string Name = "AetherphoneDev";
+    #else
     public const string Name = "Aetherphone";
+    #endif
     public const string PrimaryCommand = "/phone";
     public const string AliasCommand = "/aetherphone";
     public const string DiscordUrl = "https://discord.gg/3HbJCscMyS";

--- a/src/Aetherphone/DalamudPackager.targets
+++ b/src/Aetherphone/DalamudPackager.targets
@@ -1,0 +1,17 @@
+<Project>
+
+  <!--
+    Replaces DalamudPackager's own Debug/Release defaults, which are skipped
+    once this file exists. Both configurations package and zip: Release ships
+    Aetherphone, Debug ships the side-by-side AetherphoneDev dev plugin.
+  -->
+
+  <Target Name="PackagePlugin" AfterTargets="Build">
+    <DalamudPackager
+      ProjectDir="$(ProjectDir)"
+      OutputPath="$(OutputPath)"
+      AssemblyName="$(TargetName)"
+      MakeZip="true" />
+  </Target>
+
+</Project>


### PR DESCRIPTION
## What

Compiles the DLL when in Debug mode as `AetherphoneDev`, changes the commands to `/phonedev` as well as `/aetherphonedev`, and instructs the Dalamud Packager to generate a .zip in Debug as well.

## Why

Easier testing. Allows both production and development to be ran at the same time with different configs.

## Checklist

- [x] `dotnet build -c Release` passes
- [x] Verified in-game: opened the phone and exercised the affected app/screen
- [x] If this changes user-visible behavior, README is updated
- [x] Matches existing style: uses the shared `Windows/Components/` widgets, no `what` comments
