### PR TITLE
fix(dailies): corrected tracking for doman enclave donations

### DIFF
--- a/src/Aetherphone/Apps/Dailies/DailiesApp.cs
+++ b/src/Aetherphone/Apps/Dailies/DailiesApp.cs
@@ -112,7 +112,8 @@ internal sealed class DailiesApp : IPhoneApp
 
     private static bool IsValueTracking(DailyTracking tracking) =>
         tracking is DailyTracking.BeastTribeAllowances or DailyTracking.CustomDeliveries
-            or DailyTracking.WondrousTails or DailyTracking.Levequests or DailyTracking.HuntBills;
+            or DailyTracking.WondrousTails or DailyTracking.Levequests or DailyTracking.HuntBills
+            or DailyTracking.DomanEnclave;
 
     private bool IsOutstanding(in DailyItem item, in DailyAutoStatus status, DateTime utcNow)
     {

--- a/src/Aetherphone/Core/Dailies/DailiesReader.cs
+++ b/src/Aetherphone/Core/Dailies/DailiesReader.cs
@@ -109,13 +109,16 @@ internal static unsafe class DailiesReader
         }
 
         var state = manager->State;
-        if (state.CurrentMilestone == 0)
+        var donated = (int)state.Donated;
+        var allowance = (int)state.Allowance;
+
+        if (allowance == 0)
         {
             return DailyAutoStatus.Unavailable;
         }
 
-        var remaining = state.Allowance;
-        return new DailyAutoStatus(true, remaining == 0, remaining, remaining);
+        var remaining = allowance - donated;
+        return new DailyAutoStatus(true, remaining == 0, remaining, allowance);
     }
 
     private static DailyAutoStatus ReadLevequests(int goal)


### PR DESCRIPTION
## What

Fixed the logic we had for the doman enclave variables and changed the tracking from a check box to value tracking.

## Why

The doman enclave tracking in the Dailies app wasn't working at all. 


Closes: https://discord.com/channels/1527213298087493732/1534597135109197944

## How to test

1. Talk to the donation box within the Doman Enclave.
2. Make a donation.
3. Check Dailies app to ensure that your donations are incrementing against your allowance in the weekly tab.

## Checklist

- [x] `dotnet build -c Release` passes
- [x] Verified in-game: opened the phone and exercised the affected app/screen
- [ ] If this changes user-visible behavior, README is updated
- [x] Matches existing style: uses the shared `Windows/Components/` widgets, no `what` comments
