### PR TITLE
fix(windows): fixed switch menu staying open on focus loss.

### DIFF
--- a/src/Aetherphone/Windows/LinkpearlPopoutWindow.cs
+++ b/src/Aetherphone/Windows/LinkpearlPopoutWindow.cs
@@ -521,6 +521,10 @@ internal sealed class LinkpearlPopoutWindow : Window
         {
             Touch();
         }
+        else
+        {
+            switchMenu.Close();
+        }
 
         UpdateAttention(row, !collapsed && lively);
         chatMenu.Gate();


### PR DESCRIPTION
## What

Fixes switch menu on popout chats not collapsing on focus loss.

## Why

The switch menu staying open would cause clickthrough issues.

Closes #

## How I tested it

1. Opened popout chat ingame.
2. Opened switch menu.
3. Clicked anywhere on the screen outside of a imgui window.
4. Verified switch menu collapses on loss of focus.

## Screenshots

N/A

## Backend coordination

N/A

## Checklist

Gates (CI enforces all of these):

- [x] `dotnet build Aetherphone.sln -c Release` is clean
- [ ] `dotnet test` passes (this is where localization lockstep and accent contrast are enforced)
- [ ] No em dashes anywhere: code, strings, JSON catalogs, docs
- [ ] No `async void`, no new LINQ outside the allowlisted files, no raw `ImGuiHelpers.GlobalScale` (use `UiScale.Current`), no hand-formatted clock text (use `TimeText.Clock`)

Strings:

- [ ] Every new user-visible string is a LocString in `Core/Localization/L.cs` plus the same key in all nine JSONs under `src/Aetherphone/Localization/`, in this same PR
- [ ] Any changed English text is updated in both `L.cs` and `en.json` so they do not drift

Quality:

- [ ] Verified in-game on the screens this touches, on the build variant that matters (`/phone` or `/phonedev`)
- [ ] Draw-path code allocates nothing per frame and uses the shared `Windows/Components/` widgets, `TextStyles`, and `Metrics` tokens
- [ ] README updated if this changes what a user sees or types; the relevant page under `docs/` still tells the truth
- [ ] Commit messages and this PR body carry no AI attribution trailers
