### PR TITLE
fix(core): harden session, settings, and realtime lifecycle races

### DIFF
--- a/src/Aetherphone/Apps/Aethergram/AethergramApp.Settings.cs
+++ b/src/Aetherphone/Apps/Aethergram/AethergramApp.Settings.cs
@@ -138,12 +138,14 @@ internal sealed partial class AethergramApp
                 {
                     messagePolicy = me.MessagePolicy;
                     privateAccount = me.IsPrivate;
-                    messagePolicyLoaded = true;
                 }
+
+                messagePolicyLoaded = true;
             }
             catch (Exception exception)
             {
                 AepLog.Warning($"Aethergram message privacy load failed: {exception.Message}");
+                messagePolicyLoaded = true;
             }
             finally
             {

--- a/src/Aetherphone/Apps/Clock/ClockApp.Alarms.cs
+++ b/src/Aetherphone/Apps/Clock/ClockApp.Alarms.cs
@@ -54,7 +54,7 @@ internal sealed partial class ClockApp
     {
         var scale = UiScale.Current;
         var timeInk = alarm.Enabled ? ui.TitleInk : ui.MutedInk;
-        var time = $"{alarm.Hour:D2}:{alarm.Minute:D2}";
+        var time = TimeText.Clock(new DateTime(1, 1, 1, alarm.Hour, alarm.Minute, 0));
         var timeSize = Typography.Measure(time, TextStyles.Title1);
         Typography.Draw(new Vector2(row.Min.X, row.Center.Y - timeSize.Y * 0.5f), time, timeInk, TextStyles.Title1);
 

--- a/src/Aetherphone/Apps/Collections/CollectionsApp.Browse.cs
+++ b/src/Aetherphone/Apps/Collections/CollectionsApp.Browse.cs
@@ -539,6 +539,9 @@ internal sealed partial class CollectionsApp
 
     private void DrawOwnershipSegments(Rect bar)
     {
+        ownershipLabels[0] = Loc.T(L.Collections.FilterAll);
+        ownershipLabels[1] = Loc.T(L.Collections.FilterOwned);
+        ownershipLabels[2] = Loc.T(L.Collections.FilterMissing);
         var selected = SegmentStrip.Draw("collections.ownership", bar, ownershipLabels, (int)ownership, ui.Palette);
         if (selected != (int)ownership)
         {

--- a/src/Aetherphone/Apps/Collections/CollectionsApp.cs
+++ b/src/Aetherphone/Apps/Collections/CollectionsApp.cs
@@ -89,9 +89,6 @@ internal sealed partial class CollectionsApp : IPhoneApp
     {
         router.Reset();
         ResetFilters();
-        ownershipLabels[0] = Loc.T(L.Collections.FilterAll);
-        ownershipLabels[1] = Loc.T(L.Collections.FilterOwned);
-        ownershipLabels[2] = Loc.T(L.Collections.FilterMissing);
         lodestoneId = ResolveLocalId();
         catalog.ResetOwned();
         catalog.ResetSummaries();

--- a/src/Aetherphone/Apps/Settings/Pages/AccountPage.cs
+++ b/src/Aetherphone/Apps/Settings/Pages/AccountPage.cs
@@ -544,7 +544,9 @@ internal sealed class AccountPage : ISettingsPage, IDisposable
                 AddAccount();
             }
 
-            if (SettingsRow.Bool(actions.NextRow(), Loc.T(L.Account.FollowCharacter), session.FollowsCharacter, theme))
+            var followCharacter = SettingsRow.Bool(actions.NextRow(), Loc.T(L.Account.FollowCharacter),
+                session.FollowsCharacter, theme);
+            if (followCharacter != session.FollowsCharacter)
             {
                 ToggleFollowCharacter();
             }

--- a/src/Aetherphone/Apps/Settings/Pages/AppearancePage.cs
+++ b/src/Aetherphone/Apps/Settings/Pages/AppearancePage.cs
@@ -49,7 +49,7 @@ internal sealed class AppearancePage : ISettingsPage
         {
             SettingsSection.Header(Loc.T(L.Settings.Theme), theme);
             var accentLabel = Loc.T(L.Settings.Accent);
-            var cardWidth = ImGui.GetContentRegionAvail().X - 2f * Metrics.Space.Lg * UiScale.Current;
+            var cardWidth = ScrollLayout.StableContentWidth() - 2f * Metrics.Space.Lg * UiScale.Current;
             var accentStacked = SwatchStrip.NeedsTwoRows(accentLabel, ThemeCatalog.Accents.Count + 1, cardWidth);
             var card = GroupCard.Begin(theme, accentStacked ? 5 : 4);
             var modeIndex = SegmentStrip.Draw("settings.themeMode", card.NextRow(), ModeLabels(), CurrentModeIndex(),
@@ -179,12 +179,12 @@ internal sealed class AppearancePage : ISettingsPage
     {
         SettingsSection.Header(Loc.T(L.Home.HomeScreen), theme);
         var card = GroupCard.Begin(theme, 3);
+        var previousDensityIndex = DensityIndex(configuration.HomeGridRows);
         var densityIndex = SegmentStrip.Draw("settings.homeGrid", card.NextRow(), DensityLabels(),
-            DensityIndex(configuration.HomeGridRows), theme);
-        var rows = GridRowOptions[densityIndex];
-        if (rows != configuration.HomeGridRows)
+            previousDensityIndex, theme);
+        if (densityIndex != previousDensityIndex)
         {
-            configuration.HomeGridRows = rows;
+            configuration.HomeGridRows = GridRowOptions[densityIndex];
             configuration.Save();
         }
 

--- a/src/Aetherphone/Apps/Settings/Pages/NamePage.cs
+++ b/src/Aetherphone/Apps/Settings/Pages/NamePage.cs
@@ -27,7 +27,7 @@ internal sealed class NamePage : ISettingsPage, IDisposable
     private readonly CancellationTokenSource cancellation = new();
     private string editDisplay = string.Empty;
     private string editHandle = string.Empty;
-    private string editStatus = string.Empty;
+    private LocString? editStatusKey;
     private string? loadedFor;
     private volatile bool busy;
     private volatile int outcome;
@@ -69,13 +69,13 @@ internal sealed class NamePage : ISettingsPage, IDisposable
         if (outcome == 2)
         {
             outcome = 0;
-            editStatus = Loc.T(L.Account.HandleTaken);
+            editStatusKey = L.Account.HandleTaken;
         }
 
         if (outcome == 3)
         {
             outcome = 0;
-            editStatus = Loc.T(L.Account.CannotReach);
+            editStatusKey = L.Account.CannotReach;
         }
 
         if (loadedFor != user.Id)
@@ -83,7 +83,7 @@ internal sealed class NamePage : ISettingsPage, IDisposable
             loadedFor = user.Id;
             editDisplay = user.DisplayName;
             editHandle = user.Handle;
-            editStatus = string.Empty;
+            editStatusKey = null;
         }
 
         using (AppSurface.Begin(body))
@@ -101,12 +101,12 @@ internal sealed class NamePage : ISettingsPage, IDisposable
                 Save();
             }
 
-            if (editStatus.Length > 0)
+            if (editStatusKey is { } statusKey)
             {
                 ImGui.Dummy(new Vector2(0f, 10f * scale));
                 using (ImRaii.PushColor(ImGuiCol.Text, theme.Danger))
                 {
-                    Typography.Wrapped(editStatus);
+                    Typography.Wrapped(Loc.T(statusKey));
                 }
             }
 
@@ -188,12 +188,12 @@ internal sealed class NamePage : ISettingsPage, IDisposable
 
         if (editDisplay.Trim().Length == 0 || !SocialProfilePages.IsHandleValid(editHandle))
         {
-            editStatus = Loc.T(L.Account.HandleRules);
+            editStatusKey = L.Account.HandleRules;
             return;
         }
 
         busy = true;
-        editStatus = string.Empty;
+        editStatusKey = null;
         var request = new UpdateProfileRequest(editDisplay.Trim(), editHandle.Trim(), null);
         var token = cancellation.Token;
         _ = Task.Run(async () =>

--- a/src/Aetherphone/Apps/Settings/Pages/PrivacyPage.cs
+++ b/src/Aetherphone/Apps/Settings/Pages/PrivacyPage.cs
@@ -226,12 +226,15 @@ internal sealed class PrivacyPage : ISettingsPage, IDisposable
                 {
                     shareReadReceipts = me.ShareReadReceipts;
                     sharePresence = me.SharePresence;
-                    chatPrivacyLoaded = true;
                 }
+
+                // Latch loaded even on null/failure so a dead endpoint cannot refetch every frame.
+                chatPrivacyLoaded = true;
             }
             catch (Exception exception)
             {
                 AepLog.Warning($"Chat privacy load failed: {exception.Message}");
+                chatPrivacyLoaded = true;
             }
             finally
             {

--- a/src/Aetherphone/Apps/Settings/Pages/ProfilePage.cs
+++ b/src/Aetherphone/Apps/Settings/Pages/ProfilePage.cs
@@ -40,7 +40,11 @@ internal sealed class ProfilePage : ISettingsPage, IDisposable
         var theme = context.Theme;
         using (AppSurface.Begin(body))
         {
-            if (session.IsSignedIn && session.CurrentUser is not null && !initialSynced)
+            if (!session.IsSignedIn)
+            {
+                initialSynced = false;
+            }
+            else if (session.CurrentUser is not null && !initialSynced)
             {
                 initialSynced = true;
                 PushTimeZone(null);

--- a/src/Aetherphone/Apps/Settings/Pages/RootSettingsPage.cs
+++ b/src/Aetherphone/Apps/Settings/Pages/RootSettingsPage.cs
@@ -116,7 +116,8 @@ internal sealed class RootSettingsPage : ISettingsPage
         var size = Typography.Measure(label, 0.78f);
         var origin = ImGui.GetCursorScreenPos();
         var avail = ImGui.GetContentRegionAvail().X;
-        Typography.Draw(new Vector2(origin.X + (avail - size.X) * 0.5f, origin.Y), label, theme.TextMuted, 0.78f);
+        Typography.Draw(ImGui.GetWindowDrawList(), new Vector2(origin.X + (avail - size.X) * 0.5f, origin.Y), label,
+            theme.TextMuted, 0.78f);
         ImGui.Dummy(new Vector2(avail, size.Y));
     }
 }

--- a/src/Aetherphone/Apps/Settings/Pages/TagsMentionsPage.cs
+++ b/src/Aetherphone/Apps/Settings/Pages/TagsMentionsPage.cs
@@ -131,12 +131,14 @@ internal sealed class TagsMentionsPage : ISettingsPage, IDisposable
                     mentionPolicy = me.MentionPolicy;
                     tagPolicy = me.TagPolicy;
                     requireTagApproval = me.RequireTagApproval;
-                    loaded = true;
                 }
+
+                loaded = true;
             }
             catch (Exception exception)
             {
                 AepLog.Warning($"Tag privacy load failed: {exception.Message}");
+                loaded = true;
             }
             finally
             {

--- a/src/Aetherphone/Core/Aethernet/SignInFlow.cs
+++ b/src/Aetherphone/Core/Aethernet/SignInFlow.cs
@@ -101,7 +101,7 @@ internal sealed class SignInFlow : IDisposable
                 if (result.Auth is { } auth)
                 {
                     session.SignIn(auth.Token, auth.User);
-                    signedIn?.Invoke();
+                    _ = Plugin.Framework.RunOnFrameworkThread(() => signedIn?.Invoke());
                     Reset();
                     return;
                 }
@@ -188,7 +188,7 @@ internal sealed class SignInFlow : IDisposable
             if (result.Auth is { } auth)
             {
                 session.SignIn(auth.Token, auth.User);
-                signedIn?.Invoke();
+                _ = Plugin.Framework.RunOnFrameworkThread(() => signedIn?.Invoke());
                 Reset();
                 return;
             }

--- a/src/Aetherphone/Core/Aethernet/StoreWork.cs
+++ b/src/Aetherphone/Core/Aethernet/StoreWork.cs
@@ -67,6 +67,5 @@ internal sealed class StoreWork : IDisposable
     public void Dispose()
     {
         cancellation.Cancel();
-        cancellation.Dispose();
     }
 }

--- a/src/Aetherphone/Core/Confirm/ConfirmService.cs
+++ b/src/Aetherphone/Core/Confirm/ConfirmService.cs
@@ -25,6 +25,12 @@ internal sealed class ConfirmService
 
     public void Ask(ConfirmRequest request)
     {
+        if (!Plugin.Framework.IsInFrameworkUpdateThread)
+        {
+            _ = Plugin.Framework.RunOnFrameworkThread(() => Ask(request));
+            return;
+        }
+
         if (Active is not null)
         {
             queued.Enqueue(request);
@@ -64,15 +70,26 @@ internal sealed class ConfirmService
             Status = null;
             handler(ok =>
             {
-                Busy = false;
-                if (ok)
+                void Finish()
                 {
-                    Advance();
+                    Busy = false;
+                    if (ok)
+                    {
+                        Advance();
+                    }
+                    else
+                    {
+                        Status = request.FailedMessage;
+                    }
                 }
-                else
+
+                if (!Plugin.Framework.IsInFrameworkUpdateThread)
                 {
-                    Status = request.FailedMessage;
+                    _ = Plugin.Framework.RunOnFrameworkThread(Finish);
+                    return;
                 }
+
+                Finish();
             });
             return;
         }

--- a/src/Aetherphone/Core/Confirm/ConfirmService.cs
+++ b/src/Aetherphone/Core/Confirm/ConfirmService.cs
@@ -25,9 +25,11 @@ internal sealed class ConfirmService
 
     public void Ask(ConfirmRequest request)
     {
-        if (!Plugin.Framework.IsInFrameworkUpdateThread)
+        // Plugin.Framework is null in unit tests - run inline there. In-game, hop onto the
+        // Framework thread when Ask arrives from a websocket / worker callback.
+        if (Plugin.Framework is { } framework && !framework.IsInFrameworkUpdateThread)
         {
-            _ = Plugin.Framework.RunOnFrameworkThread(() => Ask(request));
+            _ = framework.RunOnFrameworkThread(() => Ask(request));
             return;
         }
 
@@ -83,9 +85,9 @@ internal sealed class ConfirmService
                     }
                 }
 
-                if (!Plugin.Framework.IsInFrameworkUpdateThread)
+                if (Plugin.Framework is { } framework && !framework.IsInFrameworkUpdateThread)
                 {
-                    _ = Plugin.Framework.RunOnFrameworkThread(Finish);
+                    _ = framework.RunOnFrameworkThread(Finish);
                     return;
                 }
 

--- a/src/Aetherphone/Core/Crypto/KeyVault.cs
+++ b/src/Aetherphone/Core/Crypto/KeyVault.cs
@@ -24,22 +24,26 @@ internal sealed class KeyVault : IDisposable
     private EcPrivateKey? privateKey;
     private MyKeysDto? serverBundle;
     private volatile bool refreshing;
+    private string? lastUserId;
 
     public KeyVault(Configuration configuration, AethernetSession session, KeysClient client)
     {
         this.configuration = configuration;
         this.session = session;
         this.client = client;
+        lastUserId = session.CurrentUser?.Id;
         session.Changed += OnSessionChanged;
     }
 
     private void OnSessionChanged()
     {
-        if (session.IsSignedIn)
+        var userId = session.CurrentUser?.Id;
+        if (string.Equals(userId, lastUserId, StringComparison.Ordinal))
         {
             return;
         }
 
+        lastUserId = userId;
         _ = RefreshAsync(CancellationToken.None);
     }
 

--- a/src/Aetherphone/Core/Message/ChatThreadStoreBase.cs
+++ b/src/Aetherphone/Core/Message/ChatThreadStoreBase.cs
@@ -104,7 +104,7 @@ internal abstract class ChatThreadStoreBase<TMessage, TThread> : IDisposable
     private void OnSessionAccountChanged()
     {
         var accountId = session.CurrentUser?.Id;
-        if (accountId is null || string.Equals(accountId, lastAccountId, StringComparison.Ordinal))
+        if (string.Equals(accountId, lastAccountId, StringComparison.Ordinal))
         {
             return;
         }

--- a/src/Aetherphone/Core/Telephony/CallAudioController.cs
+++ b/src/Aetherphone/Core/Telephony/CallAudioController.cs
@@ -44,13 +44,15 @@ internal sealed class CallAudioController
             return false;
         }
 
+        if (localSlot < 0)
+        {
+            return false;
+        }
+
         var input = AudioDevices.ResolveInput(configuration.CallInputDevice);
         var output = AudioDevices.ResolveOutput(configuration.CallOutputDevice);
         var created = new CallSession(callId, connection, input, output, volume) { Muted = muted, };
-        if (localSlot >= 0)
-        {
-            created.SetLocalSlot(localSlot);
-        }
+        created.SetLocalSlot(localSlot);
 
         session = created;
         remoteSlots.Clear();

--- a/src/Aetherphone/Core/Telephony/CallHub.cs
+++ b/src/Aetherphone/Core/Telephony/CallHub.cs
@@ -468,7 +468,25 @@ internal sealed class CallHub : IDisposable
                 return;
             }
 
-            var pending = 0;
+            var fromId = message.From?.UserId;
+            if (fromId is not null)
+            {
+                if (dialingTo?.UserId == fromId)
+                {
+                    dialingTo = null;
+                }
+
+                for (var index = 0; index < roster.Length; index++)
+                {
+                    if (roster[index].UserId == fromId)
+                    {
+                        var participant = roster[index];
+                        roster[index] = participant with { State = ParticipantState.Left };
+                    }
+                }
+            }
+
+            var pending = dialingTo is not null ? 1 : 0;
             for (var index = 0; index < roster.Length; index++)
             {
                 var participant = roster[index];

--- a/src/Aetherphone/Core/Telephony/RealtimeConnection.cs
+++ b/src/Aetherphone/Core/Telephony/RealtimeConnection.cs
@@ -11,12 +11,16 @@ internal sealed class RealtimeConnection : IDisposable
     private const int MaxMessageBytes = 1024 * 1024;
     private static readonly TimeSpan HealthyConnectionThreshold = TimeSpan.FromSeconds(60);
     private static readonly TimeSpan SendTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan StopJoinTimeout = TimeSpan.FromSeconds(2);
     private readonly AethernetSession session;
     private readonly object gate = new();
     private readonly SemaphoreSlim sendLock = new(1, 1);
     private CancellationTokenSource? lifetime;
     private ClientWebSocket? socket;
+    private Task? runTask;
+    private int generation;
     private volatile bool connected;
+    private volatile bool disposed;
 
     public RealtimeConnection(AethernetSession session)
     {
@@ -32,14 +36,15 @@ internal sealed class RealtimeConnection : IDisposable
     {
         lock (gate)
         {
-            if (lifetime is not null)
+            if (disposed || lifetime is not null)
             {
                 return;
             }
 
             lifetime = new CancellationTokenSource();
             var token = lifetime.Token;
-            _ = Task.Run(() => RunAsync(token));
+            var runGeneration = ++generation;
+            runTask = Task.Run(() => RunAsync(token, runGeneration));
         }
     }
 
@@ -47,12 +52,14 @@ internal sealed class RealtimeConnection : IDisposable
     {
         CancellationTokenSource? toCancel;
         ClientWebSocket? toAbort;
+        Task? toWait;
         lock (gate)
         {
             toCancel = lifetime;
             lifetime = null;
             toAbort = socket;
-            socket = null;
+            toWait = runTask;
+            runTask = null;
         }
 
         toCancel?.Cancel();
@@ -65,20 +72,33 @@ internal sealed class RealtimeConnection : IDisposable
             AepLog.Warning($"Realtime abort failed: {exception.Message}");
         }
 
-        toAbort?.Dispose();
+        // The receive loop owns the socket via `using` - only Abort here so its Dispose runs once.
+        if (toWait is not null)
+        {
+            try
+            {
+                toWait.Wait(StopJoinTimeout);
+            }
+            catch (Exception exception)
+            {
+                AepLog.Warning($"Realtime stop join failed: {exception.Message}");
+            }
+        }
+
         toCancel?.Dispose();
         SetConnected(false);
     }
 
-    private async Task RunAsync(CancellationToken token)
+    private async Task RunAsync(CancellationToken token, int runGeneration)
     {
         var attempt = 0;
         while (!token.IsCancellationRequested)
         {
             var connectedAtUtc = DateTime.MinValue;
+            ClientWebSocket? ws = null;
             try
             {
-                using var ws = new ClientWebSocket();
+                ws = new ClientWebSocket();
                 ws.Options.KeepAliveInterval = TimeSpan.FromSeconds(15);
                 ws.Options.KeepAliveTimeout = TimeSpan.FromSeconds(20);
                 var bearer = session.Token;
@@ -90,6 +110,11 @@ internal sealed class RealtimeConnection : IDisposable
                 await ws.ConnectAsync(BuildUri(session.BaseUrl), token).ConfigureAwait(false);
                 lock (gate)
                 {
+                    if (runGeneration != generation)
+                    {
+                        return;
+                    }
+
                     socket = ws;
                 }
 
@@ -109,13 +134,21 @@ internal sealed class RealtimeConnection : IDisposable
             {
                 lock (gate)
                 {
-                    socket = null;
+                    if (ReferenceEquals(socket, ws))
+                    {
+                        socket = null;
+                    }
                 }
 
-                SetConnected(false);
+                if (runGeneration == generation)
+                {
+                    SetConnected(false);
+                }
+
+                ws?.Dispose();
             }
 
-            if (token.IsCancellationRequested)
+            if (token.IsCancellationRequested || runGeneration != generation)
             {
                 break;
             }
@@ -202,6 +235,11 @@ internal sealed class RealtimeConnection : IDisposable
 
     private async Task SendAsync(byte[] payload, WebSocketMessageType type)
     {
+        if (disposed)
+        {
+            return;
+        }
+
         ClientWebSocket? ws;
         lock (gate)
         {
@@ -218,7 +256,15 @@ internal sealed class RealtimeConnection : IDisposable
             return;
         }
 
-        await sendLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            await sendLock.WaitAsync().ConfigureAwait(false);
+        }
+        catch (ObjectDisposedException)
+        {
+            return;
+        }
+
         try
         {
             using var timeout = new CancellationTokenSource(SendTimeout);
@@ -227,7 +273,16 @@ internal sealed class RealtimeConnection : IDisposable
         catch (OperationCanceledException)
         {
             AepLog.Warning("Realtime send timed out; dropping the connection.");
-            ws.Abort();
+            try
+            {
+                ws.Abort();
+            }
+            catch (Exception)
+            {
+            }
+        }
+        catch (ObjectDisposedException)
+        {
         }
         catch (Exception exception)
         {
@@ -235,7 +290,13 @@ internal sealed class RealtimeConnection : IDisposable
         }
         finally
         {
-            sendLock.Release();
+            try
+            {
+                sendLock.Release();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
         }
     }
 
@@ -267,6 +328,7 @@ internal sealed class RealtimeConnection : IDisposable
 
     public void Dispose()
     {
+        disposed = true;
         Stop();
         sendLock.Dispose();
     }

--- a/src/Aetherphone/Plugin.cs
+++ b/src/Aetherphone/Plugin.cs
@@ -169,8 +169,24 @@ public sealed class Plugin : IDalamudPlugin
         ClientState.Login -= OnLogin;
         Framework.Update -= OnAutoOpenTick;
         ContextMenu.OnMenuOpened -= OnMenuOpened;
-        CommandManager.RemoveHandler(AepConstants.PrimaryCommand);
-        CommandManager.RemoveHandler(AepConstants.AliasCommand);
+        try
+        {
+            CommandManager.RemoveHandler(AepConstants.PrimaryCommand);
+        }
+        catch (Exception exception)
+        {
+            AepLog.Warning($"Primary command remove failed during partial teardown: {exception.Message}");
+        }
+
+        try
+        {
+            CommandManager.RemoveHandler(AepConstants.AliasCommand);
+        }
+        catch (Exception exception)
+        {
+            AepLog.Warning($"Alias command remove failed during partial teardown: {exception.Message}");
+        }
+
         if (services is not null)
         {
             services.Notifications.Changed -= UpdateDtrBadge;
@@ -384,8 +400,11 @@ public sealed class Plugin : IDalamudPlugin
 
     private void OnIncomingCall()
     {
-        phoneWindow.Maximize();
-        phoneWindow.IsOpen = true;
+        _ = Framework.RunOnFrameworkThread(() =>
+        {
+            phoneWindow.Maximize();
+            phoneWindow.IsOpen = true;
+        });
     }
 
     private void OnMenuOpened(IMenuOpenedArgs args)

--- a/src/Aetherphone/Windows/Components/SocialProfilePages.cs
+++ b/src/Aetherphone/Windows/Components/SocialProfilePages.cs
@@ -81,7 +81,7 @@ internal sealed class SocialProfilePages
     private string editDisplay = string.Empty;
     private string editHandle = string.Empty;
     private string editBio = string.Empty;
-    private string editStatus = string.Empty;
+    private LocString? editStatusKey;
     private string? editLoadedFor;
     private volatile bool editBusy;
     private volatile int editOutcome;
@@ -466,7 +466,7 @@ internal sealed class SocialProfilePages
         if (editOutcome == 2)
         {
             editOutcome = 0;
-            editStatus = Loc.T(style.HandleTaken);
+            editStatusKey = style.HandleTaken;
         }
 
         if (editLoadedFor != me.Id)
@@ -475,7 +475,7 @@ internal sealed class SocialProfilePages
             editDisplay = me.DisplayName;
             editHandle = me.Handle;
             editBio = me.Bio;
-            editStatus = string.Empty;
+            editStatusKey = null;
         }
 
         var handleValid = IsHandleValid(editHandle);
@@ -509,12 +509,12 @@ internal sealed class SocialProfilePages
             DrawHandleField(theme);
             ImGui.Dummy(new Vector2(0f, 10f * scale));
             ui.Field(Loc.T(style.BioLabel), "##editBio", ref editBio, BioMax, true);
-            if (editStatus.Length > 0)
+            if (editStatusKey is { } statusKey)
             {
                 ImGui.Dummy(new Vector2(0f, 10f * scale));
                 using (ImRaii.PushColor(ImGuiCol.Text, theme.Danger))
                 {
-                    Typography.Wrapped(editStatus);
+                    Typography.Wrapped(Loc.T(statusKey));
                 }
             }
         }
@@ -566,12 +566,12 @@ internal sealed class SocialProfilePages
 
         if (!IsHandleValid(editHandle) || editDisplay.Trim().Length == 0)
         {
-            editStatus = Loc.T(style.HandleRules);
+            editStatusKey = style.HandleRules;
             return;
         }
 
         editBusy = true;
-        editStatus = string.Empty;
+        editStatusKey = null;
         store.UpdateProfile(editDisplay.Trim(), editHandle.Trim(), editBio.Trim(), (ok, _) =>
         {
             editBusy = false;


### PR DESCRIPTION
## What

Fixes several session, settings, and telephony lifecycle bugs on master: Follow Character toggle fighting itself, decrypted DM plaintext surviving sign-out, KeyVault not refreshing on account switch, Confirm/incoming-call UI mutated off the Framework thread, RealtimeConnection Stop/Start races, privacy settings refetch storms, RegionSync no-op after SignIn, and related settings/clock/call edge cases.

## Why

These bugs are present on upstream master and cause broken account follow, leftover chat plaintext after sign-out, dropped/corrupt confirm dialogs, overlapping websocket loops on account switch, and settings pages that hammer MeAsync every frame after a failed load.

Closes #

## How to test

- Open Settings → Account with more than one account: turn on Follow Character and confirm it stays on across frames.
- Sign out while a DM thread with decrypted messages is open: confirm messages/key state clear.
- Switch between signed-in accounts: confirm KeyVault refreshes for the new identity.
- Trigger an incoming call / stream decline alert and confirm the confirm overlay still works.
- Open Settings privacy / Tags & Mentions / Aethergram message privacy with the network offline briefly: confirm it does not refetch every frame forever.
- Toggle 12-hour clock and confirm Clock alarms follow `TimeText`.
- Open Appearance with HomeGridRows previously set to 8: confirm it does not silently rewrite to 6 until you change density.

## Checklist

- [x] `dotnet build -c Release` passes
- [ ] Verified in-game: opened the phone and exercised the affected app/screen
- [ ] If this changes user-visible behavior, README is updated
- [x] Matches existing style: uses the shared `Windows/Components/` widgets, no `what` comments

Made with [Cursor](https://cursor.com)