### PR TITLE
fix(venues): correct ffxiv venues fallback link

### DIFF
--- a/src/Aetherphone/Core/Venues/VenueMapper.cs
+++ b/src/Aetherphone/Core/Venues/VenueMapper.cs
@@ -23,7 +23,7 @@ internal static class VenueMapper
         var teleport = BuildFfxivTeleport(location, world);
         var tags = CollectFfxivTags(dto);
         var description = dto.Description is { Length: > 0 } ? string.Join("\n\n", dto.Description) : string.Empty;
-        var website = !string.IsNullOrEmpty(dto.Website) ? dto.Website : $"https://ffxivvenues.com/{dto.Id}";
+        var website = !string.IsNullOrEmpty(dto.Website) ? dto.Website : $"https://ffxivvenues.com/venue/{dto.Id}";
         return new VenueEvent
         {
             Id = $"ffxiv:{dto.Id}",


### PR DESCRIPTION
## What

Changed FFXIV Venues fallback links in the Venues app to use /venue/{id} instead of /{id}.

## Why

Previous base link sends users to a 404 page on the FFXIV Venues website

## Checklist

- [x] `dotnet build -c Release` passes
- [x] Verified in-game: opened the phone and exercised the affected app/screen
- [ ] If this changes user-visible behavior, README is updated
- [x] Matches existing style: uses the shared `Windows/Components/` widgets, no `what` comments
