### PR TITLE
feat(aetherstream): added toggle for in-game screen

### DIFF
--- a/src/Aetherphone/Apps/AetherStream/AetherStreamApp.Casting.cs
+++ b/src/Aetherphone/Apps/AetherStream/AetherStreamApp.Casting.cs
@@ -22,9 +22,21 @@ internal sealed partial class AetherStreamApp
             var width = ScrollLayout.StableContentWidth();
             DrawScreenStateRow(width, scale);
 
-            var windowCard = GroupCard.Begin(accentedTheme, 1);
+            var windowCard = GroupCard.Begin(accentedTheme, 2);
             var windowOpen = SettingsRow.Bool(windowCard.NextRow(), Loc.T(L.AetherStream.OpenScreenWindow),
                 screenWindow.IsOpen, accentedTheme);
+            var screenVisible = SettingsRow.Bool(windowCard.NextRow(),
+                Loc.T(L.AetherStream.InGameScreen), configuration.VideoScreenVisible, accentedTheme);
+            if (screenVisible != configuration.VideoScreenVisible)
+            {
+                configuration.VideoScreenVisible = screenVisible;
+                configuration.Save();
+                screen.Engine.ScreenVisible = screenVisible;
+                if (screenVisible)
+                {
+                    screen.Engine.RecenterScreen();
+                }
+            }
             windowCard.End();
             if (windowOpen != screenWindow.IsOpen)
             {

--- a/src/Aetherphone/Apps/AetherStream/AetherStreamApp.Casting.cs
+++ b/src/Aetherphone/Apps/AetherStream/AetherStreamApp.Casting.cs
@@ -25,6 +25,8 @@ internal sealed partial class AetherStreamApp
             var windowCard = GroupCard.Begin(accentedTheme, 2);
             var windowOpen = SettingsRow.Bool(windowCard.NextRow(), Loc.T(L.AetherStream.OpenScreenWindow),
                 screenWindow.IsOpen, accentedTheme);
+            windowCard.End();
+            
             var screenVisible = SettingsRow.Bool(windowCard.NextRow(),
                 Loc.T(L.AetherStream.InGameScreen), configuration.VideoScreenVisible, accentedTheme);
             if (screenVisible != configuration.VideoScreenVisible)
@@ -37,7 +39,7 @@ internal sealed partial class AetherStreamApp
                     screen.Engine.RecenterScreen();
                 }
             }
-            windowCard.End();
+
             if (windowOpen != screenWindow.IsOpen)
             {
                 screenWindow.IsOpen = windowOpen;
@@ -132,7 +134,7 @@ internal sealed partial class AetherStreamApp
         ImGui.Dummy(new Vector2(0f, Metrics.Space.Sm * scale));
         SettingsSection.Header(Loc.T(L.AetherStream.CastingScreenPositionHeader), accentedTheme);
 
-        if (!screen.Engine.IsActive)
+        if (!screen.Engine.IsActive || !screen.Engine.ScreenVisible)
         {
             SettingsSection.Hint(Loc.T(L.AetherStream.CastingScreenPositionHint), accentedTheme);
             return;

--- a/src/Aetherphone/Apps/AetherStream/AetherStreamApp.cs
+++ b/src/Aetherphone/Apps/AetherStream/AetherStreamApp.cs
@@ -76,6 +76,7 @@ internal sealed partial class AetherStreamApp : IPhoneApp
         video.HardwareDecoding = configuration.VideoHardwareDecoding;
         video.AllowInsecureDirectUrls = configuration.VideoAllowInsecureDirectUrls;
         video.MaxQualityHeight = configuration.VideoMaxQualityHeight;
+        screen.Engine.ScreenVisible = configuration.VideoScreenVisible;
     }
 
     public string Id => "aetherstream";

--- a/src/Aetherphone/Configuration.cs
+++ b/src/Aetherphone/Configuration.cs
@@ -126,6 +126,7 @@ internal sealed class Configuration : IPluginConfiguration, IHomeConfiguration, 
     public bool VideoAllowInsecureDirectUrls { get; set; }
     public bool VideoStreamApprovalRequired { get; set; }
     public bool VideoStreamDiscoverable { get; set; } = true;
+    public bool VideoScreenVisible { get; set; } = true;
     public List<ScreenPositionPreset> ScreenPresets { get; set; } = new();
     public List<VideoQueueRecord> VideoQueue { get; set; } = new();
     public bool GameSoundsCleared { get; set; }

--- a/src/Aetherphone/Core/Localization/L.cs
+++ b/src/Aetherphone/Core/Localization/L.cs
@@ -3393,7 +3393,7 @@ internal static class L
             "Not ready");
         public static readonly LocString CastingStateReady = new("aetherstream.castingStateReady", "Ready");
         public static readonly LocString OpenScreenWindow = new("aetherstream.openScreenWindow", "Open in a window");
-        public static readonly LocString InGameScreen = new("aetherstream.inGameScreen", "Toggle In-game Screen");
+        public static readonly LocString InGameScreen = new("aetherstream.inGameScreen", "Show In-game Screen");
         public static readonly LocString CastingScreenPositionHeader = new(
             "aetherstream.castingScreenPositionHeader", "Screen Position");
         public static readonly LocString CastingScreenPositionHint = new(

--- a/src/Aetherphone/Core/Localization/L.cs
+++ b/src/Aetherphone/Core/Localization/L.cs
@@ -3393,6 +3393,7 @@ internal static class L
             "Not ready");
         public static readonly LocString CastingStateReady = new("aetherstream.castingStateReady", "Ready");
         public static readonly LocString OpenScreenWindow = new("aetherstream.openScreenWindow", "Open in a window");
+        public static readonly LocString InGameScreen = new("aetherstream.inGameScreen", "Toggle In-game Screen");
         public static readonly LocString CastingScreenPositionHeader = new(
             "aetherstream.castingScreenPositionHeader", "Screen Position");
         public static readonly LocString CastingScreenPositionHint = new(

--- a/src/Aetherphone/Core/Video/ScreenPainter.cs
+++ b/src/Aetherphone/Core/Video/ScreenPainter.cs
@@ -11,6 +11,7 @@ using GfxScene = FFXIVClientStructs.FFXIV.Client.Graphics.Scene;
 using GfxGui = FFXIVClientStructs.FFXIV.Component.GUI;
 using GameControl = FFXIVClientStructs.FFXIV.Client.Game.Control;
 using NumericsMatrix4x4 = System.Numerics.Matrix4x4;
+using Dalamud.Bindings.ImGui;
 
 namespace Aetherphone.Core.Video;
 
@@ -43,6 +44,7 @@ internal sealed unsafe class ScreenPainter : IDisposable
 	private const int CurveSegments = 24;
 	private const float Curvature = 0.12f;
 	private const int VertexCount = (CurveSegments + 1) * 2;
+	internal bool Visible {get; set; } = true;
 
 	[StructLayout(LayoutKind.Sequential)]
 	private unsafe struct ScreenParams
@@ -173,6 +175,11 @@ internal sealed unsafe class ScreenPainter : IDisposable
 
 	private void DrawIfReady()
 	{
+		if (!Visible)
+		{
+			return;
+		}
+
 		if (!TryGetSceneTargets(out nint colorTexture, out nint depthTexture, out uint targetWidth, out uint targetHeight) || _srv == null)
 		{
 			return;

--- a/src/Aetherphone/Core/Video/ScreenPainter.cs
+++ b/src/Aetherphone/Core/Video/ScreenPainter.cs
@@ -11,7 +11,6 @@ using GfxScene = FFXIVClientStructs.FFXIV.Client.Graphics.Scene;
 using GfxGui = FFXIVClientStructs.FFXIV.Component.GUI;
 using GameControl = FFXIVClientStructs.FFXIV.Client.Game.Control;
 using NumericsMatrix4x4 = System.Numerics.Matrix4x4;
-using Dalamud.Bindings.ImGui;
 
 namespace Aetherphone.Core.Video;
 
@@ -23,6 +22,7 @@ internal sealed unsafe class ScreenPainter : IDisposable
 	internal Vector3 WorldPosition;
 	internal float WorldYaw;
 	internal float Scale = 1.0f;
+	internal bool Visible { get; set; } = true;
 
 	private readonly VertexShader _vs;
 	private readonly PixelShader _ps;
@@ -44,7 +44,6 @@ internal sealed unsafe class ScreenPainter : IDisposable
 	private const int CurveSegments = 24;
 	private const float Curvature = 0.12f;
 	private const int VertexCount = (CurveSegments + 1) * 2;
-	internal bool Visible {get; set; } = true;
 
 	[StructLayout(LayoutKind.Sequential)]
 	private unsafe struct ScreenParams

--- a/src/Aetherphone/Core/Video/VideoEngine.cs
+++ b/src/Aetherphone/Core/Video/VideoEngine.cs
@@ -635,6 +635,12 @@ internal sealed class VideoEngine : IDisposable
         }
     }
 
+    internal bool ScreenVisible
+    {
+        get => screenPainter.Visible;
+        set => screenPainter.Visible = value;
+    }
+
     public void Dispose()
     {
         lifetime.Cancel();

--- a/src/Aetherphone/Localization/de.json
+++ b/src/Aetherphone/Localization/de.json
@@ -3908,7 +3908,7 @@
   "aetherstream.castingStateNotReady": "Nicht bereit",
   "aetherstream.castingStateReady": "Bereit",
   "aetherstream.openScreenWindow": "In einem Fenster öffnen",
-  "aetherstream.inGameScreen": "Ingame-Bildschirm umschalten",
+  "aetherstream.inGameScreen": "Ingame-Bildschirm anzeigen",
   "aetherstream.castingScreenPositionHeader": "Bildschirmposition",
   "aetherstream.castingScreenPositionHint": "Starte die Wiedergabe, um den Bildschirm zu verschieben und die Größe zu ändern.",
   "aetherstream.castingPresetNameHint": "Name des Presets…",

--- a/src/Aetherphone/Localization/de.json
+++ b/src/Aetherphone/Localization/de.json
@@ -3908,6 +3908,7 @@
   "aetherstream.castingStateNotReady": "Nicht bereit",
   "aetherstream.castingStateReady": "Bereit",
   "aetherstream.openScreenWindow": "In einem Fenster öffnen",
+  "aetherstream.inGameScreen": "Ingame-Bildschirm umschalten",
   "aetherstream.castingScreenPositionHeader": "Bildschirmposition",
   "aetherstream.castingScreenPositionHint": "Starte die Wiedergabe, um den Bildschirm zu verschieben und die Größe zu ändern.",
   "aetherstream.castingPresetNameHint": "Name des Presets…",

--- a/src/Aetherphone/Localization/en.json
+++ b/src/Aetherphone/Localization/en.json
@@ -3908,7 +3908,7 @@
   "aetherstream.castingStateNotReady": "Not ready",
   "aetherstream.castingStateReady": "Ready",
   "aetherstream.openScreenWindow": "Open in a window",
-  "aetherstream.inGameScreen": "Toggle In-game Screen",
+  "aetherstream.inGameScreen": "Show In-game Screen",
   "aetherstream.castingScreenPositionHeader": "Screen Position",
   "aetherstream.castingScreenPositionHint": "Start playback to move and resize the screen.",
   "aetherstream.castingPresetNameHint": "Preset name...",

--- a/src/Aetherphone/Localization/en.json
+++ b/src/Aetherphone/Localization/en.json
@@ -3908,6 +3908,7 @@
   "aetherstream.castingStateNotReady": "Not ready",
   "aetherstream.castingStateReady": "Ready",
   "aetherstream.openScreenWindow": "Open in a window",
+  "aetherstream.inGameScreen": "Toggle In-game Screen",
   "aetherstream.castingScreenPositionHeader": "Screen Position",
   "aetherstream.castingScreenPositionHint": "Start playback to move and resize the screen.",
   "aetherstream.castingPresetNameHint": "Preset name...",

--- a/src/Aetherphone/Localization/es.json
+++ b/src/Aetherphone/Localization/es.json
@@ -3908,6 +3908,7 @@
   "aetherstream.castingStateNotReady": "No listo",
   "aetherstream.castingStateReady": "Listo",
   "aetherstream.openScreenWindow": "Abrir en una ventana",
+  "aetherstream.inGameScreen": "Alternar pantalla en el juego",
   "aetherstream.castingScreenPositionHeader": "Posición de la pantalla",
   "aetherstream.castingScreenPositionHint": "Inicia la reproducción para mover y cambiar el tamaño de la pantalla.",
   "aetherstream.castingPresetNameHint": "Nombre del ajuste preestablecido…",

--- a/src/Aetherphone/Localization/es.json
+++ b/src/Aetherphone/Localization/es.json
@@ -3908,7 +3908,7 @@
   "aetherstream.castingStateNotReady": "No listo",
   "aetherstream.castingStateReady": "Listo",
   "aetherstream.openScreenWindow": "Abrir en una ventana",
-  "aetherstream.inGameScreen": "Alternar pantalla en el juego",
+  "aetherstream.inGameScreen": "Mostrar pantalla en juego",
   "aetherstream.castingScreenPositionHeader": "Posición de la pantalla",
   "aetherstream.castingScreenPositionHint": "Inicia la reproducción para mover y cambiar el tamaño de la pantalla.",
   "aetherstream.castingPresetNameHint": "Nombre del ajuste preestablecido…",

--- a/src/Aetherphone/Localization/fr.json
+++ b/src/Aetherphone/Localization/fr.json
@@ -3908,7 +3908,7 @@
   "aetherstream.castingStateNotReady": "Pas prêt",
   "aetherstream.castingStateReady": "Prêt",
   "aetherstream.openScreenWindow": "Ouvrir dans une fenêtre",
-  "aetherstream.inGameScreen": "Basculer l'écran en jeu",
+  "aetherstream.inGameScreen": "Afficher l'écran en jeu",
   "aetherstream.castingScreenPositionHeader": "Position de l'écran",
   "aetherstream.castingScreenPositionHint": "Lancez la lecture pour déplacer et redimensionner l'écran.",
   "aetherstream.castingPresetNameHint": "Nom du préréglage…",

--- a/src/Aetherphone/Localization/fr.json
+++ b/src/Aetherphone/Localization/fr.json
@@ -3908,6 +3908,7 @@
   "aetherstream.castingStateNotReady": "Pas prêt",
   "aetherstream.castingStateReady": "Prêt",
   "aetherstream.openScreenWindow": "Ouvrir dans une fenêtre",
+  "aetherstream.inGameScreen": "Basculer l'écran en jeu",
   "aetherstream.castingScreenPositionHeader": "Position de l'écran",
   "aetherstream.castingScreenPositionHint": "Lancez la lecture pour déplacer et redimensionner l'écran.",
   "aetherstream.castingPresetNameHint": "Nom du préréglage…",

--- a/src/Aetherphone/Localization/ja.json
+++ b/src/Aetherphone/Localization/ja.json
@@ -3908,7 +3908,7 @@
   "aetherstream.castingStateNotReady": "準備できていません",
   "aetherstream.castingStateReady": "準備完了",
   "aetherstream.openScreenWindow": "ウィンドウで開く",
-  "aetherstream.inGameScreen": "ゲーム内スクリーンの切り替え",
+  "aetherstream.inGameScreen": "ゲーム内画面を表示",
   "aetherstream.castingScreenPositionHeader": "スクリーンの位置",
   "aetherstream.castingScreenPositionHint": "再生を開始すると、スクリーンの移動とサイズ変更ができます。",
   "aetherstream.castingPresetNameHint": "プリセット名…",

--- a/src/Aetherphone/Localization/ja.json
+++ b/src/Aetherphone/Localization/ja.json
@@ -3908,6 +3908,7 @@
   "aetherstream.castingStateNotReady": "準備できていません",
   "aetherstream.castingStateReady": "準備完了",
   "aetherstream.openScreenWindow": "ウィンドウで開く",
+  "aetherstream.inGameScreen": "ゲーム内スクリーンの切り替え",
   "aetherstream.castingScreenPositionHeader": "スクリーンの位置",
   "aetherstream.castingScreenPositionHint": "再生を開始すると、スクリーンの移動とサイズ変更ができます。",
   "aetherstream.castingPresetNameHint": "プリセット名…",

--- a/src/Aetherphone/Localization/pt.json
+++ b/src/Aetherphone/Localization/pt.json
@@ -3908,7 +3908,7 @@
   "aetherstream.castingStateNotReady": "Não pronto",
   "aetherstream.castingStateReady": "Pronto",
   "aetherstream.openScreenWindow": "Abrir em uma janela",
-  "aetherstream.inGameScreen": "Alternar tela no jogo",
+  "aetherstream.inGameScreen": "Mostrar tela no jogo",
   "aetherstream.castingScreenPositionHeader": "Posição da tela",
   "aetherstream.castingScreenPositionHint": "Inicie a reprodução para mover e redimensionar a tela.",
   "aetherstream.castingPresetNameHint": "Nome do predefinido…",

--- a/src/Aetherphone/Localization/pt.json
+++ b/src/Aetherphone/Localization/pt.json
@@ -3908,6 +3908,7 @@
   "aetherstream.castingStateNotReady": "Não pronto",
   "aetherstream.castingStateReady": "Pronto",
   "aetherstream.openScreenWindow": "Abrir em uma janela",
+  "aetherstream.inGameScreen": "Alternar tela no jogo",
   "aetherstream.castingScreenPositionHeader": "Posição da tela",
   "aetherstream.castingScreenPositionHint": "Inicie a reprodução para mover e redimensionar a tela.",
   "aetherstream.castingPresetNameHint": "Nome do predefinido…",

--- a/src/Aetherphone/Localization/ru.json
+++ b/src/Aetherphone/Localization/ru.json
@@ -3908,6 +3908,7 @@
   "aetherstream.castingStateNotReady": "Не готово",
   "aetherstream.castingStateReady": "Готово",
   "aetherstream.openScreenWindow": "Открыть в окне",
+  "aetherstream.inGameScreen": "Переключить экран в игре",
   "aetherstream.castingScreenPositionHeader": "Положение экрана",
   "aetherstream.castingScreenPositionHint": "Начните воспроизведение, чтобы перемещать и изменять размер экрана.",
   "aetherstream.castingPresetNameHint": "Название пресета…",

--- a/src/Aetherphone/Localization/ru.json
+++ b/src/Aetherphone/Localization/ru.json
@@ -3908,7 +3908,7 @@
   "aetherstream.castingStateNotReady": "Не готово",
   "aetherstream.castingStateReady": "Готово",
   "aetherstream.openScreenWindow": "Открыть в окне",
-  "aetherstream.inGameScreen": "Переключить экран в игре",
+  "aetherstream.inGameScreen": "Показать экран в игре",
   "aetherstream.castingScreenPositionHeader": "Положение экрана",
   "aetherstream.castingScreenPositionHint": "Начните воспроизведение, чтобы перемещать и изменять размер экрана.",
   "aetherstream.castingPresetNameHint": "Название пресета…",

--- a/src/Aetherphone/Localization/tr.json
+++ b/src/Aetherphone/Localization/tr.json
@@ -3908,7 +3908,7 @@
   "aetherstream.castingStateNotReady": "Hazır değil",
   "aetherstream.castingStateReady": "Hazır",
   "aetherstream.openScreenWindow": "Bir pencerede aç",
-  "aetherstream.inGameScreen": "Oyun içi ekranı aç/kapat",
+  "aetherstream.inGameScreen": "Oyun içi ekranı göster",
   "aetherstream.castingScreenPositionHeader": "Ekran Konumu",
   "aetherstream.castingScreenPositionHint": "Ekranı taşımak ve yeniden boyutlandırmak için oynatmayı başlat.",
   "aetherstream.castingPresetNameHint": "Ön ayar adı…",

--- a/src/Aetherphone/Localization/tr.json
+++ b/src/Aetherphone/Localization/tr.json
@@ -3908,6 +3908,7 @@
   "aetherstream.castingStateNotReady": "Hazır değil",
   "aetherstream.castingStateReady": "Hazır",
   "aetherstream.openScreenWindow": "Bir pencerede aç",
+  "aetherstream.inGameScreen": "Oyun içi ekranı aç/kapat",
   "aetherstream.castingScreenPositionHeader": "Ekran Konumu",
   "aetherstream.castingScreenPositionHint": "Ekranı taşımak ve yeniden boyutlandırmak için oynatmayı başlat.",
   "aetherstream.castingPresetNameHint": "Ön ayar adı…",

--- a/src/Aetherphone/Localization/zh.json
+++ b/src/Aetherphone/Localization/zh.json
@@ -3908,6 +3908,7 @@
   "aetherstream.castingStateNotReady": "尚未就绪",
   "aetherstream.castingStateReady": "已就绪",
   "aetherstream.openScreenWindow": "在窗口中打开",
+  "aetherstream.inGameScreen": "切换游戏内屏幕",
   "aetherstream.castingScreenPositionHeader": "屏幕位置",
   "aetherstream.castingScreenPositionHint": "开始播放后即可移动和调整屏幕大小。",
   "aetherstream.castingPresetNameHint": "预设名称…",

--- a/src/Aetherphone/Localization/zh.json
+++ b/src/Aetherphone/Localization/zh.json
@@ -3908,7 +3908,7 @@
   "aetherstream.castingStateNotReady": "尚未就绪",
   "aetherstream.castingStateReady": "已就绪",
   "aetherstream.openScreenWindow": "在窗口中打开",
-  "aetherstream.inGameScreen": "切换游戏内屏幕",
+  "aetherstream.inGameScreen": "显示游戏内屏幕",
   "aetherstream.castingScreenPositionHeader": "屏幕位置",
   "aetherstream.castingScreenPositionHint": "开始播放后即可移动和调整屏幕大小。",
   "aetherstream.castingPresetNameHint": "预设名称…",


### PR DESCRIPTION
## What

Created toggle for in-game screen for mogcast.

## Why

We had a few requests to be able to disable it.

Closes #

## How I tested it

1. Opened mogcast.
2. Opened a video.
3. Clicked "Screen".
4. Adjusted the toggle on and off to ensure not just that the in-game screen turned on/off but that it also re-centers in front of the player when re-enabled.

## Screenshots

Ask in discord.

## Backend coordination

N/A

## Checklist

Gates (CI enforces all of these):

- [x] `dotnet build Aetherphone.sln -c Release` is clean
- [x] `dotnet test` passes (this is where localization lockstep and accent contrast are enforced)
- [x] No em dashes anywhere: code, strings, JSON catalogs, docs
- [x] No `async void`, no new LINQ outside the allowlisted files, no raw `ImGuiHelpers.GlobalScale` (use `UiScale.Current`), no hand-formatted clock text (use `TimeText.Clock`)

Strings:

- [x] Every new user-visible string is a LocString in `Core/Localization/L.cs` plus the same key in all nine JSONs under `src/Aetherphone/Localization/`, in this same PR
- [x] Any changed English text is updated in both `L.cs` and `en.json` so they do not drift

Quality:

- [x] Verified in-game on the screens this touches, on the build variant that matters (`/phone` or `/phonedev`)
- [x] Draw-path code allocates nothing per frame and uses the shared `Windows/Components/` widgets, `TextStyles`, and `Metrics` tokens
- [x] README updated if this changes what a user sees or types; the relevant page under `docs/` still tells the truth
- [x] Commit messages and this PR body carry no AI attribution trailers
