### PR TITLE
fix(shell): disabled control center when in landscape mode.

### DIFF
--- a/src/Aetherphone/Apps/AetherStream/AetherStreamApp.Player.cs
+++ b/src/Aetherphone/Apps/AetherStream/AetherStreamApp.Player.cs
@@ -4,6 +4,7 @@ using Aetherphone.Core.Apps;
 using Aetherphone.Core.Localization;
 using Aetherphone.Core.Onboarding;
 using Aetherphone.Core.Platform;
+using Aetherphone.Core.Shell;
 using Aetherphone.Core.Theme;
 using Aetherphone.Core.Video;
 using Aetherphone.Windows.Components;
@@ -27,6 +28,8 @@ internal sealed partial class AetherStreamApp
     private Spring heroActionsFade;
 
     private VideoQueueEntry? CurrentEntry => watchAlong.IsViewing ? watchAlong.ViewingEntry : queue.Current;
+
+    private readonly ControlCenter controlCenter;
 
     private void DrawNowPlaying(Rect body, float scale)
     {
@@ -190,6 +193,7 @@ internal sealed partial class AetherStreamApp
         upNextSheet.Close();
         partySheet.Close();
         screenSheet.Close();
+        controlCenter.Dismiss();
         AppLandscape.Request(Id);
     }
 

--- a/src/Aetherphone/Core/Shell/ShellOverlayCoordinator.cs
+++ b/src/Aetherphone/Core/Shell/ShellOverlayCoordinator.cs
@@ -194,7 +194,7 @@ internal sealed class ShellOverlayCoordinator
         HandleEscape();
         controlCenter.Draw(screen, theme, delta,
             !navigation.IsTransitioning && !director.CapturesPointer && !state.IslandCaptures &&
-            !banOverlay.IsActive && navigation.Current?.Id != "camera",
+            !banOverlay.IsActive && navigation.Current?.Id != "camera" && !AppLandscape.Held(navigation.Current?.Id ?? string.Empty),
             !director.CapturesPointer);
         HoverTooltip.Flush();
         CopyToast.Flush();


### PR DESCRIPTION
## What

Updated shelloverlay with a check for landscape mode and added a control center dismiss to the mogcast player.

## Why

This prevents users from getting stuck in the control center with no way to exit besides reloading the phone.

Closes #

## How I tested it

1. Started a video in mogcast.
2. Entered fullscreen mode.
3. Attempted to open the control center.

## Screenshots

Ping in discord if needed.

## Backend coordination

N/A

## Checklist

Gates (CI enforces all of these):

- [ ] `dotnet build Aetherphone.sln -c Release` is clean
- [x] `dotnet test` passes (this is where localization lockstep and accent contrast are enforced)
- [x] No em dashes anywhere: code, strings, JSON catalogs, docs
- [x] No `async void`, no new LINQ outside the allowlisted files, no raw `ImGuiHelpers.GlobalScale` (use `UiScale.Current`), no hand-formatted clock text (use `TimeText.Clock`)

Strings:

- [x] Every new user-visible string is a LocString in `Core/Localization/L.cs` plus the same key in all nine JSONs under `src/Aetherphone/Localization/`, in this same PR
- [x] Any changed English text is updated in both `L.cs` and `en.json` so they do not drift

Quality:

- [x] Verified in-game on the screens this touches, on the build variant that matters (`/phone` or `/phonedev`)
- [x] Draw-path code allocates nothing per frame and uses the shared `Windows/Components/` widgets, `TextStyles`, and `Metrics` tokens
- [x] README updated if this changes what a user sees or types; the relevant page under `docs/` still tells the truth
- [x] Commit messages and this PR body carry no AI attribution trailers
