### PR TITLE
fix(dailies): removed bad check that was keeping doman enclave status from updating correctly.

### DIFF
--- a/src/Aetherphone/Core/Dailies/DailiesReader.cs
+++ b/src/Aetherphone/Core/Dailies/DailiesReader.cs
@@ -103,21 +103,16 @@ internal static unsafe class DailiesReader
     private static DailyAutoStatus ReadDomanEnclave()
     {
         var manager = DomanEnclaveManager.Instance();
-        if (manager is null || !manager->IsLoaded)
-        {
-            return DailyAutoStatus.Unavailable;
-        }
-
         var state = manager->State;
         var donated = (int)state.Donated;
         var allowance = (int)state.Allowance;
+        var remaining = allowance - donated;
 
         if (allowance == 0)
         {
             return DailyAutoStatus.Unavailable;
         }
 
-        var remaining = allowance - donated;
         return new DailyAutoStatus(true, remaining == 0, remaining, allowance);
     }
 


### PR DESCRIPTION
## What

Removed bad if statement that was preventing doman enclave tracking from updating correctly.

## Why

Simplified ReadDomanEnclave to track whether or not a player has donations unlocked via the allowance var instead of using IsLoaded as it was always evaluating as null or false unless it receives a packet otherwise. This made users have to travel to the Doman Enclave zone to get past this evaluation. The new method just checks what allowance is available and uses that to determine if doman enclave is available or not. 

## How to test

1. Make a doman enclave donation, if you haven't already.
1. Restart the game if you've visited doman enclave during your session.
1. Open dailies.
1. Check weekly tab.
1. Check that doman enclave is showing your remaining / allowance.

## Checklist

- [ ] `dotnet build -c Release` passes
- [ ] Verified in-game: opened the phone and exercised the affected app/screen
- [ ] If this changes user-visible behavior, README is updated
- [ ] Matches existing style: uses the shared `Windows/Components/` widgets, no `what` comments
