### PR TITLE
fix(chrome): correct camera landscape sizing and case rotation

### DIFF
--- a/src/Aetherphone/Apps/Camera/CameraApp.cs
+++ b/src/Aetherphone/Apps/Camera/CameraApp.cs
@@ -47,7 +47,7 @@ internal sealed class CameraApp : IPhoneApp
 
     private static Rect ViewfinderRect(Rect screen, float scale)
     {
-        if (screen.Width > screen.Height)
+        if (screen.IsLandscape())
         {
             return new Rect(new Vector2(screen.Min.X + SideBarWidth * scale, screen.Min.Y),
                 new Vector2(screen.Max.X - SideTrayWidth * scale, screen.Max.Y));
@@ -101,7 +101,7 @@ internal sealed class CameraApp : IPhoneApp
         var rounding = theme.ScreenRounding * scale;
         AdvanceTimers(ImGui.GetIO().DeltaTime);
         var screen = ScreenFrom(context.Content, theme, scale);
-        var landscape = screen.Width > screen.Height;
+        var landscape = screen.IsLandscape();
         var viewfinder = ViewfinderRect(screen, scale);
         var captureRect = CaptureRect(viewfinder);
 

--- a/src/Aetherphone/Core/Rect.cs
+++ b/src/Aetherphone/Core/Rect.cs
@@ -6,6 +6,7 @@ internal readonly record struct Rect(Vector2 Min, Vector2 Max)
     public float Height => Max.Y - Min.Y;
     public Vector2 Size => Max - Min;
     public Vector2 Center => (Min + Max) * 0.5f;
+    public bool IsLandscape() => Width > Height;
     public Rect Inset(float amount) => new(Min + new Vector2(amount, amount), Max - new Vector2(amount, amount));
     public Rect Translate(Vector2 offset) => new(Min + offset, Max + offset);
     public bool Contains(Vector2 point) => point.X >= Min.X && point.X <= Max.X && point.Y >= Min.Y && point.Y <= Max.Y;

--- a/src/Aetherphone/Core/Shell/PhoneShell.cs
+++ b/src/Aetherphone/Core/Shell/PhoneShell.cs
@@ -236,6 +236,9 @@ internal sealed class PhoneShell : IDisposable
         var theme = themes.Chrome;
         var chassis = DeviceChrome.Chassis(device, theme);
         var screen = chassis.Screen;
+        var sideButtonRect = DeviceChrome.SideButtonRect(device, chassis, out var sideButtonSide);
+        var muteButtonRect = DeviceChrome.MuteButtonRect(device, chassis, out var muteButtonSide);
+        var lockButtonRect = DeviceChrome.LockButtonRect(device, chassis, out var lockButtonSide);
         DeviceChrome.DrawBody(chassis, theme, TransparentBand(screen));
         loading.Advance(delta);
         navigation.Advance(delta);
@@ -252,7 +255,7 @@ internal sealed class PhoneShell : IDisposable
         calls.Advance(delta);
         if (!loading.IsActive)
         {
-            switch (sideButton.Update(DeviceChrome.SideButtonRect(device, chassis), theme, delta))
+            switch (sideButton.Update(sideButtonRect, sideButtonSide, theme, delta))
             {
                 case SideButtonAction.Minimize:
                     minimize.BeginCollapse();
@@ -267,14 +270,14 @@ internal sealed class PhoneShell : IDisposable
                 minimize.BeginCollapse();
             }
 
-            if (SideToggle.Update(DeviceChrome.MuteButtonRect(device, chassis), theme, configuration.DoNotDisturb,
+            if (SideToggle.Update(muteButtonRect, muteButtonSide, theme, configuration.DoNotDisturb,
                     Loc.T(configuration.DoNotDisturb ? L.Plugin.DndDisableHint : L.Plugin.DndEnableHint)))
             {
                 configuration.DoNotDisturb = !configuration.DoNotDisturb;
                 configuration.Save();
             }
 
-            if (SideToggle.Update(DeviceChrome.LockButtonRect(device, chassis), theme, configuration.LockPosition,
+            if (SideToggle.Update(lockButtonRect, lockButtonSide, theme, configuration.LockPosition,
                     Loc.T(configuration.LockPosition ? L.Plugin.UnlockPositionHint : L.Plugin.LockPositionHint)))
             {
                 configuration.LockPosition = !configuration.LockPosition;
@@ -297,8 +300,8 @@ internal sealed class PhoneShell : IDisposable
         var state = overlays.Assess(screen);
         director.Advance(delta, state.Busy, navigation.AtHome, navigation.Current?.Id);
         UiAnchors.BeginFrame(director.WantsAnchors);
-        UiAnchors.Report("chrome.lock", DeviceChrome.LockButtonRect(device, chassis));
-        UiAnchors.Report("chrome.minimize", DeviceChrome.SideButtonRect(device, chassis));
+        UiAnchors.Report("chrome.lock", lockButtonRect);
+        UiAnchors.Report("chrome.minimize", sideButtonRect);
         UiAnchors.Report("chrome.controlcenter",
             new Rect(screen.Min, new Vector2(screen.Max.X, screen.Min.Y + 44f * UiScale.Current)));
         using (InputShield.Engage(state.ShieldBase || director.CapturesPointer))

--- a/src/Aetherphone/Core/Theme/ChassisGeometry.cs
+++ b/src/Aetherphone/Core/Theme/ChassisGeometry.cs
@@ -31,11 +31,22 @@ internal readonly struct ChassisGeometry
 
     public static ChassisGeometry Device(Rect window, PhoneTheme theme, float scale)
     {
-        var rail = theme.RailWidth * scale;
-        var body = new Rect(new Vector2(window.Min.X + rail, window.Min.Y),
-            new Vector2(window.Max.X - rail, window.Max.Y));
+        var body = BodyRect(window, theme, scale);
         return new ChassisGeometry(body, theme.DeviceRounding * scale, theme.MetalWidth * scale,
             theme.GlassWidth * scale);
+    }
+
+    public static Rect BodyRect(Rect window, PhoneTheme theme, float scale)
+    {
+        var rail = theme.RailWidth * scale;
+        if (window.Width > window.Height)
+        {
+            return new Rect(new Vector2(window.Min.X, window.Min.Y + rail),
+                new Vector2(window.Max.X, window.Max.Y - rail));
+        }
+
+        return new Rect(new Vector2(window.Min.X + rail, window.Min.Y),
+            new Vector2(window.Max.X - rail, window.Max.Y));
     }
 
     public static ChassisGeometry Puck(Rect body) =>

--- a/src/Aetherphone/Core/Theme/ChassisGeometry.cs
+++ b/src/Aetherphone/Core/Theme/ChassisGeometry.cs
@@ -39,7 +39,7 @@ internal readonly struct ChassisGeometry
     public static Rect BodyRect(Rect window, PhoneTheme theme, float scale)
     {
         var rail = theme.RailWidth * scale;
-        if (window.Width > window.Height)
+        if (window.IsLandscape())
         {
             return new Rect(new Vector2(window.Min.X, window.Min.Y + rail),
                 new Vector2(window.Max.X, window.Max.Y - rail));

--- a/src/Aetherphone/Windows/Components/CaseArt.cs
+++ b/src/Aetherphone/Windows/Components/CaseArt.cs
@@ -35,8 +35,8 @@ internal static class CaseArt
 
         var topRight = new Vector2(art.Max.X, art.Min.Y);
         var bottomLeft = new Vector2(art.Min.X, art.Max.Y);
-        drawList.AddImageQuad(texture, art.Min, topRight, art.Max, bottomLeft, new Vector2(0f, 1f), Vector2.Zero,
-            new Vector2(1f, 0f), Vector2.One, tint);
+        drawList.AddImageQuad(texture, art.Min, topRight, art.Max, bottomLeft, new Vector2(1f, 0f), Vector2.One,
+            new Vector2(0f, 1f), Vector2.Zero, tint);
     }
 
     public static void QuadExcluding(ImDrawListPtr drawList, ImTextureID texture, Rect art, Rect exclude,

--- a/src/Aetherphone/Windows/Components/CaseArt.cs
+++ b/src/Aetherphone/Windows/Components/CaseArt.cs
@@ -14,7 +14,7 @@ internal static class CaseArt
 
     public static Rect RectFor(Rect body)
     {
-        var margin = body.Width * MarginFraction;
+        var margin = MathF.Min(body.Width, body.Height) * MarginFraction;
         return new Rect(body.Min - new Vector2(margin, margin), body.Max + new Vector2(margin, margin));
     }
 

--- a/src/Aetherphone/Windows/Components/CaseArt.cs
+++ b/src/Aetherphone/Windows/Components/CaseArt.cs
@@ -6,6 +6,7 @@ namespace Aetherphone.Windows.Components;
 
 internal static class CaseArt
 {
+    private const float DisplayInset = 1.5f;
     private const uint Opaque = 0xFFFFFFFFu;
 
     public const float MarginFraction = 0.25f;
@@ -25,15 +26,16 @@ internal static class CaseArt
 
     public static void QuadClipped(ImDrawListPtr drawList, ImTextureID texture, Rect art, bool landscape, uint tint)
     {
+        var drawArt = art.Inset(DisplayInset * UiScale.Current);
         if (!landscape)
         {
-            drawList.AddImage(texture, art.Min, art.Max, Vector2.Zero, Vector2.One, tint);
+            drawList.AddImage(texture, drawArt.Min, drawArt.Max, Vector2.Zero, Vector2.One, tint);
             return;
         }
 
-        var topRight = new Vector2(art.Max.X, art.Min.Y);
-        var bottomLeft = new Vector2(art.Min.X, art.Max.Y);
-        drawList.AddImageQuad(texture, art.Min, topRight, art.Max, bottomLeft, new Vector2(1f, 0f), Vector2.One,
+        var topRight = new Vector2(drawArt.Max.X, drawArt.Min.Y);
+        var bottomLeft = new Vector2(drawArt.Min.X, drawArt.Max.Y);
+        drawList.AddImageQuad(texture, drawArt.Min, topRight, drawArt.Max, bottomLeft, new Vector2(1f, 0f), Vector2.One,
             new Vector2(0f, 1f), Vector2.Zero, tint);
     }
 

--- a/src/Aetherphone/Windows/Components/CaseArt.cs
+++ b/src/Aetherphone/Windows/Components/CaseArt.cs
@@ -10,8 +10,6 @@ internal static class CaseArt
 
     public const float MarginFraction = 0.25f;
 
-    public static bool IsLandscape(Rect body) => body.Width > body.Height;
-
     public static Rect RectFor(Rect body)
     {
         var margin = MathF.Min(body.Width, body.Height) * MarginFraction;

--- a/src/Aetherphone/Windows/Components/DeviceChrome.cs
+++ b/src/Aetherphone/Windows/Components/DeviceChrome.cs
@@ -7,6 +7,11 @@ namespace Aetherphone.Windows.Components;
 
 internal static class DeviceChrome
 {
+    private const float SideButtonStartFraction = 0.250f;
+    private const float SideButtonLengthFraction = 0.108f;
+    private const float MuteButtonStartFraction = 0.205f;
+    private const float LockButtonStartFraction = 0.315f;
+    private const float ShortButtonLengthFraction = 0.082f;
     private const float ChamferFraction = 0.4f;
 
     private const float MaskGrow = 0.5f;
@@ -23,13 +28,13 @@ internal static class DeviceChrome
         var device = chassis.Body;
         if (device.IsLandscape())
         {
-            var left = device.Min.X + device.Width * 0.250f;
-            var width = device.Width * 0.108f;
+            var left = device.Min.X + device.Width * SideButtonStartFraction;
+            var width = device.Width * SideButtonLengthFraction;
             return new Rect(new Vector2(left, window.Min.Y), new Vector2(left + width, device.Min.Y + 2f * scale));
         }
 
-        var top = device.Min.Y + device.Height * 0.250f;
-        var height = device.Height * 0.108f;
+        var top = device.Min.Y + device.Height * SideButtonStartFraction;
+        var height = device.Height * SideButtonLengthFraction;
         return new Rect(new Vector2(device.Max.X - 2f * scale, top), new Vector2(window.Max.X, top + height));
     }
 
@@ -39,13 +44,13 @@ internal static class DeviceChrome
         var device = chassis.Body;
         if (device.IsLandscape())
         {
-            var left = device.Min.X + device.Width * 0.205f;
-            var width = device.Width * 0.082f;
+            var left = device.Min.X + device.Width * MuteButtonStartFraction;
+            var width = device.Width * ShortButtonLengthFraction;
             return new Rect(new Vector2(left, device.Max.Y - 2f * scale), new Vector2(left + width, window.Max.Y));
         }
 
-        var top = device.Min.Y + device.Height * 0.205f;
-        var height = device.Height * 0.082f;
+        var top = device.Min.Y + device.Height * MuteButtonStartFraction;
+        var height = device.Height * ShortButtonLengthFraction;
         return new Rect(new Vector2(window.Min.X, top), new Vector2(device.Min.X + 2f * scale, top + height));
     }
 
@@ -55,13 +60,13 @@ internal static class DeviceChrome
         var device = chassis.Body;
         if (device.IsLandscape())
         {
-            var left = device.Min.X + device.Width * 0.315f;
-            var width = device.Width * 0.082f;
+            var left = device.Min.X + device.Width * LockButtonStartFraction;
+            var width = device.Width * ShortButtonLengthFraction;
             return new Rect(new Vector2(left, device.Max.Y - 2f * scale), new Vector2(left + width, window.Max.Y));
         }
 
-        var top = device.Min.Y + device.Height * 0.315f;
-        var height = device.Height * 0.082f;
+        var top = device.Min.Y + device.Height * LockButtonStartFraction;
+        var height = device.Height * ShortButtonLengthFraction;
         return new Rect(new Vector2(window.Min.X, top), new Vector2(device.Min.X + 2f * scale, top + height));
     }
 

--- a/src/Aetherphone/Windows/Components/DeviceChrome.cs
+++ b/src/Aetherphone/Windows/Components/DeviceChrome.cs
@@ -21,7 +21,7 @@ internal static class DeviceChrome
     {
         var scale = UiScale.Current;
         var device = chassis.Body;
-        if (device.Width > device.Height)
+        if (device.IsLandscape())
         {
             var left = device.Min.X + device.Width * 0.250f;
             var width = device.Width * 0.108f;
@@ -37,7 +37,7 @@ internal static class DeviceChrome
     {
         var scale = UiScale.Current;
         var device = chassis.Body;
-        if (device.Width > device.Height)
+        if (device.IsLandscape())
         {
             var left = device.Min.X + device.Width * 0.205f;
             var width = device.Width * 0.082f;
@@ -53,7 +53,7 @@ internal static class DeviceChrome
     {
         var scale = UiScale.Current;
         var device = chassis.Body;
-        if (device.Width > device.Height)
+        if (device.IsLandscape())
         {
             var left = device.Min.X + device.Width * 0.315f;
             var width = device.Width * 0.082f;
@@ -82,7 +82,7 @@ internal static class DeviceChrome
         if (theme.WantsCaseArt && PhoneCaseTextures.Skin(theme.CaseTextureId) is { } bandTexture)
         {
             CaseArt.QuadExcluding(dl, bandTexture, CaseArt.RectFor(chassis.Body), band,
-                CaseArt.IsLandscape(chassis.Body));
+                chassis.Body.IsLandscape());
             paintMetal = false;
         }
 
@@ -130,7 +130,7 @@ internal static class DeviceChrome
                 ImGui.GetColorU32(theme.FrameMetal));
         }
 
-        CaseArt.Quad(dl, texture, CaseArt.RectFor(chassis.Body), CaseArt.IsLandscape(chassis.Body),
+        CaseArt.Quad(dl, texture, CaseArt.RectFor(chassis.Body), chassis.Body.IsLandscape(),
             CaseArt.Tint(artAlpha));
         Squircle.Fill(dl, chassis.Glass.Min, chassis.Glass.Max, chassis.GlassRadius, ImGui.GetColorU32(theme.Glass));
         Squircle.Fill(dl, chassis.Screen.Min, chassis.Screen.Max, chassis.ScreenRadius,

--- a/src/Aetherphone/Windows/Components/DeviceChrome.cs
+++ b/src/Aetherphone/Windows/Components/DeviceChrome.cs
@@ -22,49 +22,55 @@ internal static class DeviceChrome
     public static ChassisGeometry Chassis(Rect window, PhoneTheme theme) =>
         ChassisGeometry.Device(window, theme, UiScale.Current);
 
-    public static Rect SideButtonRect(Rect window, in ChassisGeometry chassis)
+    public static Rect SideButtonRect(Rect window, in ChassisGeometry chassis, out RailSide side)
     {
         var scale = UiScale.Current;
         var device = chassis.Body;
         if (device.IsLandscape())
         {
+            side = RailSide.Top;
             var left = device.Min.X + device.Width * SideButtonStartFraction;
             var width = device.Width * SideButtonLengthFraction;
             return new Rect(new Vector2(left, window.Min.Y), new Vector2(left + width, device.Min.Y + 2f * scale));
         }
 
+        side = RailSide.Right;
         var top = device.Min.Y + device.Height * SideButtonStartFraction;
         var height = device.Height * SideButtonLengthFraction;
         return new Rect(new Vector2(device.Max.X - 2f * scale, top), new Vector2(window.Max.X, top + height));
     }
 
-    public static Rect MuteButtonRect(Rect window, in ChassisGeometry chassis)
+    public static Rect MuteButtonRect(Rect window, in ChassisGeometry chassis, out RailSide side)
     {
         var scale = UiScale.Current;
         var device = chassis.Body;
         if (device.IsLandscape())
         {
+            side = RailSide.Bottom;
             var left = device.Min.X + device.Width * MuteButtonStartFraction;
             var width = device.Width * ShortButtonLengthFraction;
             return new Rect(new Vector2(left, device.Max.Y - 2f * scale), new Vector2(left + width, window.Max.Y));
         }
 
+        side = RailSide.Left;
         var top = device.Min.Y + device.Height * MuteButtonStartFraction;
         var height = device.Height * ShortButtonLengthFraction;
         return new Rect(new Vector2(window.Min.X, top), new Vector2(device.Min.X + 2f * scale, top + height));
     }
 
-    public static Rect LockButtonRect(Rect window, in ChassisGeometry chassis)
+    public static Rect LockButtonRect(Rect window, in ChassisGeometry chassis, out RailSide side)
     {
         var scale = UiScale.Current;
         var device = chassis.Body;
         if (device.IsLandscape())
         {
+            side = RailSide.Bottom;
             var left = device.Min.X + device.Width * LockButtonStartFraction;
             var width = device.Width * ShortButtonLengthFraction;
             return new Rect(new Vector2(left, device.Max.Y - 2f * scale), new Vector2(left + width, window.Max.Y));
         }
 
+        side = RailSide.Left;
         var top = device.Min.Y + device.Height * LockButtonStartFraction;
         var height = device.Height * ShortButtonLengthFraction;
         return new Rect(new Vector2(window.Min.X, top), new Vector2(device.Min.X + 2f * scale, top + height));

--- a/src/Aetherphone/Windows/Components/DeviceChrome.cs
+++ b/src/Aetherphone/Windows/Components/DeviceChrome.cs
@@ -12,10 +12,7 @@ internal static class DeviceChrome
     private const float MaskGrow = 0.5f;
 
     public static Rect BodyRect(Rect window, PhoneTheme theme)
-    {
-        var rail = theme.RailWidth * UiScale.Current;
-        return new Rect(new Vector2(window.Min.X + rail, window.Min.Y), new Vector2(window.Max.X - rail, window.Max.Y));
-    }
+        => ChassisGeometry.BodyRect(window, theme, UiScale.Current);
 
     public static ChassisGeometry Chassis(Rect window, PhoneTheme theme) =>
         ChassisGeometry.Device(window, theme, UiScale.Current);
@@ -24,6 +21,13 @@ internal static class DeviceChrome
     {
         var scale = UiScale.Current;
         var device = chassis.Body;
+        if (device.Width > device.Height)
+        {
+            var left = device.Min.X + device.Width * 0.250f;
+            var width = device.Width * 0.108f;
+            return new Rect(new Vector2(left, window.Min.Y), new Vector2(left + width, device.Min.Y + 2f * scale));
+        }
+
         var top = device.Min.Y + device.Height * 0.250f;
         var height = device.Height * 0.108f;
         return new Rect(new Vector2(device.Max.X - 2f * scale, top), new Vector2(window.Max.X, top + height));
@@ -33,6 +37,13 @@ internal static class DeviceChrome
     {
         var scale = UiScale.Current;
         var device = chassis.Body;
+        if (device.Width > device.Height)
+        {
+            var left = device.Min.X + device.Width * 0.205f;
+            var width = device.Width * 0.082f;
+            return new Rect(new Vector2(left, device.Max.Y - 2f * scale), new Vector2(left + width, window.Max.Y));
+        }
+
         var top = device.Min.Y + device.Height * 0.205f;
         var height = device.Height * 0.082f;
         return new Rect(new Vector2(window.Min.X, top), new Vector2(device.Min.X + 2f * scale, top + height));
@@ -42,6 +53,13 @@ internal static class DeviceChrome
     {
         var scale = UiScale.Current;
         var device = chassis.Body;
+        if (device.Width > device.Height)
+        {
+            var left = device.Min.X + device.Width * 0.315f;
+            var width = device.Width * 0.082f;
+            return new Rect(new Vector2(left, device.Max.Y - 2f * scale), new Vector2(left + width, window.Max.Y));
+        }
+
         var top = device.Min.Y + device.Height * 0.315f;
         var height = device.Height * 0.082f;
         return new Rect(new Vector2(window.Min.X, top), new Vector2(device.Min.X + 2f * scale, top + height));

--- a/src/Aetherphone/Windows/Components/HardwareButton.cs
+++ b/src/Aetherphone/Windows/Components/HardwareButton.cs
@@ -20,7 +20,7 @@ internal static class HardwareButton
         float press, float active)
     {
         var scale = UiScale.Current;
-        Boss(drawList, bounds, theme, scale);
+        Boss(drawList, bounds, theme, side, scale);
 
         var travel = press * PressTravel * scale;
         var shift = side switch
@@ -45,10 +45,10 @@ internal static class HardwareButton
         Squircle.Stroke(drawList, min, max, rounding, ImGui.GetColorU32(Palette.Darken(metal, 0.60f)), 1f * scale);
     }
 
-    private static void Boss(ImDrawListPtr drawList, Rect bounds, PhoneTheme theme, float scale)
+    private static void Boss(ImDrawListPtr drawList, Rect bounds, PhoneTheme theme, RailSide side, float scale)
     {
         var pad = 2.4f * scale;
-        var horizontal = bounds.IsLandscape();
+        var horizontal = side is RailSide.Top or RailSide.Bottom;
         var min = horizontal
             ? new Vector2(bounds.Min.X - pad, bounds.Min.Y)
             : new Vector2(bounds.Min.X, bounds.Min.Y - pad);

--- a/src/Aetherphone/Windows/Components/HardwareButton.cs
+++ b/src/Aetherphone/Windows/Components/HardwareButton.cs
@@ -8,6 +8,8 @@ internal enum RailSide
 {
     Left,
     Right,
+    Top,
+    Bottom,
 }
 
 internal static class HardwareButton
@@ -21,9 +23,15 @@ internal static class HardwareButton
         Boss(drawList, bounds, theme, scale);
 
         var travel = press * PressTravel * scale;
-        var shift = side == RailSide.Right ? -travel : travel;
-        var min = bounds.Min + new Vector2(shift, 0f);
-        var max = bounds.Max + new Vector2(shift, 0f);
+        var shift = side switch
+        {
+            RailSide.Right => new Vector2(-travel, 0f),
+            RailSide.Top => new Vector2(0f, travel),
+            RailSide.Bottom => new Vector2(0f, -travel),
+            _ => new Vector2(travel, 0f),
+        };
+        var min = bounds.Min + shift;
+        var max = bounds.Max + shift;
         var rounding = MathF.Min(max.X - min.X, max.Y - min.Y) * 0.5f;
 
         var metal = theme.RailMetal;
@@ -40,8 +48,13 @@ internal static class HardwareButton
     private static void Boss(ImDrawListPtr drawList, Rect bounds, PhoneTheme theme, float scale)
     {
         var pad = 2.4f * scale;
-        var min = new Vector2(bounds.Min.X, bounds.Min.Y - pad);
-        var max = new Vector2(bounds.Max.X, bounds.Max.Y + pad);
+        var horizontal = bounds.Width > bounds.Height;
+        var min = horizontal
+            ? new Vector2(bounds.Min.X - pad, bounds.Min.Y)
+            : new Vector2(bounds.Min.X, bounds.Min.Y - pad);
+        var max = horizontal
+            ? new Vector2(bounds.Max.X + pad, bounds.Max.Y)
+            : new Vector2(bounds.Max.X, bounds.Max.Y + pad);
         var rounding = MathF.Min(max.X - min.X, max.Y - min.Y) * 0.5f;
         Squircle.Fill(drawList, min, max, rounding, ImGui.GetColorU32(Palette.Lighten(theme.Glass, 0.06f)));
         Squircle.Stroke(drawList, min, max, rounding, ImGui.GetColorU32(new Vector4(0f, 0f, 0f, 0.55f)), 1f * scale);
@@ -50,6 +63,12 @@ internal static class HardwareButton
     private static void Face(ImDrawListPtr drawList, Vector2 min, Vector2 max, float rounding, RailSide side,
         Vector4 crown, Vector4 flank)
     {
+        if (side is RailSide.Top or RailSide.Bottom)
+        {
+            FaceHorizontal(drawList, min, max, rounding, side, crown, flank);
+            return;
+        }
+
         var top = min.Y + rounding;
         var bottom = max.Y - rounding;
         if (bottom <= top)
@@ -72,6 +91,31 @@ internal static class HardwareButton
         drawList.AddRectFilledMultiColor(faceMin, faceMax, crownTop, flankTop, flankBottom, crownBottom);
     }
 
+    private static void FaceHorizontal(ImDrawListPtr drawList, Vector2 min, Vector2 max, float rounding, RailSide side,
+        Vector4 crown, Vector4 flank)
+    {
+        var left = min.X + rounding;
+        var right = max.X - rounding;
+        if (right <= left)
+        {
+            return;
+        }
+
+        var crownTop = ImGui.GetColorU32(Palette.Lighten(crown, 0.10f));
+        var crownBottom = ImGui.GetColorU32(Palette.Darken(crown, 0.12f));
+        var flankTop = ImGui.GetColorU32(Palette.Lighten(flank, 0.08f));
+        var flankBottom = ImGui.GetColorU32(Palette.Darken(flank, 0.10f));
+        var faceMin = new Vector2(left, min.Y);
+        var faceMax = new Vector2(right, max.Y);
+        if (side == RailSide.Top)
+        {
+            drawList.AddRectFilledMultiColor(faceMin, faceMax, crownTop, crownTop, flankBottom, flankBottom);
+            return;
+        }
+
+        drawList.AddRectFilledMultiColor(faceMin, faceMax, flankTop, flankTop, crownBottom, crownBottom);
+    }
+
     private static void CrownSpecular(ImDrawListPtr drawList, Vector2 min, Vector2 max, float rounding, RailSide side,
         bool hovered, float press, float scale)
     {
@@ -82,6 +126,14 @@ internal static class HardwareButton
         }
 
         var color = ImGui.GetColorU32(new Vector4(1f, 1f, 1f, alpha));
+        if (side is RailSide.Top or RailSide.Bottom)
+        {
+            var y = side == RailSide.Top ? min.Y + 1.6f * scale : max.Y - 1.6f * scale;
+            drawList.AddLine(new Vector2(min.X + rounding, y), new Vector2(max.X - rounding, y), color,
+                1.3f * scale);
+            return;
+        }
+
         var x = side == RailSide.Right ? max.X - 1.6f * scale : min.X + 1.6f * scale;
         drawList.AddLine(new Vector2(x, min.Y + rounding), new Vector2(x, max.Y - rounding), color, 1.3f * scale);
     }
@@ -89,6 +141,12 @@ internal static class HardwareButton
     private static void RecessSeam(ImDrawListPtr drawList, Vector2 min, Vector2 max, float rounding, RailSide side,
         float press, float active, PhoneTheme theme, float scale)
     {
+        if (side is RailSide.Top or RailSide.Bottom)
+        {
+            RecessSeamHorizontal(drawList, min, max, rounding, side, press, active, theme, scale);
+            return;
+        }
+
         var innerX = side == RailSide.Right ? min.X + 1f * scale : max.X - 1f * scale;
         var shadow = ImGui.GetColorU32(new Vector4(0f, 0f, 0f, 0.42f + press * 0.30f));
         drawList.AddLine(new Vector2(innerX, min.Y + rounding), new Vector2(innerX, max.Y - rounding), shadow,
@@ -101,6 +159,24 @@ internal static class HardwareButton
         var accent = ImGui.GetColorU32(Palette.WithAlpha(theme.Accent, active));
         var tintX = side == RailSide.Right ? min.X + 2.6f * scale : max.X - 2.6f * scale;
         drawList.AddLine(new Vector2(tintX, min.Y + rounding), new Vector2(tintX, max.Y - rounding), accent,
+            1.6f * scale);
+    }
+
+    private static void RecessSeamHorizontal(ImDrawListPtr drawList, Vector2 min, Vector2 max, float rounding,
+        RailSide side, float press, float active, PhoneTheme theme, float scale)
+    {
+        var innerY = side == RailSide.Top ? max.Y - 1f * scale : min.Y + 1f * scale;
+        var shadow = ImGui.GetColorU32(new Vector4(0f, 0f, 0f, 0.42f + press * 0.30f));
+        drawList.AddLine(new Vector2(min.X + rounding, innerY), new Vector2(max.X - rounding, innerY), shadow,
+            1.4f * scale);
+        if (active <= 0.01f)
+        {
+            return;
+        }
+
+        var accent = ImGui.GetColorU32(Palette.WithAlpha(theme.Accent, active));
+        var tintY = side == RailSide.Top ? max.Y - 2.6f * scale : min.Y + 2.6f * scale;
+        drawList.AddLine(new Vector2(min.X + rounding, tintY), new Vector2(max.X - rounding, tintY), accent,
             1.6f * scale);
     }
 }

--- a/src/Aetherphone/Windows/Components/HardwareButton.cs
+++ b/src/Aetherphone/Windows/Components/HardwareButton.cs
@@ -48,7 +48,7 @@ internal static class HardwareButton
     private static void Boss(ImDrawListPtr drawList, Rect bounds, PhoneTheme theme, float scale)
     {
         var pad = 2.4f * scale;
-        var horizontal = bounds.Width > bounds.Height;
+        var horizontal = bounds.IsLandscape();
         var min = horizontal
             ? new Vector2(bounds.Min.X - pad, bounds.Min.Y)
             : new Vector2(bounds.Min.X, bounds.Min.Y - pad);

--- a/src/Aetherphone/Windows/Components/SideButton.cs
+++ b/src/Aetherphone/Windows/Components/SideButton.cs
@@ -68,7 +68,7 @@ internal sealed class SideButton
     private static void DrawButton(Rect bounds, PhoneTheme theme, bool hovered, float progress, bool pressing)
     {
         var press = pressing ? 0.35f + 0.65f * progress : 0f;
-        var side = bounds.Width > bounds.Height ? RailSide.Top : RailSide.Right;
+        var side = bounds.IsLandscape() ? RailSide.Top : RailSide.Right;
         HardwareButton.Draw(ImGui.GetWindowDrawList(), bounds, theme, side, hovered, press, 0f);
     }
 }

--- a/src/Aetherphone/Windows/Components/SideButton.cs
+++ b/src/Aetherphone/Windows/Components/SideButton.cs
@@ -68,6 +68,7 @@ internal sealed class SideButton
     private static void DrawButton(Rect bounds, PhoneTheme theme, bool hovered, float progress, bool pressing)
     {
         var press = pressing ? 0.35f + 0.65f * progress : 0f;
-        HardwareButton.Draw(ImGui.GetWindowDrawList(), bounds, theme, RailSide.Right, hovered, press, 0f);
+        var side = bounds.Width > bounds.Height ? RailSide.Top : RailSide.Right;
+        HardwareButton.Draw(ImGui.GetWindowDrawList(), bounds, theme, side, hovered, press, 0f);
     }
 }

--- a/src/Aetherphone/Windows/Components/SideButton.cs
+++ b/src/Aetherphone/Windows/Components/SideButton.cs
@@ -15,16 +15,18 @@ internal enum SideButtonAction
 internal sealed class SideButton
 {
     private const float HoldSeconds = 0.45f;
+    private const float InwardHitPadding = 8f;
+    private const float OutwardHitPadding = 4f;
+    private const float AlongHitPadding = 8f;
     private bool armed;
     private float held;
     private bool closeFired;
 
-    public SideButtonAction Update(Rect bounds, PhoneTheme theme, float delta)
+    public SideButtonAction Update(Rect bounds, RailSide side, PhoneTheme theme, float delta)
     {
         var scale = UiScale.Current;
-        var hitMin = new Vector2(bounds.Min.X - 8f * scale, bounds.Min.Y - 8f * scale);
-        var hitMax = new Vector2(bounds.Max.X + 4f * scale, bounds.Max.Y + 8f * scale);
-        var hovered = UiInteract.Hover(hitMin, hitMax);
+        var hit = HitRect(bounds, side, scale);
+        var hovered = UiInteract.Hover(hit.Min, hit.Max);
         var action = SideButtonAction.None;
         if (hovered && ImGui.IsMouseClicked(ImGuiMouseButton.Left))
         {
@@ -55,7 +57,7 @@ internal sealed class SideButton
         }
 
         var progress = armed ? Math.Clamp(held / HoldSeconds, 0f, 1f) : 0f;
-        DrawButton(bounds, theme, hovered, progress, armed);
+        DrawButton(bounds, side, theme, hovered, progress, armed);
         if (hovered)
         {
             ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
@@ -65,10 +67,28 @@ internal sealed class SideButton
         return action;
     }
 
-    private static void DrawButton(Rect bounds, PhoneTheme theme, bool hovered, float progress, bool pressing)
+    private static Rect HitRect(Rect bounds, RailSide side, float scale)
+    {
+        var inward = InwardHitPadding * scale;
+        var outward = OutwardHitPadding * scale;
+        var along = AlongHitPadding * scale;
+        return side switch
+        {
+            RailSide.Top => new Rect(new Vector2(bounds.Min.X - along, bounds.Min.Y - outward),
+                new Vector2(bounds.Max.X + along, bounds.Max.Y + inward)),
+            RailSide.Bottom => new Rect(new Vector2(bounds.Min.X - along, bounds.Min.Y - inward),
+                new Vector2(bounds.Max.X + along, bounds.Max.Y + outward)),
+            RailSide.Left => new Rect(new Vector2(bounds.Min.X - outward, bounds.Min.Y - along),
+                new Vector2(bounds.Max.X + inward, bounds.Max.Y + along)),
+            _ => new Rect(new Vector2(bounds.Min.X - inward, bounds.Min.Y - along),
+                new Vector2(bounds.Max.X + outward, bounds.Max.Y + along)),
+        };
+    }
+
+    private static void DrawButton(Rect bounds, RailSide side, PhoneTheme theme, bool hovered, float progress,
+        bool pressing)
     {
         var press = pressing ? 0.35f + 0.65f * progress : 0f;
-        var side = bounds.IsLandscape() ? RailSide.Top : RailSide.Right;
         HardwareButton.Draw(ImGui.GetWindowDrawList(), bounds, theme, side, hovered, press, 0f);
     }
 }

--- a/src/Aetherphone/Windows/Components/SideToggle.cs
+++ b/src/Aetherphone/Windows/Components/SideToggle.cs
@@ -6,14 +6,13 @@ namespace Aetherphone.Windows.Components;
 
 internal static class SideToggle
 {
-    public static bool Update(Rect bounds, PhoneTheme theme, bool active, string hint)
+    public static bool Update(Rect bounds, RailSide side, PhoneTheme theme, bool active, string hint)
     {
         var scale = UiScale.Current;
         var hitMin = new Vector2(bounds.Min.X - 8f * scale, bounds.Min.Y - 6f * scale);
         var hitMax = new Vector2(bounds.Max.X + 4f * scale, bounds.Max.Y + 6f * scale);
         var hovered = UiInteract.Hover(hitMin, hitMax);
         var press = hovered && ImGui.IsMouseDown(ImGuiMouseButton.Left) ? 1f : 0f;
-        var side = bounds.IsLandscape() ? RailSide.Bottom : RailSide.Left;
         HardwareButton.Draw(ImGui.GetWindowDrawList(), bounds, theme, side, hovered, press, active ? 1f : 0f);
         if (hovered)
         {

--- a/src/Aetherphone/Windows/Components/SideToggle.cs
+++ b/src/Aetherphone/Windows/Components/SideToggle.cs
@@ -13,7 +13,8 @@ internal static class SideToggle
         var hitMax = new Vector2(bounds.Max.X + 4f * scale, bounds.Max.Y + 6f * scale);
         var hovered = UiInteract.Hover(hitMin, hitMax);
         var press = hovered && ImGui.IsMouseDown(ImGuiMouseButton.Left) ? 1f : 0f;
-        HardwareButton.Draw(ImGui.GetWindowDrawList(), bounds, theme, RailSide.Left, hovered, press, active ? 1f : 0f);
+        var side = bounds.Width > bounds.Height ? RailSide.Bottom : RailSide.Left;
+        HardwareButton.Draw(ImGui.GetWindowDrawList(), bounds, theme, side, hovered, press, active ? 1f : 0f);
         if (hovered)
         {
             ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);

--- a/src/Aetherphone/Windows/Components/SideToggle.cs
+++ b/src/Aetherphone/Windows/Components/SideToggle.cs
@@ -13,7 +13,7 @@ internal static class SideToggle
         var hitMax = new Vector2(bounds.Max.X + 4f * scale, bounds.Max.Y + 6f * scale);
         var hovered = UiInteract.Hover(hitMin, hitMax);
         var press = hovered && ImGui.IsMouseDown(ImGuiMouseButton.Left) ? 1f : 0f;
-        var side = bounds.Width > bounds.Height ? RailSide.Bottom : RailSide.Left;
+        var side = bounds.IsLandscape() ? RailSide.Bottom : RailSide.Left;
         HardwareButton.Draw(ImGui.GetWindowDrawList(), bounds, theme, side, hovered, press, active ? 1f : 0f);
         if (hovered)
         {


### PR DESCRIPTION
## What

  - Fixed camera landscape mode so the phone frame, case art, and screen interior keep consistent sizing after rotation.
  - Made the usable screen area stay the same size when the phone turns sideways.
  - Rotated hardware button placement and drawing for landscape, so shell controls stay aligned with the rails.
  - Kept case-art overflow margins based on the short side to avoid oversized landscape frame art.
  - Rotated case art on landscape mode to match the rotation of the hardware buttons

## Why

  Camera landscape swaps the phone window dimensions, but the chrome geometry still treated the X axis as the narrow phone side. That made the frame/case art expand and made the interior lose rail-width pixels horizontally in landscape. Aligning the rail and case-art math with the rotated chassis keeps the phone visually the same size and prevents the camera frame from shrinking or ballooning.

## How to test

 - Open the phone
 - Go to camera
 - Flip to landscape

## Checklist

- [x] `dotnet build -c Release` passes
- [x] Verified in-game: opened the phone and exercised the affected app/screen
- [ ] If this changes user-visible behavior, README is updated
- [x] Matches existing style: uses the shared `Windows/Components/` widgets, no `what` comments
