### PR TITLE
fix(icontile): use the draw-list CenterIcon overload, not the cursor one

### DIFF
--- a/src/Aetherphone/Windows/Components/Chrome/IconTile.cs
+++ b/src/Aetherphone/Windows/Components/Chrome/IconTile.cs
@@ -12,7 +12,7 @@ internal static class IconTile
         var half = size * 0.5f;
         Squircle.Fill(drawList, center - new Vector2(half, half), center + new Vector2(half, half),
             size * Metrics.Radius.TileFactor, ImGui.GetColorU32(tint));
-        ProgressRing.CenterIcon(center, icon, AccentRing.Ink, size * 0.50f);
+        ProgressRing.CenterIcon(drawList, center, icon, AccentRing.Ink, size * 0.50f);
     }
 
     public static void DrawApp(ImDrawListPtr drawList, string appId, Vector2 center, float size, Vector4 surface)


### PR DESCRIPTION
Split out of #(venue-manager-app), per review feedback there: the fix touches every screen with an IconTile, not just Venue Sync, so it gets its own PR and its own visual pass.

## What

`IconTile.Draw` called `ProgressRing.CenterIcon`'s cursor-based overload, which calls `SetCursorScreenPos` plus `ImGui.TextUnformatted` internally and moves ImGui's real layout cursor. `IconTile.Draw` is used across screens built entirely on manual Rect-based row layout (Activity, Collections, Dailies, Fishing, Health, Muster, Timers, Venues, Yellow Pages, CoinStreakCard, Venue Sync), so every tile drawn left the cursor corrupted for whatever ImGui call came next.

Switched to the sibling draw-list overload. Same centering math (measured glyph size, `GlyphPen` offset), rendered through `dl.AddText` instead of `SetCursorScreenPos` plus a text widget, so it draws identically without the cursor side effect.

## Test plan

- [x] `dotnet build Aetherphone.sln -c Release`: 0 warnings, 0 errors
- [x] `dotnet test Aetherphone.sln -c Release`: 1557/1557 passing
- [ ] Visual pass across the 11 affected screens (not done here, that's the reason for the separate PR)