### PR TITLE
feat(composer): support shift+enter newlines in chat and post composers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ obj/
 bin/
 *.user
 .vscode/
+.kiro/
 
 # Node tooling (tools/icon-generator)
 node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ bin/
 *.user
 .vscode/
 .kiro/
+.abacusai/
+kilo.jsonc
 
 # Node tooling (tools/icon-generator)
 node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,6 @@ obj/
 bin/
 *.user
 .vscode/
-.kiro/
-.abacusai/
-kilo.jsonc
 
 # Node tooling (tools/icon-generator)
 node_modules/

--- a/src/Aetherphone/Apps/Aethergram/AethergramApp.Compose.cs
+++ b/src/Aetherphone/Apps/Aethergram/AethergramApp.Compose.cs
@@ -530,7 +530,7 @@ internal sealed partial class AethergramApp
         using (ImRaii.PushColor(ImGuiCol.Text, theme.TextStrong))
         {
             SoftWrapField.Multiline("##gramCaption", ref caption, MaxCaptionLength, inputSize, wrapWidth,
-                composeMentions);
+                composeMentions, allowNewlines: true);
         }
 
         var pickedMention = mentionPopup.Draw(composeMentions, screen, theme, images, lodestone);

--- a/src/Aetherphone/Apps/Chirper/ChirperApp.Compose.cs
+++ b/src/Aetherphone/Apps/Chirper/ChirperApp.Compose.cs
@@ -138,7 +138,7 @@ internal sealed partial class ChirperApp
             using (Plugin.Fonts.Push(1.15f))
             {
                 SoftWrapField.Multiline("##chirpBody", ref draft, MaxPostLength,
-                    new Vector2(inputWidth, inputHeight), composeWrapWidth, composeMentions);
+                    new Vector2(inputWidth, inputHeight), composeWrapWidth, composeMentions, allowNewlines: true);
             }
 
             var pickedMention = mentionPopup.Draw(composeMentions, area, theme, images, lodestone);

--- a/src/Aetherphone/Windows/Components/ChatComposer.cs
+++ b/src/Aetherphone/Windows/Components/ChatComposer.cs
@@ -30,6 +30,9 @@ internal sealed class ChatComposer : IDisposable
 {
     private const int TextKind = 0;
     private const float AccessoryBarHeight = 46f;
+    private const float ComposerBaseHeight = 56f;
+    private const float ComposerLineHeight = 20f;
+    private const int ComposerMaxLines = 4;
     private static readonly Vector4 White = new(1f, 1f, 1f, 1f);
     private static readonly Vector4 FieldFill = new(1f, 1f, 1f, 0.10f);
     private static readonly Vector4 BarFill = new(1f, 1f, 1f, 0.05f);
@@ -37,6 +40,7 @@ internal sealed class ChatComposer : IDisposable
     private readonly VoiceNoteRecorder recorder = new();
     private readonly EmojiPicker emojiPicker = new();
     private string draft = string.Empty;
+    private int composerEpoch;
     private bool focus;
     private bool emojiOpen;
     private string? replyTargetId;
@@ -60,6 +64,44 @@ internal sealed class ChatComposer : IDisposable
     public float AccessoryHeight => replyTargetId is not null || editTargetId is not null
         ? AccessoryBarHeight * UiScale.Current
         : 0f;
+
+    public float ComposerHeight
+    {
+        get
+        {
+            var scale = UiScale.Current;
+            var lines = Math.Clamp(CountLines(draft), 1, ComposerMaxLines);
+            return (ComposerBaseHeight + (lines - 1) * ComposerLineHeight) * scale;
+        }
+    }
+
+    private static int NewlineFilterCallback(ImGuiInputTextCallbackDataPtr data)
+    {
+        if (data.EventFlag == ImGuiInputTextFlags.CallbackCharFilter)
+        {
+            if (data.EventChar is '\n' or '\r')
+            {
+                var shift = ImGui.IsKeyDown(ImGuiKey.LeftShift) || ImGui.IsKeyDown(ImGuiKey.RightShift);
+                data.EventChar = shift ? '\n' : (char)0;
+            }
+        }
+
+        return 0;
+    }
+
+    internal static int CountLines(string text)
+    {
+        var lines = 1;
+        for (var index = 0; index < text.Length; index++)
+        {
+            if (text[index] == '\n')
+            {
+                lines++;
+            }
+        }
+
+        return lines;
+    }
 
     public void BeginReply(string messageId, string senderName, string preview)
     {
@@ -225,9 +267,9 @@ internal sealed class ChatComposer : IDisposable
         }
 
         var textLeft = emojiMax.X + 4f * scale;
-        ImGui.SetCursorScreenPos(new Vector2(textLeft,
-            (pillMin.Y + pillMax.Y) * 0.5f - ImGui.GetFrameHeight() * 0.5f));
-        ImGui.SetNextItemWidth(MathF.Max(1f, textRight - textLeft));
+        ImGui.SetCursorScreenPos(new Vector2(textLeft, pillMin.Y + 4f * scale));
+        var inputSize = new Vector2(MathF.Max(1f, textRight - textLeft),
+            MathF.Max(1f, pillMax.Y - pillMin.Y - 8f * scale));
         if (focus)
         {
             ImGui.SetKeyboardFocusHere();
@@ -235,15 +277,20 @@ internal sealed class ChatComposer : IDisposable
         }
 
         var submitted = false;
+        var shiftDown = ImGui.IsKeyDown(ImGuiKey.LeftShift) || ImGui.IsKeyDown(ImGuiKey.RightShift);
         Plugin.Fonts.NoticeText(draft);
         using (ImRaii.PushColor(ImGuiCol.FrameBg, new Vector4(0f, 0f, 0f, 0f)))
         using (ImRaii.PushColor(ImGuiCol.Text, theme.TextStrong))
         {
-            if (ImGui.InputTextWithHint("##chatComposerInput", Loc.T(L.Velvet.MessageHint), ref draft, model.MaxLength,
-                    ImGuiInputTextFlags.EnterReturnsTrue))
-            {
-                submitted = true;
-            }
+            ImGui.InputTextMultiline("##chatComposerInput" + composerEpoch, ref draft, model.MaxLength, inputSize,
+                ImGuiInputTextFlags.None, NewlineFilterCallback);
+        }
+
+        if (draft.Length == 0)
+        {
+            var hintPosition = new Vector2(textLeft + ImGui.GetStyle().FramePadding.X,
+                pillMin.Y + 4f * scale + ImGui.GetStyle().FramePadding.Y);
+            drawList.AddText(hintPosition, ImGui.GetColorU32(ui.MutedInk), Loc.T(L.Velvet.MessageHint));
         }
 
         var hasDraft = draft.Trim().Length > 0;
@@ -285,6 +332,11 @@ internal sealed class ChatComposer : IDisposable
             AppSkin.Icon(sendCenter, FontAwesomeIcon.PaperPlane.ToIconString(), White, 0.9f);
         }
 
+        if (ImGui.IsKeyPressed(ImGuiKey.Enter, false) && !shiftDown)
+        {
+            submitted = true;
+        }
+
         if (submitted && canSend)
         {
             if (editTargetId is { } editId)
@@ -299,6 +351,7 @@ internal sealed class ChatComposer : IDisposable
                 ClearReply();
             }
 
+            composerEpoch++;
             emojiOpen = false;
             focus = true;
         }

--- a/src/Aetherphone/Windows/Components/ChatComposer.cs
+++ b/src/Aetherphone/Windows/Components/ChatComposer.cs
@@ -41,6 +41,7 @@ internal sealed class ChatComposer : IDisposable
     private readonly EmojiPicker emojiPicker = new();
     private string draft = string.Empty;
     private int composerEpoch;
+    private string inputLabel = "##chatComposerInput0";
     private bool focus;
     private bool emojiOpen;
     private string? replyTargetId;
@@ -82,7 +83,8 @@ internal sealed class ChatComposer : IDisposable
             if (data.EventChar is '\n' or '\r')
             {
                 var shift = ImGui.IsKeyDown(ImGuiKey.LeftShift) || ImGui.IsKeyDown(ImGuiKey.RightShift);
-                data.EventChar = shift ? '\n' : (char)0;
+                var enterPressed = ImGui.IsKeyDown(ImGuiKey.Enter) || ImGui.IsKeyDown(ImGuiKey.KeypadEnter);
+                data.EventChar = shift || !enterPressed ? '\n' : (char)0;
             }
         }
 
@@ -279,11 +281,13 @@ internal sealed class ChatComposer : IDisposable
         var submitted = false;
         var shiftDown = ImGui.IsKeyDown(ImGuiKey.LeftShift) || ImGui.IsKeyDown(ImGuiKey.RightShift);
         Plugin.Fonts.NoticeText(draft);
+        bool inputActive;
         using (ImRaii.PushColor(ImGuiCol.FrameBg, new Vector4(0f, 0f, 0f, 0f)))
         using (ImRaii.PushColor(ImGuiCol.Text, theme.TextStrong))
         {
-            ImGui.InputTextMultiline("##chatComposerInput" + composerEpoch, ref draft, model.MaxLength, inputSize,
+            ImGui.InputTextMultiline(inputLabel, ref draft, model.MaxLength, inputSize,
                 ImGuiInputTextFlags.None, NewlineFilterCallback);
+            inputActive = ImGui.IsItemActive();
         }
 
         if (draft.Length == 0)
@@ -332,7 +336,8 @@ internal sealed class ChatComposer : IDisposable
             AppSkin.Icon(sendCenter, FontAwesomeIcon.PaperPlane.ToIconString(), White, 0.9f);
         }
 
-        if (ImGui.IsKeyPressed(ImGuiKey.Enter, false) && !shiftDown)
+        if (inputActive && !shiftDown &&
+            (ImGui.IsKeyPressed(ImGuiKey.Enter, false) || ImGui.IsKeyPressed(ImGuiKey.KeypadEnter, false)))
         {
             submitted = true;
         }
@@ -352,6 +357,7 @@ internal sealed class ChatComposer : IDisposable
             }
 
             composerEpoch++;
+            inputLabel = "##chatComposerInput" + composerEpoch;
             emojiOpen = false;
             focus = true;
         }

--- a/src/Aetherphone/Windows/Components/ChatThreadView.cs
+++ b/src/Aetherphone/Windows/Components/ChatThreadView.cs
@@ -275,7 +275,7 @@ internal abstract class ChatThreadView<TMessage, TThread> : IDisposable, IChatTr
         DrawHeader(area, threadId);
         var scale = UiScale.Current;
         var top = area.Min.Y + AppHeader.Height * scale;
-        var composerHeight = 56f * scale;
+        var composerHeight = composer.ComposerHeight;
         var accessoryHeight = composer.AccessoryHeight;
         var transcriptMessages = BuildTranscript(store.Messages);
         if (searchController.Open)

--- a/src/Aetherphone/Windows/Components/ChatTranscript.cs
+++ b/src/Aetherphone/Windows/Components/ChatTranscript.cs
@@ -532,6 +532,8 @@ internal sealed class ChatTranscript
         var textSize = linkLayout is null ? ImGui.CalcTextSize(message.Body, false, wrap) : linkLayout.Size;
         if (linkLayout is null && EndsWithNewline(message.Body))
         {
+            // RichText.Build already counts a trailing newline as a blank line via its own
+            // per-line height accumulation; only the raw CalcTextSize path undercounts it.
             textSize.Y += ImGui.GetTextLineHeight();
         }
         var deletedIconWidth = deleted ? 17f * scale : 0f;

--- a/src/Aetherphone/Windows/Components/ChatTranscript.cs
+++ b/src/Aetherphone/Windows/Components/ChatTranscript.cs
@@ -530,6 +530,10 @@ internal sealed class ChatTranscript
         var wrap = available * 0.74f - paddingX * 2f;
         var linkLayout = deleted ? null : LinkText.LayoutFor(message.Body, wrap);
         var textSize = linkLayout is null ? ImGui.CalcTextSize(message.Body, false, wrap) : linkLayout.Size;
+        if (linkLayout is null && EndsWithNewline(message.Body))
+        {
+            textSize.Y += ImGui.GetTextLineHeight();
+        }
         var deletedIconWidth = deleted ? 17f * scale : 0f;
         var stamp = MeasureStamp(message, mine, scale);
         var stampGap = 7f * scale;
@@ -643,6 +647,11 @@ internal sealed class ChatTranscript
             message.MediaWidth, message.MediaHeight, message.ReadAtUnix, message.SenderName, message.SenderTint,
             message.Flags, message.ReplyToId, message.ReplySenderName, message.ReplyBody, message.ReplyKind,
             message.DurationSecs, message.Reactions);
+    }
+
+    private static bool EndsWithNewline(string text)
+    {
+        return text.Length > 0 && text[^1] == '\n';
     }
 
     private void DrawPostCardBubble(TranscriptMessage message, int index, in ChatPostCard card,

--- a/src/Aetherphone/Windows/Components/SoftWrap.cs
+++ b/src/Aetherphone/Windows/Components/SoftWrap.cs
@@ -5,13 +5,17 @@ namespace Aetherphone.Windows.Components;
 
 internal static class SoftWrap
 {
-    public static int ApplyEdit(ImGuiInputTextCallbackDataPtr data, float wrapWidth, int maxLength)
+    private const char SoftWrapSentinel = '\u200B';
+
+    public static int ApplyEdit(ImGuiInputTextCallbackDataPtr data, float wrapWidth, int maxLength,
+        bool allowNewlines)
     {
         if (data.EventFlag == ImGuiInputTextFlags.CallbackCharFilter)
         {
             if (data.EventChar is '\n' or '\r')
             {
-                data.EventChar = 0;
+                var shift = ImGui.IsKeyDown(ImGuiKey.LeftShift) || ImGui.IsKeyDown(ImGuiKey.RightShift);
+                data.EventChar = allowNewlines && shift ? '\n' : (char)0;
             }
 
             return 0;
@@ -19,9 +23,9 @@ internal static class SoftWrap
 
         var current = Encoding.UTF8.GetString(data.BufSpan[..data.BufTextLen]);
         var charCursor = ByteIndexToCharIndex(current, data.CursorPos);
-        var logicalCursor = charCursor - CountNewlines(current, charCursor);
+        var logicalCursor = charCursor - CountNonLogical(current, charCursor);
 
-        var logical = StripNewlines(current);
+        var logical = StripSoftWraps(current);
         if (logical.Length > maxLength)
         {
             logical = logical[..maxLength];
@@ -64,6 +68,16 @@ internal static class SoftWrap
         var index = 0;
         while (index < text.Length)
         {
+            if (text[index] == '\n')
+            {
+                builder.Append('\n');
+                lineStart = builder.Length;
+                lineWidth = 0f;
+                wordStart = builder.Length;
+                index++;
+                continue;
+            }
+
             var runeLength = char.IsHighSurrogate(text[index]) && index + 1 < text.Length &&
                              char.IsLowSurrogate(text[index + 1])
                 ? 2
@@ -75,14 +89,14 @@ internal static class SoftWrap
             {
                 if (wordStart > lineStart)
                 {
-                    builder.Insert(wordStart, '\n');
-                    lineStart = wordStart + 1;
+                    builder.Insert(wordStart, SoftWrapSentinel + "\n");
+                    lineStart = wordStart + 2;
                     lineWidth = MeasureRange(builder, lineStart);
                     wordStart = lineStart;
                 }
                 else
                 {
-                    builder.Append('\n');
+                    builder.Append(SoftWrapSentinel).Append('\n');
                     lineStart = builder.Length;
                     lineWidth = 0f;
                     wordStart = builder.Length;
@@ -102,9 +116,30 @@ internal static class SoftWrap
         return builder.ToString();
     }
 
-    public static string StripNewlines(string text)
+    public static string StripSoftWraps(string text)
     {
-        return text.IndexOf('\n') < 0 ? text : text.Replace("\n", string.Empty);
+        if (text.IndexOf(SoftWrapSentinel) < 0)
+        {
+            return text;
+        }
+
+        var builder = new StringBuilder(text.Length);
+        for (var index = 0; index < text.Length; index++)
+        {
+            if (text[index] == SoftWrapSentinel)
+            {
+                if (index + 1 < text.Length && text[index + 1] == '\n')
+                {
+                    index++;
+                }
+
+                continue;
+            }
+
+            builder.Append(text[index]);
+        }
+
+        return builder.ToString();
     }
 
     public static void ReadLogical(ImGuiInputTextCallbackDataPtr data, out string display, out string logical,
@@ -112,8 +147,8 @@ internal static class SoftWrap
     {
         display = Encoding.UTF8.GetString(data.BufSpan[..data.BufTextLen]);
         var charCursor = ByteIndexToCharIndex(display, data.CursorPos);
-        logicalCursor = charCursor - CountNewlines(display, charCursor);
-        logical = StripNewlines(display);
+        logicalCursor = charCursor - CountNonLogical(display, charCursor);
+        logical = StripSoftWraps(display);
     }
 
     public static void SetCursor(ImGuiInputTextCallbackDataPtr data, string display, int logicalCursor)
@@ -143,7 +178,7 @@ internal static class SoftWrap
         var length = text.Length;
         for (var index = 0; index < text.Length; index++)
         {
-            if (text[index] == '\n')
+            if (text[index] == '\n' || text[index] == SoftWrapSentinel)
             {
                 length--;
             }
@@ -162,12 +197,12 @@ internal static class SoftWrap
         return ImGui.CalcTextSize(builder.ToString(start, builder.Length - start)).X;
     }
 
-    private static int CountNewlines(string text, int limit)
+    private static int CountNonLogical(string text, int limit)
     {
         var count = 0;
         for (var index = 0; index < limit; index++)
         {
-            if (text[index] == '\n')
+            if (text[index] == '\n' || text[index] == SoftWrapSentinel)
             {
                 count++;
             }
@@ -204,7 +239,7 @@ internal static class SoftWrap
         var index = 0;
         while (index < wrapped.Length && seen < logicalCursor)
         {
-            if (wrapped[index] != '\n')
+            if (wrapped[index] != '\n' && wrapped[index] != SoftWrapSentinel)
             {
                 seen++;
             }

--- a/src/Aetherphone/Windows/Components/SoftWrap.cs
+++ b/src/Aetherphone/Windows/Components/SoftWrap.cs
@@ -12,10 +12,17 @@ internal static class SoftWrap
     {
         if (data.EventFlag == ImGuiInputTextFlags.CallbackCharFilter)
         {
+            if (data.EventChar == SoftWrapSentinel)
+            {
+                data.EventChar = (char)0;
+                return 0;
+            }
+
             if (data.EventChar is '\n' or '\r')
             {
                 var shift = ImGui.IsKeyDown(ImGuiKey.LeftShift) || ImGui.IsKeyDown(ImGuiKey.RightShift);
-                data.EventChar = allowNewlines && shift ? '\n' : (char)0;
+                var enterPressed = ImGui.IsKeyDown(ImGuiKey.Enter) || ImGui.IsKeyDown(ImGuiKey.KeypadEnter);
+                data.EventChar = allowNewlines && (shift || !enterPressed) ? '\n' : (char)0;
             }
 
             return 0;

--- a/src/Aetherphone/Windows/Components/SoftWrapField.cs
+++ b/src/Aetherphone/Windows/Components/SoftWrapField.cs
@@ -11,6 +11,7 @@ internal static class SoftWrapField
         public string Logical = string.Empty;
         public float WrapWidth;
         public int MaxLength;
+        public bool AllowNewlines;
         public string? PendingHandle;
         public int LogicalCursor;
         public int? RestoreCursor;
@@ -33,7 +34,7 @@ internal static class SoftWrapField
 
             if (data.EventFlag != ImGuiInputTextFlags.CallbackAlways)
             {
-                return SoftWrap.ApplyEdit(data, WrapWidth, MaxLength);
+                return SoftWrap.ApplyEdit(data, WrapWidth, MaxLength, AllowNewlines);
             }
 
             SoftWrap.ReadLogical(data, out var display, out var logical, out var cursor);
@@ -76,11 +77,12 @@ internal static class SoftWrapField
     private static readonly Dictionary<string, Editor> Editors = new(StringComparer.Ordinal);
 
     public static void Multiline(string id, ref string value, int maxLength, Vector2 size, float wrapWidth,
-        MentionAutocomplete? mentions = null)
+        MentionAutocomplete? mentions = null, bool allowNewlines = false)
     {
         var editor = GetEditor(id, maxLength);
         editor.WrapWidth = wrapWidth;
         editor.MaxLength = maxLength;
+        editor.AllowNewlines = allowNewlines;
         editor.TabRequested = false;
 
         var logical = value ?? string.Empty;
@@ -107,7 +109,7 @@ internal static class SoftWrapField
         }
 
         Plugin.Fonts.NoticeText(editor.Display);
-        var bufferBytes = maxLength * 4 + 1024;
+        var bufferBytes = maxLength * 6 + 2048;
         var flags = ImGuiInputTextFlags.CallbackEdit | ImGuiInputTextFlags.CallbackCharFilter;
         if (mentions is not null)
         {
@@ -122,7 +124,7 @@ internal static class SoftWrapField
         var edited = ImGui.InputTextMultiline(id, ref editor.Display, bufferBytes, size, flags, editor.Callback);
         if (edited)
         {
-            editor.Logical = SoftWrap.StripNewlines(editor.Display);
+            editor.Logical = SoftWrap.StripSoftWraps(editor.Display);
         }
 
         value = editor.Logical;


### PR DESCRIPTION
close #108 

## Summary

Adds shift+Enter newline support to the chat composer and post composers, and fixes two related bugs.

## Changes

- **ChatComposer**: Reworked to use a multiline input with a newline char filter that allows `\n` only when shift is held; plain Enter submits.
- **Duplicate DM fix**: Added a `composerEpoch`-based widget ID and an Enter key-press guard to prevent duplicate DM sends caused by the stale `InputText` buffer re-syncing after a send.
- **Newline cutoff fix**: Fixed a trailing-newline height undercount in `DrawTextBubble` so messages ending in a newline are not cut off.
- **Aethergram / Chirper**: Enabled `allowNewlines` for post captions and compose bodies.

## Testing

- Shift+Enter inserts a newline in DMs and post captions; plain Enter sends.
- No duplicate DM messages on repeated sends.
- Messages ending in a newline render fully without being cut off.