### PR TITLE
fix(social): fixed stale comment and reaction counts particularly on rechirp wrappers

### DIFF
--- a/src/Aetherphone/Apps/Chirper/ChirperApp.cs
+++ b/src/Aetherphone/Apps/Chirper/ChirperApp.cs
@@ -1080,7 +1080,7 @@ internal sealed partial class ChirperApp : IPhoneApp
             }
 
             var comments = store.DetailComments;
-            var commentTotal = store.HasMoreComments ? Math.Max(post.CommentCount, comments.Length) : comments.Length;
+            var commentTotal = post.CommentCount;
             ImGui.Dummy(new Vector2(0f, 2f * scale));
             ui.SectionHeading(commentTotal > 0
                 ? $"{Loc.T(L.Chirper.RepliesTitle)} · {commentTotal}"

--- a/src/Aetherphone/Core/Aethernet/CopyOnWrite.cs
+++ b/src/Aetherphone/Core/Aethernet/CopyOnWrite.cs
@@ -199,6 +199,34 @@ internal static class CopyOnWrite
         return source;
     }
 
+    // Replaces a post that appears directly in the array, AND updates the ReferencedPost
+    // inside any rechirp wrappers (posts whose RepostOfId matches the updated post's Id).
+    public static PostDto[] ReplaceOrUpdateReferenced(PostDto[] source, PostDto updated)
+    {
+        var changed = false;
+        var result = new PostDto[source.Length];
+        for (var index = 0; index < source.Length; index++)
+        {
+            var item = source[index];
+            if (item.Id == updated.Id)
+            {
+                result[index] = updated;
+                changed = true;
+            }
+            else if (item.RepostOfId == updated.Id && item.ReferencedPost is not null)
+            {
+                result[index] = item with { ReferencedPost = updated };
+                changed = true;
+            }
+            else
+            {
+                result[index] = item;
+            }
+        }
+
+        return changed ? result : source;
+    }
+
     public static T[] Map<T>(T[] source, Func<T, bool> match, Func<T, T> transform)
     {
         var changed = false;

--- a/src/Aetherphone/Core/Social/SocialFeedStore.cs
+++ b/src/Aetherphone/Core/Social/SocialFeedStore.cs
@@ -100,6 +100,10 @@ internal abstract class SocialFeedStore : IDisposable
         if (string.Equals(removal.Kind, ContentRemovalKinds.Comment, StringComparison.Ordinal))
         {
             detailComments = CopyOnWrite.RemoveById(detailComments, removal.ContentId);
+            if (removal.ParentId is { } postId)
+            {
+                BumpCommentCount(postId, -1);
+            }
         }
     }
 
@@ -1023,9 +1027,9 @@ internal abstract class SocialFeedStore : IDisposable
 
     protected void ReplacePost(PostDto updated)
     {
-        forYouLane.Items = CopyOnWrite.Replace(forYouLane.Items, updated);
-        followingLane.Items = CopyOnWrite.Replace(followingLane.Items, updated);
-        profileLane.Items = CopyOnWrite.Replace(profileLane.Items, updated);
+        forYouLane.Items = CopyOnWrite.ReplaceOrUpdateReferenced(forYouLane.Items, updated);
+        followingLane.Items = CopyOnWrite.ReplaceOrUpdateReferenced(followingLane.Items, updated);
+        profileLane.Items = CopyOnWrite.ReplaceOrUpdateReferenced(profileLane.Items, updated);
         if (detailPost is { } current && current.Id == updated.Id)
         {
             detailPost = updated;
@@ -1089,8 +1093,16 @@ internal abstract class SocialFeedStore : IDisposable
         wasFollowing == following ? 0 : following ? 1 : -1;
 
     private static PostDto[] MapCommentCount(PostDto[] source, string postId, int delta) =>
-        CopyOnWrite.MapById(source, postId,
-            post => post with { CommentCount = Math.Max(0, post.CommentCount + delta) });
+        CopyOnWrite.Map(source,
+            post => post.Id == postId || post.RepostOfId == postId,
+            post => post.Id == postId
+                ? post with { CommentCount = Math.Max(0, post.CommentCount + delta) }
+                : post with
+                {
+                    ReferencedPost = post.ReferencedPost is { } referenced
+                        ? referenced with { CommentCount = Math.Max(0, referenced.CommentCount + delta) }
+                        : null
+                });
 
     private static UserDto[] MapFollow(UserDto[] source, string userId, bool following, bool requested) =>
         CopyOnWrite.Map(source,


### PR DESCRIPTION
## What

Fixed the feed action header bar to use post.CommentCount; instead of an if statement to ensure that we're using the comment count coming from the server and not the local array. Also added logic to handle updating comments and reacts for posts within rechirp wrappers.

## Why

Discord Issue: https://discord.com/channels/1527213298087493732/1531772997084385381

## How to test

1. Open Chirper.
2. Review posts to ensure the comment badge and replies are showing the same values. Check rechirps and original posts to make sure comments and react counters are staying in sync.

## Checklist

- [ ] `dotnet build -c Release` passes
- [ ] Verified in-game: opened the phone and exercised the affected app/screen
- [ ] If this changes user-visible behavior, README is updated
- [ ] Matches existing style: uses the shared `Windows/Components/` widgets, no `what` comments
