### PR TITLE
fix(media): cull off-screen thumbnails in photo pickers

### DIFF
--- a/src/Aetherphone/Apps/Feedback/FeedbackApp.cs
+++ b/src/Aetherphone/Apps/Feedback/FeedbackApp.cs
@@ -319,30 +319,40 @@ internal sealed class FeedbackApp : IPhoneApp
             }
 
             var gap = 6f * scale;
-            var cell = (ScrollLayout.StableContentWidth() - gap * (PickerColumns - 1)) / PickerColumns;
-            using (ImRaii.PushStyle(ImGuiStyleVar.ItemSpacing, new Vector2(gap, gap)))
+            var avail = ScrollLayout.StableContentWidth();
+            var cell = (avail - gap * (PickerColumns - 1)) / PickerColumns;
+            var origin = ImGui.GetCursorScreenPos();
+            var scrollY = ImGui.GetScrollY();
+            var viewHeight = ImGui.GetWindowSize().Y;
+            var margin = cell + 60f * scale;
+            for (var index = 0; index < pickerPaths.Length; index++)
             {
-                for (var index = 0; index < pickerPaths.Length; index++)
+                var column = index % PickerColumns;
+                var rowIndex = index / PickerColumns;
+                var rowTop = rowIndex * (cell + gap);
+                if (rowTop + cell < scrollY - margin || rowTop > scrollY + viewHeight + margin)
                 {
-                    ImGui.Dummy(new Vector2(cell, cell));
-                    var min = ImGui.GetItemRectMin();
-                    var max = ImGui.GetItemRectMax();
-                    DrawLocalThumbnail(pickerPaths[index], min, max, scale);
-                    if (UiInteract.Click(min, max, UiInteract.Hover(min, max)))
-                    {
-                        AddAttachment(pickerPaths[index]);
-                    }
+                    continue;
+                }
 
-                    if (index % PickerColumns != PickerColumns - 1)
-                    {
-                        ImGui.SameLine();
-                    }
+                var min = new Vector2(origin.X + column * (cell + gap), origin.Y + rowTop);
+                var max = new Vector2(min.X + cell, min.Y + cell);
+                var hovered = UiInteract.Hover(min, max);
+                DrawLocalThumbnail(pickerPaths[index], min, max, scale, hovered);
+                if (UiInteract.Click(min, max, hovered))
+                {
+                    AddAttachment(pickerPaths[index]);
                 }
             }
+
+            var rows = (pickerPaths.Length + PickerColumns - 1) / PickerColumns;
+            var totalHeight = rows * (cell + gap);
+            ImGui.SetCursorScreenPos(origin);
+            ImGui.Dummy(new Vector2(avail, totalHeight));
         }
     }
 
-    private void DrawLocalThumbnail(string path, Vector2 min, Vector2 max, float scale)
+    private void DrawLocalThumbnail(string path, Vector2 min, Vector2 max, float scale, bool hovered)
     {
         var drawList = ImGui.GetWindowDrawList();
         var rounding = 10f * scale;
@@ -356,7 +366,7 @@ internal sealed class FeedbackApp : IPhoneApp
         var (uv0, uv1) = ImageFit.CoverSquare(texture.Size);
         drawList.AddImageRounded(texture.Handle, min, max, uv0, uv1, 0xFFFFFFFFu, rounding,
             ImDrawFlags.RoundCornersAll);
-        if (ImGui.IsItemHovered())
+        if (hovered)
         {
             drawList.AddRectFilled(min, max, ImGui.GetColorU32(new Vector4(1f, 1f, 1f, 0.1f)), rounding);
             ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);

--- a/src/Aetherphone/Apps/Settings/Pages/WallpaperPage.cs
+++ b/src/Aetherphone/Apps/Settings/Pages/WallpaperPage.cs
@@ -365,29 +365,38 @@ internal sealed class WallpaperPage : ISettingsPage
 
             DragScrollHost.Begin(photosKey);
 
-            var cell = (ScrollLayout.StableContentWidth() - gap * (PhotoColumns - 1)) / PhotoColumns;
+            var avail = ScrollLayout.StableContentWidth();
+            var cell = (avail - gap * (PhotoColumns - 1)) / PhotoColumns;
+            var origin = ImGui.GetCursorScreenPos();
+            var scrollY = ImGui.GetScrollY();
+            var viewHeight = ImGui.GetWindowSize().Y;
+            var margin = cell + 60f * scale;
             for (var index = 0; index < photoPaths.Length; index++)
             {
-                using (ImRaii.PushId(index))
+                var column = index % PhotoColumns;
+                var rowIndex = index / PhotoColumns;
+                var top = rowIndex * (cell + gap);
+                if (top + cell < scrollY - margin || top > scrollY + viewHeight + margin)
                 {
-                    ImGui.Dummy(new Vector2(cell, cell));
-                    var min = ImGui.GetItemRectMin();
-                    var max = ImGui.GetItemRectMax();
-                    DrawPhotoThumb(photoPaths[index], min, max, theme);
-                    if (UiInteract.Click(min, max, UiInteract.Hover(min, max)))
-                    {
-                        overlay = Overlay.None;
-                        navigator.Open(new WallpaperCropPage(photoPaths[index], navigator, assign, wallpapers,
-                            wallpaperImages));
-                        return;
-                    }
+                    continue;
                 }
 
-                if (index % PhotoColumns != PhotoColumns - 1)
+                var min = new Vector2(origin.X + column * (cell + gap), origin.Y + top);
+                var max = new Vector2(min.X + cell, min.Y + cell);
+                DrawPhotoThumb(photoPaths[index], min, max, theme);
+                if (UiInteract.Click(min, max, UiInteract.Hover(min, max)))
                 {
-                    ImGui.SameLine();
+                    overlay = Overlay.None;
+                    navigator.Open(new WallpaperCropPage(photoPaths[index], navigator, assign, wallpapers,
+                        wallpaperImages));
+                    return;
                 }
             }
+
+            var rows = (photoPaths.Length + PhotoColumns - 1) / PhotoColumns;
+            var totalHeight = rows * (cell + gap);
+            ImGui.SetCursorScreenPos(origin);
+            ImGui.Dummy(new Vector2(avail, totalHeight));
         }
     }
 

--- a/src/Aetherphone/Apps/Settings/Pages/WallpaperPage.cs
+++ b/src/Aetherphone/Apps/Settings/Pages/WallpaperPage.cs
@@ -354,7 +354,6 @@ internal sealed class WallpaperPage : ISettingsPage
         var photosKey = ImGui.GetID("##wallpaperPhotos");
         ImGui.SetCursorScreenPos(grid.Min);
         var gap = 6f * scale;
-        using (ImRaii.PushStyle(ImGuiStyleVar.ItemSpacing, new Vector2(gap, gap)))
         using (var child = ImRaii.Child("##wallpaperPhotos", grid.Size, false,
                    DragScrollHost.ScrollFlags(ImGuiWindowFlags.NoBackground)))
         {
@@ -383,8 +382,9 @@ internal sealed class WallpaperPage : ISettingsPage
 
                 var min = new Vector2(origin.X + column * (cell + gap), origin.Y + top);
                 var max = new Vector2(min.X + cell, min.Y + cell);
-                DrawPhotoThumb(photoPaths[index], min, max, theme);
-                if (UiInteract.Click(min, max, UiInteract.Hover(min, max)))
+                var hovered = UiInteract.Hover(min, max);
+                DrawPhotoThumb(photoPaths[index], min, max, theme, hovered);
+                if (UiInteract.Click(min, max, hovered))
                 {
                     overlay = Overlay.None;
                     navigator.Open(new WallpaperCropPage(photoPaths[index], navigator, assign, wallpapers,
@@ -400,7 +400,7 @@ internal sealed class WallpaperPage : ISettingsPage
         }
     }
 
-    private void DrawPhotoThumb(string path, Vector2 min, Vector2 max, PhoneTheme theme)
+    private void DrawPhotoThumb(string path, Vector2 min, Vector2 max, PhoneTheme theme, bool hovered)
     {
         var dl = ImGui.GetWindowDrawList();
         var rounding = 10f * UiScale.Current;
@@ -413,7 +413,7 @@ internal sealed class WallpaperPage : ISettingsPage
 
         var (uv0, uv1) = CenterCrop(texture.Size);
         dl.AddImageRounded(texture.Handle, min, max, uv0, uv1, 0xFFFFFFFFu, rounding, ImDrawFlags.RoundCornersAll);
-        if (ImGui.IsItemHovered())
+        if (hovered)
         {
             dl.AddRectFilled(min, max, ImGui.GetColorU32(new Vector4(1f, 1f, 1f, 0.1f)), rounding);
             ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);

--- a/src/Aetherphone/Apps/YellowPages/YellowPagesApp.Compose.cs
+++ b/src/Aetherphone/Apps/YellowPages/YellowPagesApp.Compose.cs
@@ -9,7 +9,6 @@ using Aetherphone.Core.YellowPages;
 using Aetherphone.Windows.Components;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface;
-using Dalamud.Interface.Utility.Raii;
 
 namespace Aetherphone.Apps.YellowPages;
 
@@ -349,26 +348,35 @@ internal sealed partial class YellowPagesApp
             }
 
             var gap = 6f * scale;
-            var cell = (ScrollLayout.StableContentWidth() - gap * (PickerColumns - 1)) / PickerColumns;
-            using (ImRaii.PushStyle(ImGuiStyleVar.ItemSpacing, new Vector2(gap, gap)))
+            var avail = ScrollLayout.StableContentWidth();
+            var cell = (avail - gap * (PickerColumns - 1)) / PickerColumns;
+            var origin = ImGui.GetCursorScreenPos();
+            var scrollY = ImGui.GetScrollY();
+            var viewHeight = ImGui.GetWindowSize().Y;
+            var margin = cell + 60f * scale;
+            for (var index = 0; index < pickerPaths.Length; index++)
             {
-                for (var index = 0; index < pickerPaths.Length; index++)
+                var column = index % PickerColumns;
+                var rowIndex = index / PickerColumns;
+                var rowTop = rowIndex * (cell + gap);
+                if (rowTop + cell < scrollY - margin || rowTop > scrollY + viewHeight + margin)
                 {
-                    ImGui.Dummy(new Vector2(cell, cell));
-                    var min = ImGui.GetItemRectMin();
-                    var max = ImGui.GetItemRectMax();
-                    DrawPickerThumbnail(pickerPaths[index], min, max, scale);
-                    if (UiInteract.Click(min, max, UiInteract.Hover(min, max)))
-                    {
-                        AddComposePhoto(pickerPaths[index]);
-                    }
+                    continue;
+                }
 
-                    if (index % PickerColumns != PickerColumns - 1)
-                    {
-                        ImGui.SameLine();
-                    }
+                var min = new Vector2(origin.X + column * (cell + gap), origin.Y + rowTop);
+                var max = new Vector2(min.X + cell, min.Y + cell);
+                DrawPickerThumbnail(pickerPaths[index], min, max, scale);
+                if (UiInteract.Click(min, max, UiInteract.Hover(min, max)))
+                {
+                    AddComposePhoto(pickerPaths[index]);
                 }
             }
+
+            var rows = (pickerPaths.Length + PickerColumns - 1) / PickerColumns;
+            var totalHeight = rows * (cell + gap);
+            ImGui.SetCursorScreenPos(origin);
+            ImGui.Dummy(new Vector2(avail, totalHeight));
         }
     }
 

--- a/src/Aetherphone/Apps/YellowPages/YellowPagesApp.Compose.cs
+++ b/src/Aetherphone/Apps/YellowPages/YellowPagesApp.Compose.cs
@@ -366,8 +366,9 @@ internal sealed partial class YellowPagesApp
 
                 var min = new Vector2(origin.X + column * (cell + gap), origin.Y + rowTop);
                 var max = new Vector2(min.X + cell, min.Y + cell);
-                DrawPickerThumbnail(pickerPaths[index], min, max, scale);
-                if (UiInteract.Click(min, max, UiInteract.Hover(min, max)))
+                var hovered = UiInteract.Hover(min, max);
+                DrawPickerThumbnail(pickerPaths[index], min, max, scale, hovered);
+                if (UiInteract.Click(min, max, hovered))
                 {
                     AddComposePhoto(pickerPaths[index]);
                 }
@@ -380,7 +381,7 @@ internal sealed partial class YellowPagesApp
         }
     }
 
-    private void DrawPickerThumbnail(string path, Vector2 min, Vector2 max, float scale)
+    private void DrawPickerThumbnail(string path, Vector2 min, Vector2 max, float scale, bool hovered)
     {
         var drawList = ImGui.GetWindowDrawList();
         var rounding = 10f * scale;
@@ -394,7 +395,7 @@ internal sealed partial class YellowPagesApp
         var (uv0, uv1) = ImageFit.CoverSquare(texture.Size);
         drawList.AddImageRounded(texture.Handle, min, max, uv0, uv1, 0xFFFFFFFFu, rounding,
             ImDrawFlags.RoundCornersAll);
-        if (ImGui.IsItemHovered())
+        if (hovered)
         {
             drawList.AddRectFilled(min, max, ImGui.GetColorU32(new Vector4(1f, 1f, 1f, 0.1f)), rounding);
             ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);

--- a/src/Aetherphone/Windows/Components/ChatThreadView.cs
+++ b/src/Aetherphone/Windows/Components/ChatThreadView.cs
@@ -19,7 +19,6 @@ using Aetherphone.Core.Wallpapers;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface;
 using Dalamud.Interface.Textures.TextureWraps;
-using Dalamud.Interface.Utility.Raii;
 
 namespace Aetherphone.Windows.Components;
 
@@ -859,26 +858,36 @@ internal abstract class ChatThreadView<TMessage, TThread> : IDisposable, IChatTr
 
             const int columns = 3;
             var gap = 6f * scale;
-            var cell = (ScrollLayout.StableContentWidth() - gap * (columns - 1)) / columns;
-            using (ImRaii.PushStyle(ImGuiStyleVar.ItemSpacing, new Vector2(gap, gap)))
+            var avail = ScrollLayout.StableContentWidth();
+            var cell = (avail - gap * (columns - 1)) / columns;
+            var origin = ImGui.GetCursorScreenPos();
+            var scrollY = ImGui.GetScrollY();
+            var viewHeight = ImGui.GetWindowSize().Y;
+            var margin = cell + 60f * scale;
+            for (var index = 0; index < pickerPaths.Length; index++)
             {
-                for (var index = 0; index < pickerPaths.Length; index++)
+                var column = index % columns;
+                var rowIndex = index / columns;
+                var rowTop = rowIndex * (cell + gap);
+                if (rowTop + cell < scrollY - margin || rowTop > scrollY + viewHeight + margin)
                 {
-                    ImGui.Dummy(new Vector2(cell, cell));
-                    var min = ImGui.GetItemRectMin();
-                    var max = ImGui.GetItemRectMax();
-                    DrawPickerThumbnail(pickerPaths[index], min, max, scale);
-                    if (UiInteract.Click(min, max, UiInteract.Hover(min, max)))
-                    {
-                        SendChatImage(threadId, pickerPaths[index]);
-                    }
+                    continue;
+                }
 
-                    if (index % columns != columns - 1)
-                    {
-                        ImGui.SameLine();
-                    }
+                var min = new Vector2(origin.X + column * (cell + gap), origin.Y + rowTop);
+                var max = new Vector2(min.X + cell, min.Y + cell);
+                var hovered = UiInteract.Hover(min, max);
+                DrawPickerThumbnail(pickerPaths[index], min, max, scale, hovered);
+                if (UiInteract.Click(min, max, hovered))
+                {
+                    SendChatImage(threadId, pickerPaths[index]);
                 }
             }
+
+            var rows = (pickerPaths.Length + columns - 1) / columns;
+            var totalHeight = rows * (cell + gap);
+            ImGui.SetCursorScreenPos(origin);
+            ImGui.Dummy(new Vector2(avail, totalHeight));
         }
     }
 
@@ -890,7 +899,7 @@ internal abstract class ChatThreadView<TMessage, TThread> : IDisposable, IChatTr
         PopScreen();
     }
 
-    private void DrawPickerThumbnail(string path, Vector2 min, Vector2 max, float scale)
+    private void DrawPickerThumbnail(string path, Vector2 min, Vector2 max, float scale, bool hovered)
     {
         var drawList = ImGui.GetWindowDrawList();
         var rounding = 10f * scale;
@@ -922,7 +931,7 @@ internal abstract class ChatThreadView<TMessage, TThread> : IDisposable, IChatTr
         }
 
         drawList.AddImageRounded(texture.Handle, min, max, uv0, uv1, 0xFFFFFFFFu, rounding, ImDrawFlags.RoundCornersAll);
-        if (ImGui.IsItemHovered())
+        if (hovered)
         {
             ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
         }

--- a/src/Aetherphone/Windows/Components/ImagePickCrop.cs
+++ b/src/Aetherphone/Windows/Components/ImagePickCrop.cs
@@ -136,8 +136,9 @@ internal sealed class ImagePickCrop
 
                 var min = new Vector2(origin.X + column * (cell + gap), origin.Y + rowTop);
                 var max = new Vector2(min.X + cell, min.Y + cell);
-                DrawThumbnail(pickerPaths[index], min, max, theme, scale);
-                if (UiInteract.Click(min, max, UiInteract.Hover(min, max)))
+                var hovered = UiInteract.Hover(min, max);
+                DrawThumbnail(pickerPaths[index], min, max, theme, scale, hovered);
+                if (UiInteract.Click(min, max, hovered))
                 {
                     BeginCrop(pickerPaths[index]);
                 }
@@ -152,7 +153,7 @@ internal sealed class ImagePickCrop
         return cancelled ? ImagePickCropEvent.Cancelled : ImagePickCropEvent.None;
     }
 
-    private void DrawThumbnail(string path, Vector2 min, Vector2 max, PhoneTheme theme, float scale)
+    private void DrawThumbnail(string path, Vector2 min, Vector2 max, PhoneTheme theme, float scale, bool hovered)
     {
         var drawList = ImGui.GetWindowDrawList();
         var rounding = 10f * scale;
@@ -166,7 +167,7 @@ internal sealed class ImagePickCrop
         var (uv0, uv1) = ImageFit.CoverSquare(texture.Size);
         drawList.AddImageRounded(texture.Handle, min, max, uv0, uv1, 0xFFFFFFFFu, rounding,
             ImDrawFlags.RoundCornersAll);
-        if (ImGui.IsItemHovered())
+        if (hovered)
         {
             drawList.AddRectFilled(min, max, ImGui.GetColorU32(new Vector4(1f, 1f, 1f, 0.1f)), rounding);
             ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);

--- a/src/Aetherphone/Windows/Components/ImagePickCrop.cs
+++ b/src/Aetherphone/Windows/Components/ImagePickCrop.cs
@@ -7,7 +7,6 @@ using Aetherphone.Core.Platform;
 using Aetherphone.Core.Theme;
 using Aetherphone.Core.Wallpapers;
 using Dalamud.Bindings.ImGui;
-using Dalamud.Interface.Utility.Raii;
 
 namespace Aetherphone.Windows.Components;
 
@@ -119,26 +118,35 @@ internal sealed class ImagePickCrop
             }
 
             var gap = 6f * scale;
-            var cell = (ScrollLayout.StableContentWidth() - gap * (GridColumns - 1)) / GridColumns;
-            using (ImRaii.PushStyle(ImGuiStyleVar.ItemSpacing, new Vector2(gap, gap)))
+            var avail = ScrollLayout.StableContentWidth();
+            var cell = (avail - gap * (GridColumns - 1)) / GridColumns;
+            var origin = ImGui.GetCursorScreenPos();
+            var scrollY = ImGui.GetScrollY();
+            var viewHeight = ImGui.GetWindowSize().Y;
+            var margin = cell + 60f * scale;
+            for (var index = 0; index < pickerPaths.Length; index++)
             {
-                for (var index = 0; index < pickerPaths.Length; index++)
+                var column = index % GridColumns;
+                var rowIndex = index / GridColumns;
+                var rowTop = rowIndex * (cell + gap);
+                if (rowTop + cell < scrollY - margin || rowTop > scrollY + viewHeight + margin)
                 {
-                    ImGui.Dummy(new Vector2(cell, cell));
-                    var min = ImGui.GetItemRectMin();
-                    var max = ImGui.GetItemRectMax();
-                    DrawThumbnail(pickerPaths[index], min, max, theme, scale);
-                    if (UiInteract.Click(min, max, UiInteract.Hover(min, max)))
-                    {
-                        BeginCrop(pickerPaths[index]);
-                    }
+                    continue;
+                }
 
-                    if (index % GridColumns != GridColumns - 1)
-                    {
-                        ImGui.SameLine();
-                    }
+                var min = new Vector2(origin.X + column * (cell + gap), origin.Y + rowTop);
+                var max = new Vector2(min.X + cell, min.Y + cell);
+                DrawThumbnail(pickerPaths[index], min, max, theme, scale);
+                if (UiInteract.Click(min, max, UiInteract.Hover(min, max)))
+                {
+                    BeginCrop(pickerPaths[index]);
                 }
             }
+
+            var rows = (pickerPaths.Length + GridColumns - 1) / GridColumns;
+            var totalHeight = rows * (cell + gap);
+            ImGui.SetCursorScreenPos(origin);
+            ImGui.Dummy(new Vector2(avail, totalHeight));
         }
 
         return cancelled ? ImagePickCropEvent.Cancelled : ImagePickCropEvent.None;

--- a/src/Aetherphone/Windows/Components/PhotoComposeSession.cs
+++ b/src/Aetherphone/Windows/Components/PhotoComposeSession.cs
@@ -229,13 +229,14 @@ internal sealed class PhotoComposeSession
             var min = new Vector2(origin.X + column * (cell + gap), origin.Y + top);
             var max = new Vector2(min.X + cell, min.Y + cell);
             var path = pickerPaths[index];
-            DrawLocalThumbnail(path, min, max, scale, style.PlaceholderFill);
+            var hovered = UiInteract.Hover(min, max);
+            DrawLocalThumbnail(path, min, max, scale, style.PlaceholderFill, hovered);
             if (showBadges)
             {
                 DrawPickBadge(path, min, max, scale, style.Accent);
             }
 
-            if (UiInteract.Click(min, max, UiInteract.Hover(min, max)))
+            if (UiInteract.Click(min, max, hovered))
             {
                 TakePicked(path);
             }
@@ -270,7 +271,8 @@ internal sealed class PhotoComposeSession
             TextStyles.FootnoteEmphasized);
     }
 
-    public void DrawLocalThumbnail(string path, Vector2 min, Vector2 max, float scale, Vector4 placeholderFill)
+    public void DrawLocalThumbnail(string path, Vector2 min, Vector2 max, float scale, Vector4 placeholderFill,
+        bool hovered)
     {
         var drawList = ImGui.GetWindowDrawList();
         var rounding = 10f * scale;
@@ -284,7 +286,7 @@ internal sealed class PhotoComposeSession
         var (uv0, uv1) = ImageFit.CoverSquare(texture.Size);
         drawList.AddImageRounded(texture.Handle, min, max, uv0, uv1, 0xFFFFFFFFu, rounding,
             ImDrawFlags.RoundCornersAll);
-        if (ImGui.IsItemHovered())
+        if (hovered)
         {
             drawList.AddRectFilled(min, max, ImGui.GetColorU32(new Vector4(1f, 1f, 1f, 0.1f)), rounding);
             ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
@@ -390,7 +392,7 @@ internal sealed class PhotoComposeSession
         {
             var min = new Vector2(startX + index * (side + gap), strip.Min.Y);
             var max = min + new Vector2(side, side);
-            DrawLocalThumbnail(selected[index], min, max, scale, style.PlaceholderFill);
+            DrawLocalThumbnail(selected[index], min, max, scale, style.PlaceholderFill, UiInteract.Hover(min, max));
             if (index == PreviewIndex)
             {
                 drawList.AddRect(min, max, ImGui.GetColorU32(style.Accent), 8f * scale, ImDrawFlags.RoundCornersAll,

--- a/src/Aetherphone/Windows/Components/PhotoComposeSession.cs
+++ b/src/Aetherphone/Windows/Components/PhotoComposeSession.cs
@@ -8,7 +8,6 @@ using Aetherphone.Core.Theme;
 using Aetherphone.Core.Wallpapers;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Textures.TextureWraps;
-using Dalamud.Interface.Utility.Raii;
 
 namespace Aetherphone.Windows.Components;
 
@@ -211,31 +210,41 @@ internal sealed class PhotoComposeSession
     public void DrawPickGrid(Rect gridRect, float scale, in PhotoComposeStyle style, bool showBadges)
     {
         var gap = 6f * scale;
-        var cell = (ScrollLayout.StableContentWidth() - gap * (GridColumns - 1)) / GridColumns;
-        using (ImRaii.PushStyle(ImGuiStyleVar.ItemSpacing, new Vector2(gap, gap)))
+        var avail = ScrollLayout.StableContentWidth();
+        var cell = (avail - gap * (GridColumns - 1)) / GridColumns;
+        var origin = ImGui.GetCursorScreenPos();
+        var scrollY = ImGui.GetScrollY();
+        var viewHeight = ImGui.GetWindowSize().Y;
+        var margin = cell + 60f * scale;
+        for (var index = 0; index < pickerPaths.Length; index++)
         {
-            for (var index = 0; index < pickerPaths.Length; index++)
+            var column = index % GridColumns;
+            var rowIndex = index / GridColumns;
+            var top = rowIndex * (cell + gap);
+            if (top + cell < scrollY - margin || top > scrollY + viewHeight + margin)
             {
-                ImGui.Dummy(new Vector2(cell, cell));
-                var min = ImGui.GetItemRectMin();
-                var max = ImGui.GetItemRectMax();
-                DrawLocalThumbnail(pickerPaths[index], min, max, scale, style.PlaceholderFill);
-                if (showBadges)
-                {
-                    DrawPickBadge(pickerPaths[index], min, max, scale, style.Accent);
-                }
+                continue;
+            }
 
-                if (UiInteract.Click(min, max, UiInteract.Hover(min, max)))
-                {
-                    TakePicked(pickerPaths[index]);
-                }
+            var min = new Vector2(origin.X + column * (cell + gap), origin.Y + top);
+            var max = new Vector2(min.X + cell, min.Y + cell);
+            var path = pickerPaths[index];
+            DrawLocalThumbnail(path, min, max, scale, style.PlaceholderFill);
+            if (showBadges)
+            {
+                DrawPickBadge(path, min, max, scale, style.Accent);
+            }
 
-                if (index % GridColumns != GridColumns - 1)
-                {
-                    ImGui.SameLine();
-                }
+            if (UiInteract.Click(min, max, UiInteract.Hover(min, max)))
+            {
+                TakePicked(path);
             }
         }
+
+        var rows = (pickerPaths.Length + GridColumns - 1) / GridColumns;
+        var totalHeight = rows * (cell + gap);
+        ImGui.SetCursorScreenPos(origin);
+        ImGui.Dummy(new Vector2(avail, totalHeight));
     }
 
     private void DrawPickBadge(string path, Vector2 min, Vector2 max, float scale, Vector4 accent)


### PR DESCRIPTION
## Summary

Four photo picker grids decoded every image in their source list on every frame, with no check for what was actually scrolled into view: the compose "+" picker shared by Aethergram and Velvet, the wallpaper picker, the avatar and music station crop picker, and the classified ad photo picker.

Users with large photo libraries hit crashes and freezes opening these. One report in Discord: deleting photos fixed it for them. Decode count caused it, not image size. PR #69 already caps single-image dimensions, so one large photo can't do this on its own.

## Root cause

`PhotosApp.Grid.cs` already virtualizes its grid: it checks `scrollY`/`viewHeight`/`margin` before decoding a row. These four pickers used `ImGui.Dummy` plus `SameLine` auto-layout instead, looping the full path array and calling `Get()` on every entry regardless of visibility.

## Fix

I ported the scroll-culling pattern from `PhotosApp.Grid.cs` to all four sites: compute each cell's position directly, skip decode and click handling for rows outside `scrollY ± margin`, reserve the full scroll height with a trailing `Dummy`.

Three files (`PhotoComposeSession.cs`, `ImagePickCrop.cs`, `YellowPagesApp.Compose.cs`) used `ImRaii.PushStyle(ItemSpacing)` to space the old auto-layout grid. The new manual layout computes spacing itself, so that call and its `using Dalamud.Interface.Utility.Raii;` import are gone from those three. `WallpaperPage.cs` still uses `ImRaii` elsewhere, so its import stays.

## Testing

Local dev build, 2880 dummy photos (1280x720) dropped into the Photos library, opened the compose picker before and after.

- Before: memory spiked roughly 4GB above idle, UI froze.
- After: negligible RAM impact, no freeze.

This dataset didn't produce a full crash, only a freeze, but the mechanism matches what caused the reported crashes on larger or higher resolution libraries. I confirmed the other three pickers build and follow the identical code path; I didn't load-test each one individually.