### PR TITLE
feat(market): added toggle to enable/disable market context menu item.

### DIFF
--- a/src/Aetherphone/Apps/Settings/Pages/BehaviorPage.cs
+++ b/src/Aetherphone/Apps/Settings/Pages/BehaviorPage.cs
@@ -81,6 +81,18 @@ internal sealed class BehaviorPage : ISettingsPage
             ImGui.Dummy(new Vector2(0f, 8f * scale));
             SettingsSection.Hint(Loc.T(L.Settings.ChirperMediaPostsHint), theme);
 
+            ImGui.Dummy(new Vector2(0f, 8f * scale));
+            var menuContextCard = GroupCard.Begin(theme,1);
+            var menuContextToggle = SettingsRow.Bool(menuContextCard.NextRow(), Loc.T(L.Settings.MarketContextMenu), configuration.MarketContextMenu, theme);
+            menuContextCard.End();
+            if (menuContextToggle != configuration.MarketContextMenu)
+            {
+                configuration.MarketContextMenu = menuContextToggle;
+                configuration.Save();
+            }
+            ImGui.Dummy(new Vector2(0f, 8f * scale));
+            SettingsSection.Hint(Loc.T(L.Settings.MarketContextMenuHint), theme);
+
             ImGui.Dummy(new Vector2(0f, 12f * scale));
             var startupCard = GroupCard.Begin(theme, 2);
             var openStartup = SettingsRow.Bool(startupCard.NextRow(), Loc.T(L.Settings.OpenOnStartup),

--- a/src/Aetherphone/Configuration.cs
+++ b/src/Aetherphone/Configuration.cs
@@ -215,6 +215,8 @@ internal sealed class Configuration : IPluginConfiguration, IHomeConfiguration, 
     public bool TimerNotified { get; set; }
     public string LastSeenChangelogVersion { get; set; } = string.Empty;
     public bool ChangelogSeenInitialized { get; set; }
+    
+    public bool MarketContextMenu { get; set; } = true;
 
     public bool HasUnseenChangelog => LastSeenChangelogVersion != ChangelogData.LatestVersion;
 

--- a/src/Aetherphone/Core/Localization/L.cs
+++ b/src/Aetherphone/Core/Localization/L.cs
@@ -1236,6 +1236,8 @@ internal static class L
         public static readonly LocString SoundDefault = new("settings.soundDefault", "Default");
         public static readonly LocString Immersion = new("settings.immersion", "Immersion");
         public static readonly LocString Behavior = new("settings.behavior", "Behavior");
+        public static readonly LocString MarketContextMenu = new("settings.marketContextMenu", "Enable Market Search in Context Menu");
+        public static readonly LocString MarketContextMenuHint = new("settings.marketContextMenuHint", "Shows \"Search the Market\" option in the in-game context menu when right-clicking on an item.");
         public static readonly LocString ScrollWhileIdle = new("settings.scrollWhileIdle", "Scroll while idle");
         public static readonly LocString ScrollWhileIdleHint = new("settings.scrollWhileIdleHint", "Your character scrolls through their phone (Tomescroll emote) while standing still and out of combat. Does nothing if you haven't unlocked the emote.");
         public static readonly LocString ShowInGpose = new("settings.showInGpose", "Show in Group Pose");

--- a/src/Aetherphone/Localization/de.json
+++ b/src/Aetherphone/Localization/de.json
@@ -675,6 +675,8 @@
   "settings.soundDefault": "Standard",
   "settings.immersion": "Immersion",
   "settings.behavior": "Verhalten",
+  "settings.marketContextMenu": "Marktsuche im Kontextmenü aktivieren",
+  "settings.marketContextMenuHint": "Zeigt die Option \"Auf dem Markt suchen\" im Kontextmenü an, wenn du im Spiel mit Rechtsklick auf einen Gegenstand klickst.",
   "settings.scrollWhileIdle": "Im Leerlauf scrollen",
   "settings.scrollWhileIdleHint": "Dein Charakter scrollt durch sein Handy (Tomescroll-Emote), während er still steht und sich nicht im Kampf befindet. Ohne Wirkung, falls die Emote nicht freigeschaltet ist.",
   "settings.showInGpose": "In Gruppenpose anzeigen",

--- a/src/Aetherphone/Localization/en.json
+++ b/src/Aetherphone/Localization/en.json
@@ -675,6 +675,8 @@
   "settings.soundDefault": "Default",
   "settings.immersion": "Immersion",
   "settings.behavior": "Behavior",
+  "settings.marketContextMenu": "Enable Market Search in Context Menu",
+  "settings.marketContextMenuHint": "Shows \"Search the Market\" option in the in-game context menu when right-clicking on an item.",
   "settings.scrollWhileIdle": "Scroll while idle",
   "settings.scrollWhileIdleHint": "Your character scrolls through their phone (Tomescroll emote) while standing still and out of combat. Does nothing if you haven't unlocked the emote.",
   "settings.showInGpose": "Show in Group Pose",

--- a/src/Aetherphone/Localization/es.json
+++ b/src/Aetherphone/Localization/es.json
@@ -675,6 +675,8 @@
   "settings.soundDefault": "Predeterminado",
   "settings.immersion": "Inmersión",
   "settings.behavior": "Comportamiento",
+  "settings.marketContextMenu": "Activar búsqueda de mercado en el menú contextual",
+  "settings.marketContextMenuHint": "Muestra la opción \"Buscar en el mercado\" en el menú contextual del juego al hacer clic derecho en un objeto.",
   "settings.scrollWhileIdle": "Desplazar estando inactivo",
   "settings.scrollWhileIdleHint": "Tu personaje revisa su teléfono (emote Tomescroll) mientras está quieto y fuera de combate. No hace nada si no has desbloqueado el emote.",
   "settings.showInGpose": "Mostrar en Pose de grupo",

--- a/src/Aetherphone/Localization/fr.json
+++ b/src/Aetherphone/Localization/fr.json
@@ -675,6 +675,8 @@
   "settings.soundDefault": "Par défaut",
   "settings.immersion": "Immersion",
   "settings.behavior": "Comportement",
+  "settings.marketContextMenu": "Activer la recherche du marché dans le menu contextuel",
+  "settings.marketContextMenuHint": "Affiche l'option « Chercher sur le marché » dans le menu contextuel en jeu lorsque vous faites un clic droit sur un objet.",
   "settings.scrollWhileIdle": "Faire défiler à l'arrêt",
   "settings.scrollWhileIdleHint": "Votre personnage fait défiler son téléphone (émote Tomescroll) lorsqu'il reste immobile et hors combat. Sans effet si vous n'avez pas débloqué l'émote.",
   "settings.showInGpose": "Afficher dans le Photodrame",

--- a/src/Aetherphone/Localization/ja.json
+++ b/src/Aetherphone/Localization/ja.json
@@ -675,6 +675,8 @@
   "settings.soundDefault": "デフォルト",
   "settings.immersion": "没入感",
   "settings.behavior": "動作",
+  "settings.marketContextMenu": "コンテキストメニューでマーケット検索を有効にする",
+  "settings.marketContextMenuHint": "ゲーム内でアイテムを右クリックしたときに表示されるコンテキストメニューに「マーケットで検索」オプションを表示します。",
   "settings.scrollWhileIdle": "待機中にスクロール",
   "settings.scrollWhileIdleHint": "立ち止まっていて非戦闘状態の時、キャラクターが電話をスクロールする（トームストーン）エモートを実行します。エモートを解放していない場合は機能しません。",
   "settings.showInGpose": "グループポーズ中に表示",

--- a/src/Aetherphone/Localization/pt.json
+++ b/src/Aetherphone/Localization/pt.json
@@ -675,6 +675,8 @@
   "settings.soundDefault": "Padrão",
   "settings.immersion": "Imersão",
   "settings.behavior": "Comportamento",
+  "settings.marketContextMenu": "Ativar busca no mercado no menu de contexto",
+  "settings.marketContextMenuHint": "Mostra a opção \"Buscar no Mercado\" no menu de contexto do jogo ao clicar com o botão direito em um item.",
   "settings.scrollWhileIdle": "Rolar quando parado",
   "settings.scrollWhileIdleHint": "Seu personagem rola o telefone (emote Tomescroll) enquanto fica parado e fora de combate. Não faz nada se você não desbloqueou o emote.",
   "settings.showInGpose": "Mostrar no Group Pose",

--- a/src/Aetherphone/Localization/ru.json
+++ b/src/Aetherphone/Localization/ru.json
@@ -675,6 +675,8 @@
   "settings.soundDefault": "По умолчанию",
   "settings.immersion": "Погружение",
   "settings.behavior": "Поведение",
+  "settings.marketContextMenu": "Поиск на рынке в контекстном меню",
+  "settings.marketContextMenuHint": "Показывает пункт «Искать на рынке» в контекстном меню при нажатии правой кнопкой мыши на предмет.",
   "settings.scrollWhileIdle": "Листать телефон на месте",
   "settings.scrollWhileIdleHint": "Ваш персонаж листает телефон (эмоция Tomescroll), стоя на месте вне боя. Не работает, если эмоция не разблокирована.",
   "settings.showInGpose": "Показывать в групповой позе",

--- a/src/Aetherphone/Localization/tr.json
+++ b/src/Aetherphone/Localization/tr.json
@@ -675,6 +675,8 @@
   "settings.soundDefault": "Varsayılan",
   "settings.immersion": "Atmosfer",
   "settings.behavior": "Davranış",
+  "settings.marketContextMenu": "Sağ tık menüsünde pazar aramasını etkinleştir",
+  "settings.marketContextMenuHint": "Oyun içinde bir eşyaya sağ tıkladığında \"Pazarda Ara\" seçeneğini gösterir.",
   "settings.scrollWhileIdle": "Boştayken kaydır",
   "settings.scrollWhileIdleHint": "Karakterin hareketsiz ve savaş dışındayken telefonunda gezinir (Tomescroll emotu). Bu emotu açmadıysan hiçbir şey yapmaz.",
   "settings.showInGpose": "Grup pozunda göster",

--- a/src/Aetherphone/Localization/zh.json
+++ b/src/Aetherphone/Localization/zh.json
@@ -675,6 +675,8 @@
   "settings.soundDefault": "默认",
   "settings.immersion": "沉浸感",
   "settings.behavior": "行为",
+  "settings.marketContextMenu": "在右键菜单中启用市场搜索",
+  "settings.marketContextMenuHint": "在游戏中右键点击物品时，在右键菜单中显示"在市场搜索"选项。",
   "settings.scrollWhileIdle": "待机时滑动手机",
   "settings.scrollWhileIdleHint": "你的角色在站立且非战斗状态下会滑动手机（使用神典石情感动作）。如果未解锁该动作则无效。",
   "settings.showInGpose": "集体动作时显示",

--- a/src/Aetherphone/Plugin.cs
+++ b/src/Aetherphone/Plugin.cs
@@ -390,14 +390,21 @@ public sealed class Plugin : IDalamudPlugin
 
     private void OnMenuOpened(IMenuOpenedArgs args)
     {
-        var itemId = ResolveContextItem(args);
-        if (itemId == 0 || !services.MarketIndex.TryGet(itemId, out _))
+        if(!Cfg.MarketContextMenu)
         {
             return;
         }
-
-        args.AddMenuItem(
-            new MenuItem { Name = Loc.T(L.Plugin.SearchTheMarket), OnClicked = _ => OpenMarketAt(itemId), });
+            else
+        {
+            var itemId = ResolveContextItem(args);
+            if (itemId == 0 || !services.MarketIndex.TryGet(itemId, out _))
+            {
+                return;
+            }
+            
+            args.AddMenuItem(
+                new MenuItem { Name = Loc.T(L.Plugin.SearchTheMarket), OnClicked = _ => OpenMarketAt(itemId), });
+        }
     }
 
     private static uint ResolveContextItem(IMenuOpenedArgs args)


### PR DESCRIPTION
## What

Aetherphone adds a "Search the Market" context menu item when right-clicking on items ingame. This PR introduces a toggle to the behavior settings to allow users to toggle it on or off. By default it's currently set to on.

## Why

Users have been asking for a way to remove it.

Closes # https://discord.com/channels/1527213298087493732/1529393371024720033 & https://discord.com/channels/1527213298087493732/1529768145970139156

## How to test

1. Right-click any item in your inventory in-game.
2. See context menu option for "Search the Market"
3. Open Settings App in Aetherphone.
4. Open Behavior Page.
5. Toggle off "Enable Market Search in Context Menu"
6. Right-click any item in your inventory in-game again.
7. Option should be removed when toggled off.

## In-game Behavior

Enabled:
<img width="1138" height="982" alt="image" src="https://github.com/user-attachments/assets/dbefd0e2-a100-4ba4-a39e-a17bdd723cc0" />

Disabled:
<img width="1119" height="1034" alt="image" src="https://github.com/user-attachments/assets/5d4f3cab-cc5f-4602-a3b6-59b064e58254" />


## Checklist

- [x] `dotnet build -c Release` passes
- [x] Verified in-game: opened the phone and exercised the affected app/screen
- [x] If this changes user-visible behavior, README is updated
- [x] Matches existing style: uses the shared `Windows/Components/` widgets, no `what` comments
