### PR TITLE
fix(media):tightened corruption check and added higher quality jpeg fallback.

### DIFF
--- a/src/Aetherphone.Tests/ImageProcessorEncodeVerificationTests.cs
+++ b/src/Aetherphone.Tests/ImageProcessorEncodeVerificationTests.cs
@@ -69,7 +69,7 @@ public sealed class ImageProcessorEncodeVerificationTests
     {
         var source = BuildFlat(10, 10, 14);
         var decoded = (byte[])source.Clone();
-        for (var dashIndex = 0; dashIndex < 4; dashIndex++)
+        for (var dashIndex = 0; dashIndex < 2; dashIndex++)
         {
             var pixelIndex = ((16 * Width) + 20 + dashIndex) * 4;
             decoded[pixelIndex] = (byte)Math.Min(255, decoded[pixelIndex] + 128);

--- a/src/Aetherphone.Tests/ImageProcessorEncodeVerificationTests.cs
+++ b/src/Aetherphone.Tests/ImageProcessorEncodeVerificationTests.cs
@@ -65,11 +65,11 @@ public sealed class ImageProcessorEncodeVerificationTests
     }
 
     [Fact]
-    public void IgnoresFewerThanThreeCorruptSamples()
+    public void FlagsASingleCorruptCellInDarkRegion()
     {
         var source = BuildFlat(10, 10, 14);
         var decoded = (byte[])source.Clone();
-        for (var dashIndex = 0; dashIndex < 2; dashIndex++)
+        for (var dashIndex = 0; dashIndex < 4; dashIndex++)
         {
             var pixelIndex = ((16 * Width) + 20 + dashIndex) * 4;
             decoded[pixelIndex] = (byte)Math.Min(255, decoded[pixelIndex] + 128);
@@ -77,7 +77,7 @@ public sealed class ImageProcessorEncodeVerificationTests
             decoded[pixelIndex + 2] = (byte)Math.Min(255, decoded[pixelIndex + 2] + 128);
         }
 
-        Assert.False(ImageProcessor.HasEncodeCorruption(source, decoded, Width, Height));
+        Assert.True(ImageProcessor.HasEncodeCorruption(source, decoded, Width, Height));
     }
 
     [Fact]

--- a/src/Aetherphone/Core/Media/ImageProcessor.cs
+++ b/src/Aetherphone/Core/Media/ImageProcessor.cs
@@ -28,10 +28,11 @@ internal readonly struct BakedImage
 internal static class ImageProcessor
 {
     private const int JpegQuality = 88;
+    private const int JpegQualityFallback = 91;
     private const int EncodeAttemptLimit = 3;
     private const float LumaDeltaLimit = 80f;
     private const float ChromaDeltaLimit = 64f;
-    private const int CorruptSampleLimit = 3;
+    private const int CorruptSampleLimit = 1;
 
     public const long MaxDecodePixels = 4096L * 4096L;
     public const long MaxLocalDecodePixels = 8192L * 8192L;
@@ -159,8 +160,11 @@ internal static class ImageProcessor
                 AepLog.Warning($"[Media] jpeg encode attempt {attempt} of {EncodeAttemptLimit} " +
                     "produced corrupt samples, re-encoding");
             }
+            AepLog.Info("[Media] all encode attempts produced corruption, falling back to quality 91.");
+            using var fallbackStream = new MemoryStream();
+            image.SaveAsJpeg(fallbackStream, new JpegEncoder { Quality = JpegQualityFallback });
 
-            return encoded;
+            return fallbackStream.ToArray();
         }
         finally
         {


### PR DESCRIPTION
## What

Adjusted jpeg encoder corruption check by making it stricter, and on the 3rd failure falling back to a higher quality encoding.

## Why

A subset of users were seeing jpeg corruption on photo uploads.

Closes #

## How I tested it

Had kiro assist with writing a test that simulated the jpeg corruption.

## Screenshots

If needed ask on discord.

## Backend coordination

I added a failback quality var that bumps the quality to 91 from 88 on jpeg encoding. This has a side effect of increasing the file size of the pictures by roughly 17.8% as tested across 64 different personal screenshots. However, the change does not apply to every photo that is uploaded, only photos that fail our corruption loop 3 times, a majority of photos will stay at 88 quality.

The data is below, you'd have to make a call on if we want to tolerate jpeg corruption (and let our end users that it's gonna happen sometimes.) or if we want to tighten our checks and have a higher quality fallback to avoid the issue.

| # | Description | Q88 (KB) | Q91 (KB) | Increase |
|---|---|---:|---:|---:|
| 1 | FFXIV screenshot (reshade A) | 318 | 373 | 17.4% |
| 2 | FFXIV screenshot (indoor, dark) | 162 | 189 | 16.3% |
| 3 | FFXIV screenshot (gameplay A) | 467 | 547 | 17.1% |
| 4 | FFXIV screenshot (gameplay B) | 380 | 451 | 18.5% |
| 5 | FFXIV screenshot (reshade B) | 253 | 298 | 18.0% |
| 6 | FFXIV screenshot (outdoor, no shader) | 236 | 276 | 16.8% |
| 7 | FFXIV screenshot (outdoor, reshade C) | 215 | 256 | 18.9% |
| 8 | FFXIV screenshot (outdoor, reshade D) | 212 | 253 | 19.1% |
| 9 | FFXIV screenshot (outdoor, no shader B) | 160 | 185 | 15.5% |
| 10 | FFXIV screenshot (indoor, lit A) | 357 | 417 | 16.6% |
| 11 | FFXIV screenshot (indoor, lit B) | 337 | 398 | 18.1% |
| 12 | FFXIV screenshot (indoor, dark B) | 204 | 241 | 18.3% |
| 13 | FFXIV screenshot (outdoor, no shader C) | 514 | 613 | 19.3% |
| 14 | FFXIV screenshot (night, outdoor) | 243 | 284 | 17.0% |
| 15 | FFXIV screenshot (indoor, studio A) | 447 | 531 | 18.9% |
| 16 | FFXIV screenshot (indoor, studio B) | 355 | 420 | 18.5% |
| 17 | FFXIV screenshot (indoor, studio C) | 545 | 642 | 17.8% |
| 18 | FFXIV screenshot (indoor, studio D) | 281 | 333 | 18.3% |
| 19 | FFXIV screenshot (indoor, studio E) | 375 | 441 | 17.5% |
| 20 | FFXIV screenshot (indoor, studio F) | 565 | 674 | 19.3% |
| 21 | FFXIV screenshot (indoor, studio G) | 661 | 783 | 18.4% |
| 22 | FFXIV screenshot (indoor, studio H) | 677 | 798 | 17.8% |
| 23 | FFXIV screenshot (indoor, studio I) | 624 | 739 | 18.4% |
| 24 | FFXIV screenshot (indoor, studio J) | 833 | 974 | 16.9% |
| 25 | FFXIV screenshot (indoor, studio K) | 477 | 559 | 17.1% |
| 26 | FFXIV screenshot (indoor, studio L) | 621 | 731 | 17.7% |
| 27 | FFXIV screenshot (indoor, studio M) | 530 | 623 | 17.6% |
| 28 | FFXIV screenshot (indoor, studio N) | 317 | 374 | 17.7% |
| 29 | FFXIV screenshot (indoor, studio O) | 380 | 449 | 18.1% |
| 30 | FFXIV screenshot (indoor, studio P) | 504 | 597 | 18.3% |
| 31 | FFXIV screenshot (indoor, studio Q) | 514 | 608 | 18.2% |
| 32 | FFXIV screenshot (indoor, studio R) | 587 | 690 | 17.6% |
| 33 | FFXIV screenshot (indoor, studio S) | 503 | 594 | 18.1% |
| 34 | FFXIV screenshot (indoor, studio T) | 455 | 545 | 19.7% |
| 35 | FFXIV screenshot (indoor, studio U) | 680 | 805 | 18.3% |
| 36 | FFXIV screenshot (indoor, detailed A) | 1,071 | 1,267 | 18.2% |
| 37 | FFXIV screenshot (indoor, detailed B) | 1,049 | 1,240 | 18.2% |
| 38 | FFXIV screenshot (indoor, studio V) | 410 | 478 | 16.7% |
| 39 | FFXIV screenshot (indoor, studio W) | 378 | 448 | 18.5% |
| 40 | FFXIV screenshot (indoor, studio X) | 317 | 375 | 18.1% |
| 41 | FFXIV screenshot (indoor, studio Y) | 297 | 354 | 19.0% |
| 42 | FFXIV screenshot (indoor, studio Z) | 314 | 370 | 18.1% |
| 43 | FFXIV screenshot (indoor, dark C) | 354 | 423 | 19.4% |
| 44 | FFXIV screenshot (indoor, studio AA) | 432 | 507 | 17.3% |
| 45 | FFXIV screenshot (indoor, studio AB) | 349 | 413 | 18.3% |
| 46 | FFXIV screenshot (indoor, dark D) | 280 | 330 | 17.9% |
| 47 | FFXIV screenshot (indoor, detailed C) | 955 | 1,111 | 16.4% |
| 48 | FFXIV screenshot (indoor, dark E) | 223 | 263 | 17.9% |
| 49 | FFXIV screenshot (indoor, dark F) | 214 | 254 | 18.3% |
| 50 | FFXIV screenshot (indoor, detailed D) | 786 | 917 | 16.6% |
| 51 | FFXIV screenshot (indoor, detailed E) | 710 | 829 | 16.7% |
| 52 | FFXIV screenshot (indoor, studio AC) | 626 | 736 | 17.5% |
| 53 | FFXIV screenshot (indoor, studio AD) | 611 | 721 | 17.9% |
| 54 | FFXIV screenshot (indoor, studio AE) | 468 | 552 | 17.8% |
| 55 | FFXIV screenshot (indoor, studio AF) | 447 | 520 | 16.3% |
| 56 | Flat color graphic | 14 | 14 | 2.6% |
| 57 | FFXIV screenshot (outdoor, reshade E) | 486 | 578 | 18.9% |
| 58 | FFXIV screenshot (outdoor, reshade F) | 450 | 530 | 17.9% |
| 59 | FFXIV screenshot (outdoor, reshade G) | 380 | 448 | 17.9% |
| 60 | FFXIV screenshot (outdoor, reshade H) | 361 | 421 | 16.7% |
| 61 | FFXIV screenshot (outdoor, reshade I) | 641 | 760 | 18.6% |
| 62 | FFXIV screenshot (outdoor, reshade J) | 361 | 432 | 19.7% |
| 63 | FFXIV screenshot (indoor, detailed F) | 1,280 | 1,494 | 16.6% |
| 64 | FFXIV screenshot (indoor, detailed G) | 1,271 | 1,485 | 16.8% |
| | **Total** | **30,557** | **35,989** | **17.8%** |
 

## Checklist

Gates (CI enforces all of these):

- [x] `dotnet build Aetherphone.sln -c Release` is clean
- [x] `dotnet test` passes (this is where localization lockstep and accent contrast are enforced)
- [x] No em dashes anywhere: code, strings, JSON catalogs, docs
- [x] No `async void`, no new LINQ outside the allowlisted files, no raw `ImGuiHelpers.GlobalScale` (use `UiScale.Current`), no hand-formatted clock text (use `TimeText.Clock`)

Strings:

- [x] Every new user-visible string is a LocString in `Core/Localization/L.cs` plus the same key in all nine JSONs under `src/Aetherphone/Localization/`, in this same PR
- [x] Any changed English text is updated in both `L.cs` and `en.json` so they do not drift

Quality:

- [x] Verified in-game on the screens this touches, on the build variant that matters (`/phone` or `/phonedev`)
- [x] Draw-path code allocates nothing per frame and uses the shared `Windows/Components/` widgets, `TextStyles`, and `Metrics` tokens
- [x] README updated if this changes what a user sees or types; the relevant page under `docs/` still tells the truth
- [x] Commit messages and this PR body carry no AI attribution trailers
