### PR TITLE
(Chats) update thread logic to ensure scroll is based o nthe l…

### DIFF
--- a/src/Aetherphone/Windows/Components/ChatThreadView.cs
+++ b/src/Aetherphone/Windows/Components/ChatThreadView.cs
@@ -245,6 +245,7 @@ internal abstract class ChatThreadView<TMessage, TThread> : IDisposable, IChatTr
             composer.CancelVoice();
             voicePlayer.Stop();
             OnThreadOpened(threadId);
+			transcript.RequestSnapToBottom()
         }
 
         if (pendingPrefill is { } prefill)

--- a/src/Aetherphone/Windows/Components/ChatTranscript.cs
+++ b/src/Aetherphone/Windows/Components/ChatTranscript.cs
@@ -278,7 +278,7 @@ internal sealed class ChatTranscript
                 return;
             }
 
-            SyncFollow(model.ThreadId);
+            SyncFollow(model.ThreadId, model.Loading);
             MaybeLoadOlder(model);
             ImGui.Dummy(new Vector2(0f, 8f * scale));
             var messages = model.Messages;
@@ -435,26 +435,29 @@ internal sealed class ChatTranscript
         }
     }
 
-    private void SyncFollow(string threadId)
+    private void SyncFollow(string threadId, bool loading)
+{
+    var scale = UiScale.Current;
+    if (followThreadId == threadId)
     {
-        var scale = UiScale.Current;
-        if (followThreadId == threadId)
+        if (!loading)
         {
             followBottom = ImGui.GetScrollY() >= ImGui.GetScrollMaxY() - 4f * scale;
         }
-        else
-        {
-            followThreadId = threadId;
-            followBottom = true;
-            olderAnchorFromBottom = -1f;
-        }
-
-        if (snapToBottom)
-        {
-            followBottom = true;
-            snapToBottom = false;
-        }
     }
+    else
+    {
+        followThreadId = threadId;
+        followBottom = true;
+        olderAnchorFromBottom = -1f;
+    }
+
+    if (snapToBottom)
+    {
+        followBottom = true;
+        snapToBottom = false;
+    }
+}
 
     private static void DrawSenderLabel(TranscriptMessage message, PhoneTheme theme)
     {


### PR DESCRIPTION
…oaded data, instead of the previous conversaion/unloaded contentSize

## What
Updated ChatTranscript and ChatThreadView to ensure that ScrollY is set only once the data is laoded

## Why

Previously, opening longer chat caused the scroll to start roughly midway, based on the data loaded o the first frame, instead of the data once fully loaded

Closes #

## How to test

<!--
Minimum steps a reviewer can run to verify the change. Testing usually means opening the phone with `/phone`, navigating to the app or screen you touched, and confirming it behaves. If you changed messaging, send yourself a /tell and watch it land. For UI-only changes, describe what to click and attach a before/after screenshot.
-->

## Checklist

- [ ] `dotnet build -c Release` passes
- [ ] Open a chat in game, ensure the scrolling is always at the bottom, especially on longer chats