### PR TITLE
fix(yellowpages): wrapping ad creation form failure text

### DIFF
--- a/src/Aetherphone/Apps/YellowPages/YellowPagesApp.Compose.cs
+++ b/src/Aetherphone/Apps/YellowPages/YellowPagesApp.Compose.cs
@@ -726,9 +726,9 @@ internal sealed partial class YellowPagesApp
         var cursorY = origin.Y;
         if (composeOutcome is { } outcome)
         {
-            Typography.Draw(new Vector2(origin.X, cursorY), OutcomeText(outcome), theme.Danger,
-                TextStyles.FootnoteEmphasized);
-            cursorY += 22f * scale;
+            var outcomeHeight = Typography.DrawWrappedLeft(new Vector2(origin.X, cursorY), OutcomeText(outcome),
+                theme.Danger, TextStyles.FootnoteEmphasized, width);
+            cursorY += outcomeHeight + Metrics.Space.Xs * scale;
         }
         else if (!valid)
         {


### PR DESCRIPTION
## What

Previously any failure messages in creating an ad for yellow pages would be cut off by the width of the phone. 

- Switched the Yellow Pages ad form failure message from single-line drawing to wrapped text, and now spaces the submit button based on the wrapped message height.

## Why

As shown by recent bug ticket, users are not sure what went wrong when failure message is cut off. Has the added benefit of making the plugin look cleaner when overflow doesn't happen.

## Checklist

- [x] `dotnet build -c Release` passes
- [x] Verified in-game: opened the phone and exercised the affected app/screen
- [ ] If this changes user-visible behavior, README is updated
- [x] Matches existing style: uses the shared `Windows/Components/` widgets, no `what` comments
