### PR TITLE
fix(shell): updated dynamic island dimensions to prevent clipping with the signal bars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 obj/
 bin/
 *.user
+.vscode/
 
 # Node tooling (tools/icon-generator)
 node_modules/

--- a/src/Aetherphone/Core/Shell/DynamicIsland.cs
+++ b/src/Aetherphone/Core/Shell/DynamicIsland.cs
@@ -26,8 +26,8 @@ internal sealed class DynamicIsland
     private const float PresenceSmoothTime = 0.14f;
     private const float SplitSmoothTime = 0.12f;
     private const float ExpandSmoothTime = 0.16f;
-    private const float CompactPadX = 22f;
-    private const float CompactPadY = 5f;
+    private const float CompactPadX = 8f;
+    private const float CompactPadY = 3f;
     private const float BubbleGap = 7f;
     private const float CallExpandedHeight = 104f;
     private const float CallExpandedHalfWidth = 138f;


### PR DESCRIPTION
## What

Updated dimensions for the dynamic island when music is playing.

## Why

Current dimensions were causing the dynamic island to overlap with the signal icon.

Closes #

## How to test

1. Open Music.
2. Play a song or start a radio station.
3. Check dynamic island at the top of the phone.

## Checklist

- [ ] `dotnet build -c Release` passes
- [ ] Verified in-game: opened the phone and exercised the affected app/screen
- [ ] If this changes user-visible behavior, README is updated
- [ ] Matches existing style: uses the shared `Windows/Components/` widgets, no `what` comments
