### PR TITLE
fix(ui): keep the compose FAB clear of the native scrollbar column

### DIFF
--- a/src/Aetherphone.Tests/ComposeFabTests.cs
+++ b/src/Aetherphone.Tests/ComposeFabTests.cs
@@ -1,0 +1,38 @@
+using System.Numerics;
+using Aetherphone.Core;
+using Aetherphone.Windows.Components;
+using Xunit;
+
+namespace Aetherphone.Tests;
+
+public sealed class ComposeFabTests
+{
+    private static readonly Rect ListArea = new(Vector2.Zero, new Vector2(360f, 640f));
+
+    [Fact]
+    public void LockedPhoneBoxIsFlushToTheCorner()
+    {
+        var box = ComposeFab.ComputeBoxRect(ListArea, 26f, 1f, 0f, scrollbarInset: 0f);
+        Assert.Equal(ListArea.Max.X, box.Max.X);
+        Assert.Equal(ListArea.Max.Y, box.Max.Y);
+    }
+
+    [Fact]
+    public void UnlockedPhoneBoxClearsTheNativeScrollbarColumn()
+    {
+        const float scrollbarSize = 14f;
+        var box = ComposeFab.ComputeBoxRect(ListArea, 26f, 1f, 0f, scrollbarInset: scrollbarSize);
+        Assert.Equal(ListArea.Max.X - scrollbarSize, box.Max.X);
+        Assert.True(box.Max.X <= ListArea.Max.X - scrollbarSize,
+            "The FAB must not extend into the column the native scrollbar occupies when it is showing.");
+    }
+
+    [Fact]
+    public void ScrollbarInsetShiftsPositionWithoutChangingSize()
+    {
+        var locked = ComposeFab.ComputeBoxRect(ListArea, 26f, 1f, 0f, scrollbarInset: 0f);
+        var unlocked = ComposeFab.ComputeBoxRect(ListArea, 26f, 1f, 0f, scrollbarInset: 14f);
+        Assert.Equal(locked.Width, unlocked.Width);
+        Assert.Equal(locked.Height, unlocked.Height);
+    }
+}

--- a/src/Aetherphone/Windows/Components/Fields/ComposeFab.cs
+++ b/src/Aetherphone/Windows/Components/Fields/ComposeFab.cs
@@ -29,14 +29,14 @@ internal static class ComposeFab
     {
         var scale = UiScale.Current;
         var radius = radiusUnscaled * scale;
-        var margin = 18f * scale;
         var glowPad = gradientBottom is null ? 0f : GlowReach * scale;
-        var boxSize = radius * 2f + margin + glowPad;
-        var boxMin = new Vector2(area.Max.X - boxSize, area.Max.Y - boxSize);
-        ImGui.SetCursorScreenPos(boxMin);
+        var scrollbarInset = DragScrollHost.Enabled ? 0f : ImGui.GetStyle().ScrollbarSize;
+        var box = ComputeBoxRect(area, radiusUnscaled, scale, glowPad, scrollbarInset);
+        var boxSize = box.Width;
+        ImGui.SetCursorScreenPos(box.Min);
         using var overlay = ImRaii.Child(childId, new Vector2(boxSize, boxSize), false,
             ImGuiWindowFlags.NoBackground | ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse);
-        var center = new Vector2(area.Max.X - radius - margin, area.Max.Y - radius - margin);
+        var center = box.Center;
         var fabRect = new Rect(center - new Vector2(radius, radius), center + new Vector2(radius, radius));
         if (anchorKey is not null)
         {
@@ -84,6 +84,16 @@ internal static class ComposeFab
         }
 
         return UiInteract.Click(fabRect.Min, fabRect.Max, hovered);
+    }
+
+    internal static Rect ComputeBoxRect(Rect area, float radiusUnscaled, float scale, float glowPad,
+        float scrollbarInset)
+    {
+        var radius = radiusUnscaled * scale;
+        var margin = 18f * scale;
+        var boxSize = radius * 2f + margin + glowPad;
+        var boxMin = new Vector2(area.Max.X - boxSize - scrollbarInset, area.Max.Y - boxSize);
+        return new Rect(boxMin, boxMin + new Vector2(boxSize, boxSize));
     }
 
     private static float HoverEase(string id, bool hovered)


### PR DESCRIPTION
## Summary
- With the phone unlocked, `DragScrollHost` falls back to ImGui's native scrollbar instead of drag-scrolling, but `ComposeFab` still anchored its hit box flush to the same right edge the scrollbar renders in.
- The FAB's overlay child window is created after the list's, so it won hover and click resolution in that overlapping corner, blocking scrollbar drags there.
- `ComposeFab` now reserves the native scrollbar width when `DragScrollHost.Enabled` is false, so the FAB hit box no longer overlaps the scrollbar column. This fixes every app that shares the component: Aethergram, Chirper, Velvet, Photos, Muster, and Message.
- The FAB's positioning math was extracted into a pure `ComposeFab.ComputeBoxRect` helper so it can be covered by a test without a live ImGui context.

## Test plan
- [x] `dotnet build Aetherphone.sln -c Release` succeeds with 0 warnings/errors
- [x] `dotnet test src/Aetherphone.Tests` passes (1930/1930, including 3 new `ComposeFabTests`)
- [x] Verified the new test is red-capable: temporarily simulated the pre-fix call site (scrollbar inset always 0) and confirmed the assertion fails, then removed the scratch check