### PR TITLE
fix(ui): stop InputShield from hijacking an in-flight drag scroll

### DIFF
--- a/src/Aetherphone/Windows/Components/DragScrollHost.cs
+++ b/src/Aetherphone/Windows/Components/DragScrollHost.cs
@@ -109,6 +109,16 @@ internal static class DragScrollHost
             return new Surface(region, 0f, false);
         }
 
+        if (InputShield.Active)
+        {
+            if (region.Pressed)
+            {
+                region.CancelGesture();
+            }
+
+            return new Surface(region, scroller.PullDistance, false);
+        }
+
         var io = ImGui.GetIO();
         var deltaSeconds = io.DeltaTime;
         var pointerY = io.MousePos.Y;


### PR DESCRIPTION

<!--
Title: conventional commit style with a scope and a lowercase summary, e.g.
  feat(timers): add a retainer venture alarm
  fix(net): cap the rate-limit pause at 30 seconds
One concern per PR. If the title needs an "and", split the PR.

Translation-only PR (editing one JSON under src/Aetherphone/Localization/)?
Fill in "What" and open it; CI runs the lockstep check for you and the rest
of this template does not apply. See docs/translating.md.
-->

## What
Pushing a new router view shields the outgoing view for the transition by moving io.MousePos off-screen. DragScrollHost read that sentinel position straight into an already-pressed KineticScroller, which read as a huge swipe toward the sentinel and clamped the scroll to one end.

Tapping a button that both lives inside a scrollable AppSurface and pushes a new view in the same frame (Velvet's Discover/Feed filter button, for one) latches a press right before the shield engages, so the very next transitioning frame snaps the scroll to the bottom.

Cancel any in-flight gesture for a region while the shield is active instead of feeding it the off-screen pointer position.
<!-- One or two sentences: what changes, and where (which app, Core service, or doc). -->

## Why

<!-- The motivating problem or the user-visible behavior this fixes. -->

Closes #

## How I tested it
 - Open Velvet's feed
 - Scroll down to load entries
 - Scroll up and click the filter button
 - Return to the Feed page
 - Confirm that thescroll does not snap to the bottom
<!--
Exact steps a reviewer can repeat.
- Release build: open the phone with /phone and exercise the screen you touched.
- Debug build: loads side by side as AetherphoneDev, opens with /phonedev, and
  talks to the development Aethernet instance. Use it for anything backend-facing.
- Messaging: send yourself a /tell and watch it land. Notifications: /phone test.
- State: if you touched persistence, say what you did to verify old configs survive.
-->

## Checklist

Gates (CI enforces all of these):

- [ ] `dotnet build Aetherphone.sln -c Release` is clean
- [ ] `dotnet test` passes (this is where localization lockstep and accent contrast are enforced)
- [ ] No em dashes anywhere: code, strings, JSON catalogs, docs
- [ ] No `async void`, no new LINQ outside the allowlisted files, no raw `ImGuiHelpers.GlobalScale` (use `UiScale.Current`), no hand-formatted clock text (use `TimeText.Clock`)

Strings:

- [ ] Every new user-visible string is a LocString in `Core/Localization/L.cs` plus the same key in all nine JSONs under `src/Aetherphone/Localization/`, in this same PR
- [ ] Any changed English text is updated in both `L.cs` and `en.json` so they do not drift

Quality:

- [ ] Verified in-game on the screens this touches, on the build variant that matters (`/phone` or `/phonedev`)
- [ ] Draw-path code allocates nothing per frame and uses the shared `Windows/Components/` widgets, `TextStyles`, and `Metrics` tokens
- [ ] README updated if this changes what a user sees or types; the relevant page under `docs/` still tells the truth
- [ ] Commit messages and this PR body carry no AI attribution trailers
