### PR TITLE
feat(home): let Shortcuts plugin launchers live in home folders

### DIFF
--- a/docs/app-framework.md
+++ b/docs/app-framework.md
@@ -271,7 +271,7 @@ Dismissing the sheet (`ShareService.Dismiss`) clears `Pending` but intentionally
 `HomeLayoutService` (src/Aetherphone/Core/Home/HomeLayoutService.cs) owns what appears on the home screen:
 
 - The grid is 4 columns (`Columns`) by 5 to 8 rows (`MinRows`/`MaxRows`, default 6), plus a dock of up to 4 apps (`DockCapacity`).
-- Pages hold `HomeTile` items: an app, a folder of apps, or a widget. Layout is persisted as `HomeLayout` (src/Aetherphone/Core/Home/HomeLayout.cs) with per-item `Column`/`Row`, the `Installed` app list, the `Known` list (apps the user has ever seen), and the `Dock`.
+- Pages hold `HomeTile` items: an app, a shortcut, a folder of apps and/or shortcuts, or a widget. Layout is persisted as `HomeLayout` (src/Aetherphone/Core/Home/HomeLayout.cs) with per-item `Column`/`Row`, the `Installed` app list, the `Known` list (apps the user has ever seen), and the `Dock`.
 - Placement is free-form and sticky: each tile keeps its saved `GridCell`, and the solver (`HomeGridSolver`) only assigns cells to tiles that have none or that conflict. Removing a tile leaves a hole; the grid never auto-compacts.
 - `Installed` decides which apps exist on the phone. First run seeds it with every available app; installing via the App Store app (`AppStoreApp`, id `"appstore"`) appends a tile to the last page. `MandatoryApps` (`"appstore"`, `"settings"`, `"announcements"`) cannot be uninstalled.
 - `AppInstaller` (src/Aetherphone/Core/Home/AppInstaller.cs) is the facade other systems use: `IsInstalled` (which also folds in availability), `Install`, `Uninstall`, and `Gate(appId)` returning an `AppGate` that background services (alarm timers, reminders) check before emitting notifications for an app that may be uninstalled.

--- a/src/Aetherphone.Tests/HomeLayoutServiceFolderTests.cs
+++ b/src/Aetherphone.Tests/HomeLayoutServiceFolderTests.cs
@@ -1,0 +1,229 @@
+using Aetherphone.Core.Apps;
+using Aetherphone.Core.Home;
+using Aetherphone.Core.Shortcuts;
+using Xunit;
+
+namespace Aetherphone.Tests;
+
+public sealed class HomeLayoutServiceFolderTests
+{
+    [Fact]
+    public void AShortcutDraggedOntoAnApp_MakesAFolderThatSurvivesAReload()
+    {
+        var apps = MakeApps("a", "b");
+        var shortcuts = SourceWith(out var shortcut);
+        var configuration = ConfigurationWith(AppItem("a"), AppItem("b"), ShortcutItem(shortcut));
+
+        var layout = BuildLayout(apps, shortcuts, configuration);
+        layout.MakeFolder(AppTile(layout, "a"), ShortcutTile(layout, shortcut));
+
+        var reloaded = BuildLayout(apps, shortcuts, configuration);
+        var folder = FolderTile(reloaded);
+
+        Assert.Equal(2, folder.Members.Count);
+        Assert.True(HoldsShortcut(folder, shortcut), "A shortcut dropped into a folder must come back after a reload");
+        Assert.True(HoldsApp(folder, "a"));
+    }
+
+    [Fact]
+    public void AShortcutInsideAFolder_CountsAsPinned()
+    {
+        var apps = MakeApps("a", "b");
+        var shortcuts = SourceWith(out var shortcut);
+        var configuration = ConfigurationWith(AppItem("a"), AppItem("b"), ShortcutItem(shortcut));
+
+        var layout = BuildLayout(apps, shortcuts, configuration);
+        layout.MakeFolder(AppTile(layout, "a"), ShortcutTile(layout, shortcut));
+
+        Assert.True(layout.HasShortcut(shortcut.Id), "Shortcuts must not look unpinned once they move into a folder");
+        Assert.False(layout.AddShortcut(shortcut.Id), "Pinning again would put a duplicate tile on Home");
+    }
+
+    [Fact]
+    public void DeletingAShortcutThatLivesInAFolder_TakesItOutOfThatFolder()
+    {
+        var apps = MakeApps("a", "b");
+        var shortcuts = SourceWith(out var shortcut);
+        var configuration = ConfigurationWith(AppItem("a"), AppItem("b"), ShortcutItem(shortcut));
+
+        var layout = BuildLayout(apps, shortcuts, configuration);
+        layout.MakeFolder(AppTile(layout, "a"), ShortcutTile(layout, shortcut));
+
+        Assert.True(layout.RemoveShortcut(shortcut.Id));
+        Assert.False(layout.HasShortcut(shortcut.Id));
+
+        shortcuts.Entries.Clear();
+        var reloaded = BuildLayout(apps, shortcuts, configuration);
+
+        Assert.Equal("a", AppTile(reloaded, "a").App!.Id);
+    }
+
+    [Fact]
+    public void AFolderSavedByAnOlderBuild_StillGroupsItsApps()
+    {
+        var apps = MakeApps("a", "b", "c");
+        var shortcuts = new FakeShortcutSource();
+        var configuration = ConfigurationWith(AppItem("a"),
+            new HomeItem { Kind = "folder", FolderName = "Stuff", AppIds = new List<string> { "b", "c" } });
+
+        var layout = BuildLayout(apps, shortcuts, configuration);
+        var folder = FolderTile(layout);
+
+        Assert.Equal("Stuff", folder.FolderName);
+        Assert.True(HoldsApp(folder, "b"));
+        Assert.True(HoldsApp(folder, "c"));
+    }
+
+    [Fact]
+    public void ASavedFolder_StillWritesAppIdsForBuildsThatOnlyReadThem()
+    {
+        var apps = MakeApps("a", "b");
+        var shortcuts = SourceWith(out var shortcut);
+        var configuration = ConfigurationWith(AppItem("a"), AppItem("b"), ShortcutItem(shortcut));
+
+        var layout = BuildLayout(apps, shortcuts, configuration);
+        layout.MakeFolder(AppTile(layout, "a"), ShortcutTile(layout, shortcut));
+
+        var stored = SavedFolder(configuration);
+        Assert.Equal(new[] { "a" }, stored.AppIds);
+    }
+
+    private static HomeLayoutService BuildLayout(List<IPhoneApp> apps, FakeShortcutSource shortcuts,
+        FakeHomeConfiguration configuration) =>
+        new(apps, new WidgetRegistry(Array.Empty<IHomeWidget>(), apps), shortcuts, configuration);
+
+    private static FakeShortcutSource SourceWith(out ShortcutEntry shortcut)
+    {
+        shortcut = new ShortcutEntry { Name = "Launch" };
+        var source = new FakeShortcutSource();
+        source.Entries.Add(shortcut);
+        return source;
+    }
+
+    private static FakeHomeConfiguration ConfigurationWith(params HomeItem[] items)
+    {
+        var page = new HomePage();
+        var installed = new List<string>();
+        for (var index = 0; index < items.Length; index++)
+        {
+            page.Items.Add(items[index]);
+            if (!string.IsNullOrEmpty(items[index].AppId))
+            {
+                installed.Add(items[index].AppId);
+            }
+
+            for (var appIndex = 0; appIndex < items[index].AppIds.Count; appIndex++)
+            {
+                installed.Add(items[index].AppIds[appIndex]);
+            }
+        }
+
+        return new FakeHomeConfiguration
+        {
+            Home = new HomeLayout
+            {
+                Dock = new List<string>(),
+                Pages = new List<HomePage> { page },
+                Installed = installed,
+            },
+        };
+    }
+
+    private static HomeItem AppItem(string appId) => new() { Kind = "app", AppId = appId };
+
+    private static HomeItem ShortcutItem(ShortcutEntry shortcut) =>
+        new() { Kind = "shortcut", ShortcutId = shortcut.Id.ToString("N") };
+
+    private static HomeItem SavedFolder(FakeHomeConfiguration configuration)
+    {
+        var items = configuration.Home!.Pages[0].Items;
+        for (var index = 0; index < items.Count; index++)
+        {
+            if (string.Equals(items[index].Kind, "folder", StringComparison.Ordinal))
+            {
+                return items[index];
+            }
+        }
+
+        throw new InvalidOperationException("The saved layout has no folder");
+    }
+
+    private static HomeTile FolderTile(HomeLayoutService layout)
+    {
+        var tiles = layout.Page(0);
+        for (var index = 0; index < tiles.Count; index++)
+        {
+            if (tiles[index].IsFolder)
+            {
+                return tiles[index];
+            }
+        }
+
+        throw new InvalidOperationException("Page 0 has no folder");
+    }
+
+    private static HomeTile AppTile(HomeLayoutService layout, string appId)
+    {
+        var tiles = layout.Page(0);
+        for (var index = 0; index < tiles.Count; index++)
+        {
+            if (tiles[index].App?.Id == appId)
+            {
+                return tiles[index];
+            }
+        }
+
+        throw new InvalidOperationException($"App '{appId}' is not on page 0");
+    }
+
+    private static HomeTile ShortcutTile(HomeLayoutService layout, ShortcutEntry shortcut)
+    {
+        var tiles = layout.Page(0);
+        for (var index = 0; index < tiles.Count; index++)
+        {
+            if (tiles[index].Shortcut?.Id == shortcut.Id)
+            {
+                return tiles[index];
+            }
+        }
+
+        throw new InvalidOperationException("The shortcut is not on page 0");
+    }
+
+    private static bool HoldsShortcut(HomeTile folder, ShortcutEntry shortcut)
+    {
+        for (var index = 0; index < folder.Members.Count; index++)
+        {
+            if (folder.Members[index].Shortcut?.Id == shortcut.Id)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HoldsApp(HomeTile folder, string appId)
+    {
+        for (var index = 0; index < folder.Members.Count; index++)
+        {
+            if (folder.Members[index].App?.Id == appId)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static List<IPhoneApp> MakeApps(params string[] ids)
+    {
+        var apps = new List<IPhoneApp>(ids.Length);
+        for (var index = 0; index < ids.Length; index++)
+        {
+            apps.Add(new FakeApp(ids[index]));
+        }
+
+        return apps;
+    }
+}

--- a/src/Aetherphone.Tests/HomeLayoutServiceInstallTests.cs
+++ b/src/Aetherphone.Tests/HomeLayoutServiceInstallTests.cs
@@ -290,9 +290,9 @@ public sealed class HomeLayoutServiceInstallTests
                     return page;
                 }
 
-                for (var appIndex = 0; appIndex < tile.Apps.Count; appIndex++)
+                for (var memberIndex = 0; memberIndex < tile.Members.Count; memberIndex++)
                 {
-                    if (tile.Apps[appIndex].Id == appId)
+                    if (tile.Members[memberIndex].App?.Id == appId)
                     {
                         return page;
                     }

--- a/src/Aetherphone/Core/Home/HomeLayout.cs
+++ b/src/Aetherphone/Core/Home/HomeLayout.cs
@@ -25,6 +25,7 @@ internal sealed class HomeItem
     public string FolderName { get; set; } = string.Empty;
     public string FolderTint { get; set; } = string.Empty;
     public List<string> AppIds { get; set; } = new();
+    public List<HomeItem> Members { get; set; } = new();
     public string WidgetId { get; set; } = string.Empty;
     public string WidgetSize { get; set; } = string.Empty;
     public string ShortcutId { get; set; } = string.Empty;

--- a/src/Aetherphone/Core/Home/HomeLayoutService.cs
+++ b/src/Aetherphone/Core/Home/HomeLayoutService.cs
@@ -1117,7 +1117,11 @@ internal sealed class HomeLayoutService
                     continue;
                 }
 
-                item.Members.Add(new HomeItem { Kind = "app", AppId = member.App!.Id });
+                var appId = member.App!.Id;
+                item.Members.Add(new HomeItem { Kind = "app", AppId = appId });
+
+                // Mirrored into AppIds so rolling back to a build that only reads AppIds keeps the app grouping.
+                item.AppIds.Add(appId);
             }
 
             return item;

--- a/src/Aetherphone/Core/Home/HomeLayoutService.cs
+++ b/src/Aetherphone/Core/Home/HomeLayoutService.cs
@@ -223,8 +223,8 @@ internal sealed class HomeLayoutService
 
     public void MakeFolder(HomeTile target, HomeTile dragged)
     {
-        if (ReferenceEquals(target, dragged) || target.IsWidget || dragged.IsWidget || target.IsShortcut ||
-            dragged.IsShortcut || target.IsFolder && dragged.IsFolder)
+        if (ReferenceEquals(target, dragged) || target.IsWidget || dragged.IsWidget
+            || target.IsFolder && dragged.IsFolder)
         {
             return;
         }
@@ -237,29 +237,29 @@ internal sealed class HomeLayoutService
 
         if (target.IsFolder)
         {
-            AddApps(target, dragged);
+            AddMember(target, dragged);
         }
         else
         {
             (targetPage, targetIndex) = Locate(target);
-            var folder = HomeTile.ForFolder(NextFolderKey(), string.Empty, new[] { target.App! });
+            var folder = HomeTile.ForFolder(NextFolderKey(), string.Empty, new[] { HomeTile.AsLeaf(target) });
             folder.Cell = target.Cell;
-            AddApps(folder, dragged);
+            AddMember(folder, dragged);
             pages[targetPage][targetIndex] = folder;
         }
 
         Commit();
     }
 
-    public void RemoveFromFolder(HomeTile folder, IPhoneApp app, int targetPage)
+    public void RemoveFromFolder(HomeTile folder, HomeTile member, int targetPage)
     {
-        if (!folder.IsFolder || !folder.Apps.Remove(app))
+        if (!folder.IsFolder || !folder.Members.Remove(member))
         {
             return;
         }
 
         targetPage = Math.Clamp(targetPage, 0, Math.Max(0, pages.Count - 1));
-        pages[targetPage].Add(HomeTile.ForApp(app));
+        pages[targetPage].Add(HomeTile.AsLeaf(member));
         Commit();
     }
 
@@ -356,11 +356,11 @@ internal sealed class HomeLayoutService
                     return;
                 }
 
-                for (var appIndex = tile.Apps.Count - 1; appIndex >= 0; appIndex--)
+                for (var memberIndex = tile.Members.Count - 1; memberIndex >= 0; memberIndex--)
                 {
-                    if (string.Equals(tile.Apps[appIndex].Id, appId, StringComparison.Ordinal))
+                    if (string.Equals(tile.Members[memberIndex].App?.Id, appId, StringComparison.Ordinal))
                     {
-                        tile.Apps.RemoveAt(appIndex);
+                        tile.Members.RemoveAt(memberIndex);
                         return;
                     }
                 }
@@ -375,9 +375,23 @@ internal sealed class HomeLayoutService
             var tiles = pages[page];
             for (var index = 0; index < tiles.Count; index++)
             {
-                if (tiles[index].Shortcut?.Id == id)
+                var tile = tiles[index];
+                if (tile.Shortcut?.Id == id)
                 {
                     return true;
+                }
+
+                if (!tile.IsFolder)
+                {
+                    continue;
+                }
+
+                for (var memberIndex = 0; memberIndex < tile.Members.Count; memberIndex++)
+                {
+                    if (tile.Members[memberIndex].Shortcut?.Id == id)
+                    {
+                        return true;
+                    }
                 }
             }
         }
@@ -405,10 +419,26 @@ internal sealed class HomeLayoutService
             var tiles = pages[page];
             for (var index = tiles.Count - 1; index >= 0; index--)
             {
-                if (tiles[index].Shortcut?.Id == id)
+                var tile = tiles[index];
+                if (tile.Shortcut?.Id == id)
                 {
                     tiles.RemoveAt(index);
                     removed = true;
+                    continue;
+                }
+
+                if (!tile.IsFolder)
+                {
+                    continue;
+                }
+
+                for (var memberIndex = tile.Members.Count - 1; memberIndex >= 0; memberIndex--)
+                {
+                    if (tile.Members[memberIndex].Shortcut?.Id == id)
+                    {
+                        tile.Members.RemoveAt(memberIndex);
+                        removed = true;
+                    }
                 }
             }
         }
@@ -478,10 +508,10 @@ internal sealed class HomeLayoutService
         }
 
         pages[page].RemoveAt(index);
-        for (var appIndex = 0; appIndex < folder.Apps.Count; appIndex++)
+        for (var memberIndex = 0; memberIndex < folder.Members.Count; memberIndex++)
         {
-            var tile = HomeTile.ForApp(folder.Apps[appIndex]);
-            if (appIndex == 0)
+            var tile = HomeTile.AsLeaf(folder.Members[memberIndex]);
+            if (memberIndex == 0)
             {
                 tile.Cell = folder.Cell;
             }
@@ -516,19 +546,19 @@ internal sealed class HomeLayoutService
         return true;
     }
 
-    private static void AddApps(HomeTile folder, HomeTile source)
+    private static void AddMember(HomeTile folder, HomeTile source)
     {
         if (source.IsFolder)
         {
-            for (var index = 0; index < source.Apps.Count; index++)
+            for (var index = 0; index < source.Members.Count; index++)
             {
-                folder.Apps.Add(source.Apps[index]);
+                folder.Members.Add(source.Members[index]);
             }
 
             return;
         }
 
-        folder.Apps.Add(source.App!);
+        folder.Members.Add(HomeTile.AsLeaf(source));
     }
 
     private void Load()
@@ -721,14 +751,14 @@ internal sealed class HomeLayoutService
     {
         if (string.Equals(item.Kind, "folder", StringComparison.Ordinal))
         {
-            var contents = ResolveApps(item.AppIds, placed);
+            var contents = ResolveFolderMembers(item, placed);
             if (contents.Count == 0)
             {
                 return null;
             }
 
             return contents.Count == 1
-                ? HomeTile.ForApp(contents[0])
+                ? HomeTile.AsLeaf(contents[0])
                 : HomeTile.ForFolder(NextFolderKey(), item.FolderName, contents, item.FolderTint);
         }
 
@@ -787,6 +817,52 @@ internal sealed class HomeLayoutService
                 page.Add(HomeTile.ForApp(app));
             }
         }
+    }
+
+    private List<HomeTile> ResolveFolderMembers(HomeItem item, HashSet<string> placed)
+    {
+        if (item.Members.Count > 0)
+        {
+            var contents = new List<HomeTile>(item.Members.Count);
+            for (var index = 0; index < item.Members.Count; index++)
+            {
+                if (ResolveFolderMember(item.Members[index], placed) is { } member)
+                {
+                    contents.Add(member);
+                }
+            }
+
+            return contents;
+        }
+
+        var apps = ResolveApps(item.AppIds, placed);
+        var legacy = new List<HomeTile>(apps.Count);
+        for (var index = 0; index < apps.Count; index++)
+        {
+            legacy.Add(HomeTile.ForApp(apps[index]));
+        }
+
+        return legacy;
+    }
+
+    private HomeTile? ResolveFolderMember(HomeItem item, HashSet<string> placed)
+    {
+        if (string.Equals(item.Kind, "shortcut", StringComparison.Ordinal))
+        {
+            if (!Guid.TryParse(item.ShortcutId, out var shortcutId) || shortcuts.Find(shortcutId) is not { } shortcut)
+            {
+                return null;
+            }
+
+            return HomeTile.ForShortcut(shortcut);
+        }
+
+        if (byId.TryGetValue(item.AppId, out var app) && app.IsAvailable && placed.Add(app.Id))
+        {
+            return HomeTile.ForApp(app);
+        }
+
+        return null;
     }
 
     private List<IPhoneApp> ResolveApps(List<string> ids, HashSet<string> placed)
@@ -884,14 +960,14 @@ internal sealed class HomeLayoutService
             for (var index = pages[page].Count - 1; index >= 0; index--)
             {
                 var tile = pages[page][index];
-                if (!tile.IsFolder || tile.Apps.Count > 1)
+                if (!tile.IsFolder || tile.Members.Count > 1)
                 {
                     continue;
                 }
 
-                if (tile.Apps.Count == 1)
+                if (tile.Members.Count == 1)
                 {
-                    var folded = HomeTile.ForApp(tile.Apps[0]);
+                    var folded = HomeTile.AsLeaf(tile.Members[0]);
                     folded.Cell = tile.Cell;
                     pages[page][index] = folded;
                 }
@@ -963,6 +1039,15 @@ internal sealed class HomeLayoutService
                 {
                     target.Add(item.AppIds[appIndex]);
                 }
+
+                for (var memberIndex = 0; memberIndex < item.Members.Count; memberIndex++)
+                {
+                    var member = item.Members[memberIndex];
+                    if (!string.IsNullOrEmpty(member.AppId))
+                    {
+                        target.Add(member.AppId);
+                    }
+                }
             }
         }
 
@@ -1020,9 +1105,19 @@ internal sealed class HomeLayoutService
         if (tile.IsFolder)
         {
             var item = new HomeItem { Kind = "folder", FolderName = tile.FolderName, FolderTint = tile.FolderTint };
-            for (var appIndex = 0; appIndex < tile.Apps.Count; appIndex++)
+            for (var memberIndex = 0; memberIndex < tile.Members.Count; memberIndex++)
             {
-                item.AppIds.Add(tile.Apps[appIndex].Id);
+                var member = tile.Members[memberIndex];
+                if (member.IsShortcut)
+                {
+                    item.Members.Add(new HomeItem
+                    {
+                        Kind = "shortcut", ShortcutId = member.Shortcut!.Id.ToString("N"),
+                    });
+                    continue;
+                }
+
+                item.Members.Add(new HomeItem { Kind = "app", AppId = member.App!.Id });
             }
 
             return item;

--- a/src/Aetherphone/Core/Home/HomeTile.cs
+++ b/src/Aetherphone/Core/Home/HomeTile.cs
@@ -13,7 +13,7 @@ internal sealed class HomeTile : IGridTile
     public WidgetSize Size { get; set; } = WidgetSize.Medium;
     public string FolderName { get; set; } = string.Empty;
     public string FolderTint { get; set; } = string.Empty;
-    public List<IPhoneApp> Apps { get; } = new();
+    public List<HomeTile> Members { get; } = new();
     public bool IsWidget => Widget is not null;
     public bool IsShortcut => Shortcut is not null;
     public bool IsFolder => App is null && Widget is null && Shortcut is null;
@@ -28,14 +28,24 @@ internal sealed class HomeTile : IGridTile
     public static HomeTile ForWidget(string key, IHomeWidget widget, WidgetSize size) =>
         new() { Key = key, Widget = widget, Size = size };
 
-    public static HomeTile ForFolder(string key, string name, IReadOnlyList<IPhoneApp> apps, string tint = "")
+    public static HomeTile ForFolder(string key, string name, IReadOnlyList<HomeTile> members, string tint = "")
     {
         var tile = new HomeTile { Key = key, App = null, FolderName = name, FolderTint = tint };
-        for (var index = 0; index < apps.Count; index++)
+        for (var index = 0; index < members.Count; index++)
         {
-            tile.Apps.Add(apps[index]);
+            tile.Members.Add(members[index]);
         }
 
         return tile;
+    }
+
+    public static HomeTile AsLeaf(HomeTile tile)
+    {
+        if (tile.IsShortcut)
+        {
+            return ForShortcut(tile.Shortcut!);
+        }
+
+        return ForApp(tile.App!);
     }
 }

--- a/src/Aetherphone/Core/Shell/Home/FolderOverlay.cs
+++ b/src/Aetherphone/Core/Shell/Home/FolderOverlay.cs
@@ -2,6 +2,7 @@ using Aetherphone.Core.Animation;
 using Aetherphone.Core.Apps;
 using Aetherphone.Core.Home;
 using Aetherphone.Core.Localization;
+using Aetherphone.Core.Shortcuts;
 using Aetherphone.Core.Theme;
 using Aetherphone.Windows.Components;
 using Dalamud.Bindings.ImGui;
@@ -14,6 +15,8 @@ internal sealed class FolderOverlay
     private static readonly Vector4 NoTintSwatch = new(0.55f, 0.56f, 0.60f, 1f);
 
     private readonly HomeLayoutService layout;
+    private readonly ShortcutStore shortcuts;
+    private readonly ShortcutRunner runner;
     private HomeTile? folder;
     private bool closing;
     private Spring anim;
@@ -22,9 +25,11 @@ internal sealed class FolderOverlay
     private float scrollY;
     private int openedFrame;
 
-    public FolderOverlay(HomeLayoutService layout)
+    public FolderOverlay(HomeLayoutService layout, ShortcutStore shortcuts, ShortcutRunner runner)
     {
         this.layout = layout;
+        this.shortcuts = shortcuts;
+        this.runner = runner;
     }
 
     public bool Active => folder is not null;
@@ -75,8 +80,8 @@ internal sealed class FolderOverlay
         var drawList = ImGui.GetWindowDrawList();
         drawList.PushClipRect(content.Min, content.Max, true);
         Material.Veil(drawList, content.Min, content.Max, 0.5f * eased);
-        var columns = current.Apps.Count <= 9 ? 3 : 4;
-        var rows = (current.Apps.Count + columns - 1) / columns;
+        var columns = current.Members.Count <= 9 ? 3 : 4;
+        var rows = (current.Members.Count + columns - 1) / columns;
         var panelWidth = content.Width * 0.84f;
         var pad = 18f * scale;
         var cellWidth = (panelWidth - pad * 2f) / columns;
@@ -127,11 +132,11 @@ internal sealed class FolderOverlay
             scrollY -= ImGui.GetIO().MouseWheel * 40f * scale;
         }
 
-        var rows = (current.Apps.Count + columns - 1) / columns;
+        var rows = (current.Members.Count + columns - 1) / columns;
         var contentHeight = rows * cellHeight;
         scrollY = Math.Clamp(scrollY, 0f, MathF.Max(0f, contentHeight - gridView.Height));
 
-        for (var index = 0; index < current.Apps.Count; index++)
+        for (var index = 0; index < current.Members.Count; index++)
         {
             var column = index % columns;
             var row = index / columns;
@@ -142,8 +147,17 @@ internal sealed class FolderOverlay
                 continue;
             }
 
-            var app = current.Apps[index];
-            HomeTileView.DrawApp(center, iconSize, app, theme, 1f, 1f, true, cellWidth);
+            var member = current.Members[index];
+            if (member.IsShortcut)
+            {
+                HomeTileView.DrawShortcut(center, iconSize, member.Shortcut!, shortcuts.Icon(member.Shortcut!), theme,
+                    1f, 1f, true, cellWidth);
+            }
+            else
+            {
+                HomeTileView.DrawApp(center, iconSize, member.App!, theme, 1f, 1f, true, cellWidth);
+            }
+
             var half = iconSize * 0.5f;
             var iconRect = new Rect(new Vector2(center.X - half, center.Y - half),
                 new Vector2(center.X + half, center.Y + half));
@@ -152,8 +166,8 @@ internal sealed class FolderOverlay
                 if (HomeTileView.RemoveBadge(new Vector2(center.X - half + 2f * scale, center.Y - half + 2f * scale),
                         scale, theme))
                 {
-                    layout.RemoveFromFolder(current, app, currentPage);
-                    if (current.Apps.Count <= 1)
+                    layout.RemoveFromFolder(current, member, currentPage);
+                    if (current.Members.Count <= 1)
                     {
                         RequestClose();
                     }
@@ -168,7 +182,15 @@ internal sealed class FolderOverlay
                 if (ImGui.IsMouseClicked(ImGuiMouseButton.Left))
                 {
                     RequestClose();
-                    navigation.OpenAppFrom(app, iconRect);
+                    if (member.IsShortcut)
+                    {
+                        runner.Run(member.Shortcut!);
+                    }
+                    else
+                    {
+                        navigation.OpenAppFrom(member.App!, iconRect);
+                    }
+
                     drawList.PopClipRect();
                     return;
                 }

--- a/src/Aetherphone/Core/Shell/Home/HomeGridRenderer.cs
+++ b/src/Aetherphone/Core/Shell/Home/HomeGridRenderer.cs
@@ -8,6 +8,7 @@ using Aetherphone.Core.Shortcuts;
 using Aetherphone.Core.Theme;
 using Aetherphone.Windows.Components;
 using Dalamud.Bindings.ImGui;
+using Dalamud.Interface.Textures.TextureWraps;
 
 namespace Aetherphone.Core.Shell.Home;
 
@@ -18,6 +19,7 @@ internal sealed class HomeGridRenderer
     private readonly TilePoseCache poses;
     private readonly HomeInteractionController interaction;
     private readonly ShortcutStore shortcuts;
+    private readonly Func<ShortcutEntry, IDalamudTextureWrap?> shortcutIcon;
     private readonly ConfirmService confirm;
     private bool widgetAnchorReported;
 
@@ -29,6 +31,7 @@ internal sealed class HomeGridRenderer
         this.poses = poses;
         this.interaction = interaction;
         this.shortcuts = shortcuts;
+        shortcutIcon = shortcuts.Icon;
         this.confirm = confirm;
     }
 
@@ -149,7 +152,7 @@ internal sealed class HomeGridRenderer
         {
             HomeTileView.DrawFolder(center, rect.Width, tile, theme,
                 interaction.TapScale(tile) * interaction.Magnify(center, metrics.CellWidth),
-                labelAlpha, showLabels, Loc.T(L.Home.NewFolder), metrics.CellWidth, zoom, shortcuts.Icon);
+                labelAlpha, showLabels, Loc.T(L.Home.NewFolder), metrics.CellWidth, shortcutIcon, zoom);
             if (interaction.RemoveBadgesLive(motion) &&
                 HomeTileView.RemoveBadge(new Vector2(rect.Min.X + 2f * scale, rect.Min.Y + 2f * scale), scale, theme))
             {
@@ -309,7 +312,7 @@ internal sealed class HomeGridRenderer
         if (tile.IsFolder)
         {
             HomeTileView.DrawFolder(position, metrics.IconSize, tile, theme, scale, 0f, true, Loc.T(L.Home.NewFolder),
-                metrics.CellWidth, 1f, shortcuts.Icon);
+                metrics.CellWidth, shortcutIcon);
             return;
         }
 

--- a/src/Aetherphone/Core/Shell/Home/HomeGridRenderer.cs
+++ b/src/Aetherphone/Core/Shell/Home/HomeGridRenderer.cs
@@ -149,7 +149,7 @@ internal sealed class HomeGridRenderer
         {
             HomeTileView.DrawFolder(center, rect.Width, tile, theme,
                 interaction.TapScale(tile) * interaction.Magnify(center, metrics.CellWidth),
-                labelAlpha, showLabels, Loc.T(L.Home.NewFolder), metrics.CellWidth, zoom);
+                labelAlpha, showLabels, Loc.T(L.Home.NewFolder), metrics.CellWidth, zoom, shortcuts.Icon);
             if (interaction.RemoveBadgesLive(motion) &&
                 HomeTileView.RemoveBadge(new Vector2(rect.Min.X + 2f * scale, rect.Min.Y + 2f * scale), scale, theme))
             {
@@ -309,7 +309,7 @@ internal sealed class HomeGridRenderer
         if (tile.IsFolder)
         {
             HomeTileView.DrawFolder(position, metrics.IconSize, tile, theme, scale, 0f, true, Loc.T(L.Home.NewFolder),
-                metrics.CellWidth);
+                metrics.CellWidth, 1f, shortcuts.Icon);
             return;
         }
 

--- a/src/Aetherphone/Core/Shell/Home/HomeInteractionController.cs
+++ b/src/Aetherphone/Core/Shell/Home/HomeInteractionController.cs
@@ -436,14 +436,14 @@ internal sealed class HomeInteractionController
 
         var tiles = layout.Page(dragPage);
         var cells = layout.Placements(dragPage);
-        if (!dragTile!.IsWidget && !dragTile.IsShortcut)
+        if (!dragTile!.IsWidget)
         {
             var radius = metrics.IconSize * 0.42f;
             for (var index = 0; index < tiles.Count && index < cells.Count; index++)
             {
                 var candidate = tiles[index];
-                if (ReferenceEquals(candidate, dragTile) || candidate.IsWidget || candidate.IsShortcut ||
-                    candidate.IsFolder && dragTile.IsFolder)
+                if (ReferenceEquals(candidate, dragTile) || candidate.IsWidget
+                    || candidate.IsFolder && dragTile.IsFolder)
                 {
                     continue;
                 }

--- a/src/Aetherphone/Core/Shell/HomeScreen.cs
+++ b/src/Aetherphone/Core/Shell/HomeScreen.cs
@@ -27,7 +27,7 @@ internal sealed class HomeScreen
     {
         this.configuration = configuration;
         layout = new HomeLayoutService(apps, widgets, shortcuts, configuration);
-        folder = new FolderOverlay(layout);
+        folder = new FolderOverlay(layout, shortcuts, runner);
         sizeMenu = new WidgetSizeMenu(layout);
         gallery = new WidgetGallery(layout, widgets);
         interaction = new HomeInteractionController(layout, widgets, pager, folder, sizeMenu, gallery, poses, runner);
@@ -131,9 +131,9 @@ internal sealed class HomeScreen
             return tile.Widget!.AppId == appId;
         }
 
-        for (var index = 0; index < tile.Apps.Count; index++)
+        for (var index = 0; index < tile.Members.Count; index++)
         {
-            if (tile.Apps[index].Id == appId)
+            if (tile.Members[index].App?.Id == appId)
             {
                 return true;
             }

--- a/src/Aetherphone/Windows/Components/HomeTileView.cs
+++ b/src/Aetherphone/Windows/Components/HomeTileView.cs
@@ -47,8 +47,8 @@ internal static class HomeTileView
     }
 
     public static void DrawFolder(Vector2 center, float size, HomeTile folder, PhoneTheme theme, float drawScale,
-        float labelAlpha, bool showLabels, string fallbackName, float labelWidth, float zoom = 1f,
-        Func<ShortcutEntry, IDalamudTextureWrap?>? shortcutIcon = null)
+        float labelAlpha, bool showLabels, string fallbackName, float labelWidth,
+        Func<ShortcutEntry, IDalamudTextureWrap?> shortcutIcon, float zoom = 1f)
     {
         var scale = UiScale.Current * zoom;
         var dl = ImGui.GetWindowDrawList();
@@ -74,8 +74,7 @@ internal static class HomeTileView
             var member = folder.Members[index];
             if (member.IsShortcut)
             {
-                ShortcutArt.DrawSurface(dl, cellCenter, mini, member.Shortcut!,
-                    shortcutIcon?.Invoke(member.Shortcut!), scale);
+                ShortcutArt.DrawSurface(dl, cellCenter, mini, member.Shortcut!, shortcutIcon(member.Shortcut!), scale);
                 continue;
             }
 

--- a/src/Aetherphone/Windows/Components/HomeTileView.cs
+++ b/src/Aetherphone/Windows/Components/HomeTileView.cs
@@ -47,7 +47,8 @@ internal static class HomeTileView
     }
 
     public static void DrawFolder(Vector2 center, float size, HomeTile folder, PhoneTheme theme, float drawScale,
-        float labelAlpha, bool showLabels, string fallbackName, float labelWidth, float zoom = 1f)
+        float labelAlpha, bool showLabels, string fallbackName, float labelWidth, float zoom = 1f,
+        Func<ShortcutEntry, IDalamudTextureWrap?>? shortcutIcon = null)
     {
         var scale = UiScale.Current * zoom;
         var dl = ImGui.GetWindowDrawList();
@@ -62,7 +63,7 @@ internal static class HomeTileView
         var inner = drawHalf * 2f - pad * 2f;
         var cell = inner / 3f;
         var mini = cell * 0.78f;
-        var count = Math.Min(9, folder.Apps.Count);
+        var count = Math.Min(9, folder.Members.Count);
         for (var index = 0; index < count; index++)
         {
             var col = index % 3;
@@ -70,7 +71,15 @@ internal static class HomeTileView
             var cellCenter = new Vector2(min.X + pad + (col + 0.5f) * cell, min.Y + pad + (row + 0.5f) * cell);
             var miniMin = new Vector2(cellCenter.X - mini * 0.5f, cellCenter.Y - mini * 0.5f);
             var miniMax = new Vector2(cellCenter.X + mini * 0.5f, cellCenter.Y + mini * 0.5f);
-            var appItem = folder.Apps[index];
+            var member = folder.Members[index];
+            if (member.IsShortcut)
+            {
+                ShortcutArt.DrawSurface(dl, cellCenter, mini, member.Shortcut!,
+                    shortcutIcon?.Invoke(member.Shortcut!), scale);
+                continue;
+            }
+
+            var appItem = member.App!;
             var surface = IconTile.Surface(appItem.Accent);
             Squircle.Fill(dl, miniMin, miniMax, mini * 0.3f, ImGui.GetColorU32(surface));
             AppIconArt.TryDraw(appItem.Id, cellCenter, mini, GlyphInk, Palette.Darken(surface, 0.25f));
@@ -80,10 +89,10 @@ internal static class HomeTileView
         DrawLabel(center, size, name, theme, scale, labelAlpha, showLabels, labelWidth, zoom);
         var badgeTotal = 0;
         var badgeHasDot = false;
-        for (var appIndex = 0; appIndex < folder.Apps.Count; appIndex++)
+        for (var memberIndex = 0; memberIndex < folder.Members.Count; memberIndex++)
         {
-            var folderApp = folder.Apps[appIndex];
-            if (folderApp.BadgeCount <= 0)
+            var folderApp = folder.Members[memberIndex].App;
+            if (folderApp is null || folderApp.BadgeCount <= 0)
             {
                 continue;
             }


### PR DESCRIPTION
## What

Home folders can now contain Shortcuts tiles (including plugin launchers), not only apps. Drag a shortcut onto an app or into a folder to group them; the folder overlay draws, opens, and removes those shortcuts.

## Why

Pinning a plugin launcher to the Home screen worked, but folders rejected shortcuts, so users could not organize plugin icons the same way as apps.

Closes #

## How to test

1. Open Shortcuts, create a plugin launcher, enable Show on Home, save.
2. On the Home screen, enter edit mode and drag the shortcut onto another app icon: a folder should form.
3. Drag another shortcut into that folder.
4. Open the folder: tap a shortcut to run it; in edit mode, remove it with the badge.
5. Reload the plugin and confirm the folder still contains the shortcuts.

## Checklist

- [x] `dotnet build -c Release` passes
- [ ] Verified in-game: opened the phone and exercised the affected app/screen
- [ ] If this changes user-visible behavior, README is updated
- [x] Matches existing style: uses the shared `Windows/Components/` widgets, no `what` comments

Made with [Cursor](https://cursor.com)