### PR TITLE
fix(aetherstream): prevent audio dropout on long streams

### DIFF
--- a/src/Aetherphone/Core/Video/VideoEngine.cs
+++ b/src/Aetherphone/Core/Video/VideoEngine.cs
@@ -342,17 +342,20 @@ internal sealed class VideoEngine : IDisposable
             framesProgressAtTicks = now;
         }
 
-        if (info.CoreIdle || !info.HasAudioPosition)
+        if (info.CoreIdle)
         {
             lastObservedAudioPosition = info.AudioPositionSeconds;
             audioProgressAtTicks = now;
         }
-        else if (!audioPositionSeen
-                 || Math.Abs(info.AudioPositionSeconds - lastObservedAudioPosition) > StallPositionTolerance)
+        else if (info.HasAudioPosition)
         {
-            audioPositionSeen = true;
-            lastObservedAudioPosition = info.AudioPositionSeconds;
-            audioProgressAtTicks = now;
+            if (!audioPositionSeen
+                 || Math.Abs(info.AudioPositionSeconds - lastObservedAudioPosition) > StallPositionTolerance)
+            {
+                audioPositionSeen = true;
+                lastObservedAudioPosition = info.AudioPositionSeconds;
+                audioProgressAtTicks = now;
+            }
         }
 
         var nearEnd = info.DurationSeconds > 0d


### PR DESCRIPTION
## What

Fixes audio stall detection in VideoEngine that prevents recovery when audio stops reporting on long streams. The watchdog timer logic was broken, causing audio dropouts after 20-30 minutes to go undetected.

## Why

Audio dropout detection had an impossible condition: it required audio position to be both present and absent simultaneously. When libmpv stopped reporting audio-pts, the code reset the stall timer on every frame instead of letting it count down, so the 10-second timeout never accumulated and recovery never triggered.

Closes #

## How I tested it

Release build: video playback with audio monitoring. Build verified clean with dotnet build Aetherphone.sln -c Release.

## Screenshots

## Backend coordination

## Checklist

Gates (CI enforces all of these):

- [x] `dotnet build Aetherphone.sln -c Release` is clean
- [x] `dotnet test` passes
- [x] No em dashes anywhere: code, strings, JSON catalogs, docs
- [x] No `async void`, no new LINQ outside the allowlisted files, no raw `ImGuiHelpers.GlobalScale`, no hand-formatted clock text

Strings:

- [x] No new user-visible strings changed

Quality:

- [x] Verified build on Release variant
- [x] No AI attribution trailers in commits or PR body
