### PR TITLE
fix(home): stop widget-removal from soft-locking the home screen

### DIFF
--- a/src/Aetherphone/Core/Shell/Home/WidgetSizeMenu.cs
+++ b/src/Aetherphone/Core/Shell/Home/WidgetSizeMenu.cs
@@ -44,6 +44,7 @@ internal sealed class WidgetSizeMenu
     {
         tile = null;
         closing = false;
+        pop.SnapTo(0f);
     }
 
     public void Draw(Rect content, Rect anchor, PhoneTheme theme, float delta, float scale)

--- a/src/Aetherphone/Core/Shell/Home/WidgetSizeMenu.cs
+++ b/src/Aetherphone/Core/Shell/Home/WidgetSizeMenu.cs
@@ -40,6 +40,12 @@ internal sealed class WidgetSizeMenu
         closing = true;
     }
 
+    public void CloseImmediate()
+    {
+        tile = null;
+        closing = false;
+    }
+
     public void Draw(Rect content, Rect anchor, PhoneTheme theme, float delta, float scale)
     {
         if (tile is null)

--- a/src/Aetherphone/Core/Shell/HomeScreen.cs
+++ b/src/Aetherphone/Core/Shell/HomeScreen.cs
@@ -192,7 +192,7 @@ internal sealed class HomeScreen
         var anchor = interaction.CommittedRect(metrics, tile);
         if (anchor is not { } rect)
         {
-            sizeMenu.Close();
+            sizeMenu.CloseImmediate();
             return;
         }
 

--- a/src/Aetherphone/Core/Shell/HomeScreen.cs
+++ b/src/Aetherphone/Core/Shell/HomeScreen.cs
@@ -99,6 +99,7 @@ internal sealed class HomeScreen
     {
         gallery.CloseImmediate();
         spotlight.CloseImmediate();
+        sizeMenu.CloseImmediate();
         interaction.ResetForReveal();
         var page = PageContaining(appId);
         if (page >= 0)


### PR DESCRIPTION
## What

Fixes a home screen soft-lock when removing a widget via the size menu's "Remove" row. Added `WidgetSizeMenu.CloseImmediate()`, called from `HomeScreen.DrawSizeMenu` when the menu's tile can no longer be found.

## Why

`WidgetSizeMenu.Close()` only sets `closing = true`; the shrink animation in `Draw` is what actually clears `tile` back to null. Remove detaches the tile from the layout first, so on the next frame the menu's anchor lookup fails, `DrawSizeMenu` returns early, and `Draw` (and its cleanup) never runs again. `tile` never clears, so home input stays blocked until reload. Resize doesn't hit this because the tile stays in the layout.

Ref: https://discord.com/channels/1527213298087493732/1543792025244274738

## How I tested it

Release build, `/phone`:
- Add a widget, open its size menu, tap Remove: closes cleanly, home stays clickable. Repeated a few times.
- Pick a size, tap outside the menu: both still animate out normally.
- No exceptions in `/xllog` through the repro.

## Screenshots

<img width="250" alt="widget-remove-fix" src="https://github.com/user-attachments/assets/6f178a4c-8835-47ab-a58a-38dc3c2b851a" />

## Checklist

Gates (CI enforces all of these):

- [x] `dotnet build Aetherphone.sln -c Release` is clean
- [x] `dotnet test` passes (this is where localization lockstep and accent contrast are enforced)
- [x] No em dashes anywhere: code, strings, JSON catalogs, docs
- [x] No `async void`, no new LINQ outside the allowlisted files, no raw `ImGuiHelpers.GlobalScale` (use `UiScale.Current`), no hand-formatted clock text (use `TimeText.Clock`)

Strings:

- [ ] Every new user-visible string is a LocString in `Core/Localization/L.cs` plus the same key in all nine JSONs under `src/Aetherphone/Localization/`, in this same PR
- [ ] Any changed English text is updated in both `L.cs` and `en.json` so they do not drift

Quality:

- [x] Verified in-game on the screens this touches, on the build variant that matters (`/phone` or `/phonedev`)
- [x] Draw-path code allocates nothing per frame and uses the shared `Windows/Components/` widgets, `TextStyles`, and `Metrics` tokens
- [ ] README updated if this changes what a user sees or types; the relevant page under `docs/` still tells the truth
- [x] Commit messages and this PR body carry no AI attribution trailers
